### PR TITLE
feat(profile): add Mongo-backed player profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 Telegram Mini App card battle built with Next.js and a custom Node/WebSocket server.
 
-Players build a deck, fight AI locally, or queue into a live PvP match. Inside Telegram, the app reads the current user from `Telegram.WebApp`, opens in fullscreen when supported, and stores the selected deck in Telegram CloudStorage with a browser `sessionStorage` fallback.
+Players build a deck, fight AI locally, or queue into a live PvP match. Inside Telegram, the app reads the current user from `Telegram.WebApp`, opens in fullscreen when supported, and uses MongoDB-backed player profiles for durable player state.
 
 ## Features
 
-- Deck builder with persisted player decks.
+- Deck builder and MongoDB-backed player profile API.
 - AI battle mode for single-player testing.
 - Human-vs-human matchmaking over `/ws`.
-- Telegram Mini App integration for user names, fullscreen launch, and CloudStorage deck sync.
+- Telegram Mini App integration for user names, fullscreen launch, and Telegram-id profile lookup.
 - Docker-ready production server that serves both Next.js and WebSocket traffic.
 
 ## Battle Rules
@@ -31,7 +31,7 @@ bun run dev
 
 Open [http://localhost:3000](http://localhost:3000).
 
-`npm run dev` starts the custom Node server, so local PvP uses the same `/ws` path as production.
+`bun run dev` starts the custom Node server, so local PvP uses the same `/ws` path as production.
 
 ## Production
 
@@ -42,12 +42,14 @@ docker compose up -d --build
 ```
 
 By default Compose binds the app to `127.0.0.1:3010` and the container listens on `3000`.
+Compose also starts MongoDB with the persistent `nexus_mongodb_data` volume and provides `MONGODB_URI=mongodb://mongo:27017/nexus-card-battle` to the app. Set `MONGODB_URI` in the shell to point the app at a different MongoDB instance.
 See [docs/deploy.md](docs/deploy.md) for the Nginx WebSocket proxy block.
 
 ## Verification
 
 ```bash
 bun run lint
+bun run test:profile
 bun run build
 bun run test:e2e
 ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ By default Compose binds the app to `127.0.0.1:3010` and the container listens o
 Compose also starts MongoDB with the persistent `nexus_mongodb_data` volume and provides `MONGODB_URI=mongodb://mongo:27017/nexus-card-battle` to the app. Set `MONGODB_URI` in the shell to point the app at a different MongoDB instance.
 See [docs/deploy.md](docs/deploy.md) for the Nginx WebSocket proxy block.
 
+## Known Limitations
+
+Until booster onboarding lands, empty new profiles render a non-durable starter deck fallback so the existing battle prototype remains playable. The fallback is not imported from legacy CloudStorage or `sessionStorage`.
+
+Telegram profiles currently use the client-provided `Telegram.WebApp.initDataUnsafe.user.id` for MVP bootstrap. Server-side Telegram `initData` HMAC verification is intentionally deferred and should be added before treating Telegram identity as trusted.
+
 ## Verification
 
 ```bash

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "nexus-card-battle",
       "dependencies": {
+        "mongodb": "^7.2.0",
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -155,6 +156,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.10", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-DDb3OAw8ezai9p2i1F7R5wMVmyrMIuT8ixjV56R4Hl4cazCo2tOMTDyPR5rrCUcHiMbWHzCXOdife5OD6H1C8w=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
     "@next/env": ["@next/env@16.2.4", "", {}, "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw=="],
@@ -236,6 +239,10 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
+
+    "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/type-utils": "8.59.1", "@typescript-eslint/utils": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag=="],
 
@@ -342,6 +349,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": "cli.js" }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
 
     "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
 
@@ -649,6 +658,8 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "memory-pager": ["memory-pager@1.5.0", "", {}, "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
@@ -656,6 +667,10 @@
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mongodb": ["mongodb@7.2.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^7.2.0", "mongodb-connection-string-url": "^7.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.806.0", "@mongodb-js/zstd": "^7.0.0", "gcp-metadata": "^7.0.1", "kerberos": "^7.0.0", "mongodb-client-encryption": ">=7.0.0 <7.1.0", "snappy": "^7.3.2", "socks": "^2.8.6" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw=="],
+
+    "mongodb-connection-string-url": ["mongodb-connection-string-url@7.0.1", "", { "dependencies": { "@types/whatwg-url": "^13.0.0", "whatwg-url": "^14.1.0" } }, "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -775,6 +790,8 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "sparse-bitfield": ["sparse-bitfield@3.0.3", "", { "dependencies": { "memory-pager": "^1.0.2" } }, "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ=="],
+
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
@@ -809,6 +826,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
@@ -838,6 +857,10 @@
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -877,8 +900,6 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
-    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
@@ -892,8 +913,6 @@
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "is-bun-module/semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,33 @@
 services:
+  mongo:
+    image: mongo:7
+    container_name: nexus-card-battle-mongo
+    restart: unless-stopped
+    volumes:
+      - nexus_mongodb_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   nexus-card-battle:
     build:
       context: .
     image: nexus-card-battle:latest
     container_name: nexus-card-battle
     restart: unless-stopped
+    depends_on:
+      mongo:
+        condition: service_healthy
     environment:
       NODE_ENV: production
       NEXT_TELEMETRY_DISABLED: "1"
       HOSTNAME: 0.0.0.0
       PORT: "3000"
+      MONGODB_URI: "${MONGODB_URI:-mongodb://mongo:27017/nexus-card-battle}"
     ports:
       - "${APP_HOST:-127.0.0.1}:${APP_PORT:-3010}:3000"
+
+volumes:
+  nexus_mongodb_data:

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
     "build": "next build",
     "start": "bun server.js",
     "lint": "eslint",
+    "test": "bun test tests/playerProfile.test.ts",
+    "test:profile": "bun test tests/playerProfile.test.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "mongodb": "^7.2.0",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
+  testMatch: "**/*.spec.ts",
   timeout: 120_000,
   expect: {
     timeout: 5_000,

--- a/src/app/api/player/route.ts
+++ b/src/app/api/player/route.ts
@@ -1,0 +1,12 @@
+import { handlePlayerProfileGet, handlePlayerProfilePost } from "@/features/player/profile/api";
+import { getMongoPlayerProfileStore } from "@/features/player/profile/mongo";
+
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+  return handlePlayerProfileGet(request, getMongoPlayerProfileStore());
+}
+
+export async function POST(request: Request) {
+  return handlePlayerProfilePost(request, getMongoPlayerProfileStore());
+}

--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { cards } from "@/features/battle/model/cards";
 import { BattleGame } from "@/features/battle/ui/BattleGame";
 import { RealtimeBattleGame } from "@/features/battle/ui/RealtimeBattleGame";
@@ -8,8 +8,6 @@ import type { TelegramPlayer } from "@/shared/lib/telegram";
 import { PLAYER_DECK_SIZE } from "../model/randomDeck";
 import { CollectionDeckScreen } from "./collection/CollectionDeckScreen";
 
-const DECK_SESSION_STORAGE_KEY = "nexus:deck-session:v1";
-const DECK_CLOUD_STORAGE_KEY = "nexus_deck_v1";
 type BattleMode = "ai" | "human";
 type TelegramWindow = Window & {
   Telegram?: {
@@ -32,10 +30,6 @@ type TelegramWindow = Window & {
           last_name?: string;
         };
       };
-      CloudStorage?: {
-        getItem: (key: string, callback: (error: string | Error | null, value?: string) => void) => void;
-        setItem: (key: string, value: string, callback?: (error: string | Error | null, stored?: boolean) => void) => void;
-      };
     };
   };
 };
@@ -52,36 +46,14 @@ export function GameRoot() {
   const [telegramPlayer, setTelegramPlayer] = useState<TelegramPlayer>(() => readTelegramPlayer());
   const [telegramLandscapePromptActive, setTelegramLandscapePromptActive] = useState(false);
   const playerName = telegramPlayer.name;
-  const deckIdsRef = useRef(deckIds);
-  const deckTouchedRef = useRef(false);
-  const persistenceReadyRef = useRef(false);
-
-  useEffect(() => {
-    deckIdsRef.current = deckIds;
-  }, [deckIds]);
 
   useEffect(() => {
     const telegramPlayerHandle = window.setTimeout(() => setTelegramPlayer(readTelegramPlayer()), 0);
 
-    const cancelPersistenceTask = schedulePersistenceTask(() => {
-      void loadSavedDeckIds(collectionIds).then((savedDeckIds) => {
-        persistenceReadyRef.current = true;
-
-        if (savedDeckIds && !deckTouchedRef.current) {
-          deckIdsRef.current = savedDeckIds;
-          setDeckIds(savedDeckIds);
-          return;
-        }
-
-        void saveDeckIds(deckIdsRef.current);
-      });
-    });
-
     return () => {
       window.clearTimeout(telegramPlayerHandle);
-      cancelPersistenceTask();
     };
-  }, [collectionIds]);
+  }, []);
 
   useEffect(() => {
     const webApp = getTelegramWebApp();
@@ -121,19 +93,10 @@ export function GameRoot() {
     };
   }, []);
 
-  useEffect(() => {
-    if (!persistenceReadyRef.current) return;
-    return schedulePersistenceTask(() => {
-      void saveDeckIds(deckIds);
-    });
-  }, [deckIds]);
-
   const handleDeckChange = useCallback(
     (nextDeckIds: string[]) => {
       const sanitizedDeckIds = sanitizeDeckIds(nextDeckIds, collectionIds);
 
-      deckTouchedRef.current = true;
-      deckIdsRef.current = sanitizedDeckIds;
       setDeckIds(sanitizedDeckIds);
     },
     [collectionIds],
@@ -180,25 +143,6 @@ export function GameRoot() {
   );
 }
 
-async function loadSavedDeckIds(collectionIds: string[]) {
-  if (typeof window === "undefined") return null;
-
-  const cloudDeckIds = await readCloudDeckIds(collectionIds);
-  if (cloudDeckIds) return cloudDeckIds;
-
-  try {
-    const raw = window.sessionStorage.getItem(DECK_SESSION_STORAGE_KEY);
-    if (!raw) return null;
-
-    const parsed = JSON.parse(raw);
-    if (!isStringArray(parsed)) return null;
-
-    return sanitizeDeckIds(parsed, collectionIds);
-  } catch {
-    return null;
-  }
-}
-
 function readTelegramPlayer(): TelegramPlayer {
   if (typeof window === "undefined") return {};
 
@@ -227,18 +171,6 @@ function readStorageString(key: string) {
     return window.localStorage.getItem(key)?.trim() || window.sessionStorage.getItem(key)?.trim() || undefined;
   } catch {
     return undefined;
-  }
-}
-
-async function saveDeckIds(deckIds: string[]) {
-  if (typeof window === "undefined") return;
-
-  await writeCloudDeckIds(deckIds);
-
-  try {
-    window.sessionStorage.setItem(DECK_SESSION_STORAGE_KEY, JSON.stringify(deckIds));
-  } catch {
-    // Storage can be unavailable in private or restricted browser contexts.
   }
 }
 
@@ -304,44 +236,6 @@ function TelegramLandscapeOverlay({ active }: { active: boolean }) {
   );
 }
 
-async function readCloudDeckIds(collectionIds: string[]) {
-  const cloudStorage = getTelegramWebApp()?.CloudStorage;
-  if (!cloudStorage) return null;
-
-  const raw = await new Promise<string | undefined>((resolve) => {
-    cloudStorage.getItem(DECK_CLOUD_STORAGE_KEY, (error, value) => {
-      resolve(error ? undefined : value);
-    });
-  });
-
-  if (!raw) return null;
-
-  try {
-    const parsed = JSON.parse(raw);
-    if (!isStringArray(parsed)) return null;
-
-    return sanitizeDeckIds(parsed, collectionIds);
-  } catch {
-    return null;
-  }
-}
-
-async function writeCloudDeckIds(deckIds: string[]) {
-  const cloudStorage = getTelegramWebApp()?.CloudStorage;
-  if (!cloudStorage) return;
-
-  await new Promise<void>((resolve) => {
-    cloudStorage.setItem(DECK_CLOUD_STORAGE_KEY, JSON.stringify(deckIds), () => resolve());
-  });
-}
-
-function schedulePersistenceTask(task: () => void) {
-  if (typeof window === "undefined") return () => {};
-
-  const handle = window.setTimeout(task, 0);
-  return () => window.clearTimeout(handle);
-}
-
 function sanitizeDeckIds(deckIds: string[], collectionIds: string[]) {
   const collection = new Set(collectionIds);
   const normalized = unique(deckIds).filter((cardId) => collection.has(cardId));
@@ -363,10 +257,6 @@ function sanitizeDeckIds(deckIds: string[], collectionIds: string[]) {
 
 function createStarterDeckIds(collectionIds: string[]) {
   return collectionIds.slice(0, PLAYER_DECK_SIZE);
-}
-
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
 function unique(values: string[]) {

--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -1,14 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cards } from "@/features/battle/model/cards";
 import { BattleGame } from "@/features/battle/ui/BattleGame";
 import { RealtimeBattleGame } from "@/features/battle/ui/RealtimeBattleGame";
+import { fetchPlayerProfile, resolveClientPlayerIdentity } from "@/features/player/profile/client";
+import type { PlayerIdentity, PlayerProfile } from "@/features/player/profile/types";
 import type { TelegramPlayer } from "@/shared/lib/telegram";
 import { PLAYER_DECK_SIZE } from "../model/randomDeck";
 import { CollectionDeckScreen } from "./collection/CollectionDeckScreen";
 
 type BattleMode = "ai" | "human";
+type ProfileStatus = "loading" | "ready" | "fallback";
+type DeckSource = "profile" | "starter-fallback";
 type TelegramWindow = Window & {
   Telegram?: {
     WebApp?: {
@@ -39,12 +43,20 @@ type LockableScreenOrientation = ScreenOrientation & {
 };
 
 export function GameRoot() {
-  const [collectionIds] = useState(() => cards.map((card) => card.id));
+  const allCardIds = useMemo(() => cards.map((card) => card.id), []);
   const [screen, setScreen] = useState<"collection" | "battle">("collection");
   const [battleMode, setBattleMode] = useState<BattleMode>("ai");
-  const [deckIds, setDeckIds] = useState(() => createStarterDeckIds(collectionIds));
+  const [deckIds, setDeckIds] = useState(() => createStarterDeckIds(allCardIds));
+  const [playerProfile, setPlayerProfile] = useState<PlayerProfile | null>(null);
+  const [playerIdentity, setPlayerIdentity] = useState<PlayerIdentity | null>(null);
+  const [profileStatus, setProfileStatus] = useState<ProfileStatus>("loading");
   const [telegramPlayer, setTelegramPlayer] = useState<TelegramPlayer>(() => readTelegramPlayer());
   const [telegramLandscapePromptActive, setTelegramLandscapePromptActive] = useState(false);
+  const deckTouchedRef = useRef(false);
+  const collectionIds = useMemo(() => getCollectionIdsForProfile(playerProfile, allCardIds), [allCardIds, playerProfile]);
+  const profileDeckIds = useMemo(() => getDeckIdsForProfile(playerProfile, collectionIds), [collectionIds, playerProfile]);
+  const deckSource: DeckSource = profileDeckIds.length > 0 ? "profile" : "starter-fallback";
+  const starterFreeBoostersRemaining = playerProfile?.starterFreeBoostersRemaining ?? 0;
   const playerName = telegramPlayer.name;
 
   useEffect(() => {
@@ -54,6 +66,35 @@ export function GameRoot() {
       window.clearTimeout(telegramPlayerHandle);
     };
   }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    const identity = resolveClientPlayerIdentity();
+
+    void fetchPlayerProfile(identity)
+      .then((profile) => {
+        if (disposed) return;
+        setPlayerIdentity(identity);
+        setPlayerProfile(profile);
+        setProfileStatus("ready");
+      })
+      .catch(() => {
+        if (disposed) return;
+        setPlayerIdentity(identity);
+        setProfileStatus("fallback");
+      });
+
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (deckTouchedRef.current) return;
+
+    const nextDeckIds = profileDeckIds.length > 0 ? profileDeckIds : createStarterDeckIds(collectionIds);
+    setDeckIds(nextDeckIds);
+  }, [collectionIds, profileDeckIds]);
 
   useEffect(() => {
     const webApp = getTelegramWebApp();
@@ -97,6 +138,7 @@ export function GameRoot() {
     (nextDeckIds: string[]) => {
       const sanitizedDeckIds = sanitizeDeckIds(nextDeckIds, collectionIds);
 
+      deckTouchedRef.current = true;
       setDeckIds(sanitizedDeckIds);
     },
     [collectionIds],
@@ -131,6 +173,12 @@ export function GameRoot() {
       <CollectionDeckScreen
         collectionIds={collectionIds}
         deckIds={deckIds}
+        profileStatus={profileStatus}
+        profileIdentityMode={playerIdentity?.mode}
+        profileOwnedCardCount={playerProfile?.ownedCardIds.length ?? 0}
+        profileDeckCount={playerProfile?.deckIds.length ?? 0}
+        deckSource={deckSource}
+        starterFreeBoostersRemaining={starterFreeBoostersRemaining}
         onDeckChange={handleDeckChange}
         onPlay={(nextDeckIds, mode) => {
           handleDeckChange(nextDeckIds);
@@ -234,6 +282,20 @@ function TelegramLandscapeOverlay({ active }: { active: boolean }) {
       </div>
     </section>
   );
+}
+
+function getCollectionIdsForProfile(profile: PlayerProfile | null, allCardIds: string[]) {
+  if (!profile || profile.ownedCardIds.length === 0) return allCardIds;
+
+  const knownCards = new Set(allCardIds);
+  const ownedCardIds = unique(profile.ownedCardIds).filter((cardId) => knownCards.has(cardId));
+
+  return ownedCardIds.length > 0 ? ownedCardIds : allCardIds;
+}
+
+function getDeckIdsForProfile(profile: PlayerProfile | null, collectionIds: string[]) {
+  if (!profile || profile.deckIds.length === 0) return [];
+  return unique(profile.deckIds).filter((cardId) => collectionIds.includes(cardId));
 }
 
 function sanitizeDeckIds(deckIds: string[], collectionIds: string[]) {

--- a/src/features/game/ui/collection/CollectionDeckScreen.tsx
+++ b/src/features/game/ui/collection/CollectionDeckScreen.tsx
@@ -12,6 +12,12 @@ import { PLAYER_DECK_SIZE } from "../../model/randomDeck";
 type Props = {
   collectionIds: string[];
   deckIds: string[];
+  profileStatus: "loading" | "ready" | "fallback";
+  profileIdentityMode?: "telegram" | "guest";
+  profileOwnedCardCount: number;
+  profileDeckCount: number;
+  deckSource: "profile" | "starter-fallback";
+  starterFreeBoostersRemaining: number;
   onDeckChange: (deckIds: string[]) => void;
   onPlay: (deckIds: string[], mode: "ai" | "human") => void;
 };
@@ -47,7 +53,18 @@ const sortModes: { id: SortMode; label: string }[] = [
   { id: "name", label: "Ім’я" },
 ];
 
-export function CollectionDeckScreen({ collectionIds, deckIds: savedDeckIds = [], onDeckChange, onPlay }: Props) {
+export function CollectionDeckScreen({
+  collectionIds,
+  deckIds: savedDeckIds = [],
+  profileStatus,
+  profileIdentityMode,
+  profileOwnedCardCount,
+  profileDeckCount,
+  deckSource,
+  starterFreeBoostersRemaining,
+  onDeckChange,
+  onPlay,
+}: Props) {
   const collectionSet = useMemo(() => new Set(collectionIds), [collectionIds]);
   const collectionCards = useMemo(() => cards.filter((card) => collectionSet.has(card.id)), [collectionSet]);
   const deckIds = useMemo(
@@ -120,7 +137,16 @@ export function CollectionDeckScreen({ collectionIds, deckIds: savedDeckIds = []
   }
 
   return (
-    <main className="min-h-screen bg-[#07090b] text-[#f9efd8]">
+    <main
+      className="min-h-screen bg-[#07090b] text-[#f9efd8]"
+      data-testid="player-profile-shell"
+      data-profile-status={profileStatus}
+      data-profile-identity-mode={profileIdentityMode ?? "unknown"}
+      data-profile-owned-card-count={profileOwnedCardCount}
+      data-profile-deck-count={profileDeckCount}
+      data-deck-source={deckSource}
+      data-starter-free-boosters-remaining={starterFreeBoostersRemaining}
+    >
       <div className="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,rgba(11,15,17,0.96),rgba(5,7,10,0.98)),url('/nexus-assets/backgrounds/arena-bar-1024x576.png')] bg-cover bg-center px-4 py-4 max-[760px]:px-2">
         <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,rgba(250,199,76,0.06),transparent_24%,transparent_76%,rgba(75,204,220,0.06))]" />
 

--- a/src/features/player/profile/api.ts
+++ b/src/features/player/profile/api.ts
@@ -1,0 +1,92 @@
+import {
+  PlayerIdentityValidationError,
+  type PlayerIdentity,
+  type PlayerProfile,
+  type StoredPlayerProfile,
+  parsePlayerIdentity,
+  toPlayerProfile,
+} from "./types";
+
+export type PlayerProfileStore = {
+  findOrCreateByIdentity(identity: PlayerIdentity): Promise<StoredPlayerProfile>;
+};
+
+export async function handlePlayerProfilePost(request: Request, store: PlayerProfileStore) {
+  try {
+    const body = await readJsonObject(request);
+    const identity = parsePlayerIdentity(body.identity);
+    const profile = await store.findOrCreateByIdentity(identity);
+
+    return playerProfileResponse(toPlayerProfile(profile));
+  } catch (error) {
+    return playerProfileErrorResponse(error);
+  }
+}
+
+export async function handlePlayerProfileGet(request: Request, store: PlayerProfileStore) {
+  try {
+    const url = new URL(request.url);
+    const mode = url.searchParams.get("mode");
+    const identity =
+      mode === "telegram"
+        ? parsePlayerIdentity({ mode, telegramId: url.searchParams.get("telegramId") })
+        : parsePlayerIdentity({ mode, guestId: url.searchParams.get("guestId") });
+    const profile = await store.findOrCreateByIdentity(identity);
+
+    return playerProfileResponse(toPlayerProfile(profile));
+  } catch (error) {
+    return playerProfileErrorResponse(error);
+  }
+}
+
+function playerProfileResponse(player: PlayerProfile) {
+  return Response.json(
+    { player },
+    {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}
+
+function playerProfileErrorResponse(error: unknown) {
+  if (error instanceof PlayerIdentityValidationError || error instanceof SyntaxError) {
+    return Response.json(
+      {
+        error: "invalid_identity",
+        message: error.message,
+      },
+      { status: 400 },
+    );
+  }
+
+  console.error("Player profile API failed.", error);
+  return Response.json(
+    {
+      error: "profile_unavailable",
+      message: "Player profile is unavailable.",
+    },
+    { status: 500 },
+  );
+}
+
+async function readJsonObject(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    throw new SyntaxError("request body must be valid JSON.");
+  }
+
+  if (!isRecord(body)) {
+    throw new PlayerIdentityValidationError("request body must be an object.");
+  }
+
+  return body;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/features/player/profile/client.ts
+++ b/src/features/player/profile/client.ts
@@ -1,0 +1,81 @@
+import type { PlayerIdentity, PlayerProfile } from "./types";
+
+export const PLAYER_GUEST_ID_STORAGE_KEY = "nexus:player-guest-id:v1";
+
+type TelegramProfileWindow = Window & {
+  Telegram?: {
+    WebApp?: {
+      initDataUnsafe?: {
+        user?: {
+          id?: number | string;
+        };
+      };
+    };
+  };
+};
+
+export function resolveClientPlayerIdentity(): PlayerIdentity {
+  const telegramId = readTelegramId();
+  if (telegramId) {
+    return {
+      mode: "telegram",
+      telegramId,
+    };
+  }
+
+  return {
+    mode: "guest",
+    guestId: getOrCreateGuestId(),
+  };
+}
+
+export async function fetchPlayerProfile(identity: PlayerIdentity = resolveClientPlayerIdentity()): Promise<PlayerProfile> {
+  const response = await fetch("/api/player", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ identity }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load player profile: ${response.status}`);
+  }
+
+  const body = (await response.json()) as { player?: PlayerProfile };
+  if (!body.player) {
+    throw new Error("Player profile response did not include player.");
+  }
+
+  return body.player;
+}
+
+function readTelegramId() {
+  if (typeof window === "undefined") return undefined;
+
+  const telegramId = (window as TelegramProfileWindow).Telegram?.WebApp?.initDataUnsafe?.user?.id;
+  if (telegramId === undefined || telegramId === null) return undefined;
+
+  const value = String(telegramId).trim();
+  return value || undefined;
+}
+
+function getOrCreateGuestId() {
+  if (typeof window === "undefined") return createGuestId();
+
+  try {
+    const existing = window.localStorage.getItem(PLAYER_GUEST_ID_STORAGE_KEY)?.trim();
+    if (existing) return existing;
+
+    const guestId = createGuestId();
+    window.localStorage.setItem(PLAYER_GUEST_ID_STORAGE_KEY, guestId);
+    return guestId;
+  } catch {
+    return createGuestId();
+  }
+}
+
+function createGuestId() {
+  const cryptoApi = typeof crypto !== "undefined" ? crypto : undefined;
+  return `guest_${cryptoApi?.randomUUID?.() ?? Math.random().toString(36).slice(2)}`;
+}

--- a/src/features/player/profile/mongo.ts
+++ b/src/features/player/profile/mongo.ts
@@ -1,0 +1,133 @@
+import { MongoClient, type Collection, type Filter, type WithId } from "mongodb";
+import { createNewStoredPlayerProfile, type PlayerIdentity, type StoredPlayerProfile } from "./types";
+import type { PlayerProfileStore } from "./api";
+
+const DEFAULT_MONGODB_URI = "mongodb://127.0.0.1:27017/nexus-card-battle";
+const DEFAULT_MONGODB_DB = "nexus-card-battle";
+const PLAYERS_COLLECTION = "players";
+
+type MongoPlayerDocument = Omit<StoredPlayerProfile, "id"> & {
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const mongoGlobal = globalThis as typeof globalThis & {
+  __nexusPlayerMongoClientPromise?: Promise<MongoClient>;
+};
+
+export function getMongoPlayerProfileStore() {
+  const { uri, dbName } = getMongoConfig();
+  const clientPromise = getMongoClient(uri);
+  return new MongoPlayerProfileStore(clientPromise, dbName);
+}
+
+export class MongoPlayerProfileStore implements PlayerProfileStore {
+  private indexesReady?: Promise<void>;
+
+  constructor(
+    private readonly clientPromise: Promise<MongoClient>,
+    private readonly dbName: string,
+  ) {}
+
+  async findOrCreateByIdentity(identity: PlayerIdentity): Promise<StoredPlayerProfile> {
+    const collection = await this.getPlayersCollection();
+    const now = new Date();
+    const filter = identityFilter(identity);
+    const insertedProfile = createNewStoredPlayerProfile("", identity);
+    const document = await collection.findOneAndUpdate(
+      filter,
+      {
+        $setOnInsert: {
+          identity: insertedProfile.identity,
+          ownedCardIds: insertedProfile.ownedCardIds,
+          deckIds: insertedProfile.deckIds,
+          starterFreeBoostersRemaining: insertedProfile.starterFreeBoostersRemaining,
+          openedBoosterIds: insertedProfile.openedBoosterIds,
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+      {
+        upsert: true,
+        returnDocument: "after",
+      },
+    );
+
+    if (!document) {
+      throw new Error("MongoDB did not return a player profile.");
+    }
+
+    return fromMongoDocument(document);
+  }
+
+  private async getPlayersCollection() {
+    const client = await this.clientPromise;
+    const collection = client.db(this.dbName).collection<MongoPlayerDocument>(PLAYERS_COLLECTION);
+    await this.ensureIndexes(collection);
+    return collection;
+  }
+
+  private ensureIndexes(collection: Collection<MongoPlayerDocument>) {
+    this.indexesReady ??= Promise.all([
+      collection.createIndex(
+        { "identity.telegramId": 1 },
+        {
+          name: "uniq_player_telegram_identity",
+          unique: true,
+          partialFilterExpression: { "identity.mode": "telegram" },
+        },
+      ),
+      collection.createIndex(
+        { "identity.guestId": 1 },
+        {
+          name: "uniq_player_guest_identity",
+          unique: true,
+          partialFilterExpression: { "identity.mode": "guest" },
+        },
+      ),
+    ]).then(() => undefined);
+
+    return this.indexesReady;
+  }
+}
+
+function getMongoClient(uri: string) {
+  mongoGlobal.__nexusPlayerMongoClientPromise ??= new MongoClient(uri).connect();
+  return mongoGlobal.__nexusPlayerMongoClientPromise;
+}
+
+function getMongoConfig() {
+  const uri = process.env.MONGODB_URI || DEFAULT_MONGODB_URI;
+  return {
+    uri,
+    dbName: process.env.MONGODB_DB || parseDatabaseName(uri) || DEFAULT_MONGODB_DB,
+  };
+}
+
+function parseDatabaseName(uri: string) {
+  try {
+    const pathname = new URL(uri).pathname.replace(/^\//, "");
+    return pathname || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function identityFilter(identity: PlayerIdentity): Filter<MongoPlayerDocument> {
+  if (identity.mode === "telegram") {
+    return { "identity.mode": "telegram", "identity.telegramId": identity.telegramId };
+  }
+
+  return { "identity.mode": "guest", "identity.guestId": identity.guestId };
+}
+
+function fromMongoDocument(document: WithId<MongoPlayerDocument>): StoredPlayerProfile {
+  return {
+    id: document._id.toHexString(),
+    identity: document.identity,
+    ownedCardIds: document.ownedCardIds,
+    deckIds: document.deckIds,
+    starterFreeBoostersRemaining: document.starterFreeBoostersRemaining,
+    openedBoosterIds: document.openedBoosterIds,
+  };
+}

--- a/src/features/player/profile/types.ts
+++ b/src/features/player/profile/types.ts
@@ -1,0 +1,155 @@
+export const STARTER_FREE_BOOSTERS = 2;
+
+export type PlayerIdentity = TelegramPlayerIdentity | GuestPlayerIdentity;
+
+export type TelegramPlayerIdentity = {
+  mode: "telegram";
+  telegramId: string;
+};
+
+export type GuestPlayerIdentity = {
+  mode: "guest";
+  guestId: string;
+};
+
+export type PlayerOnboardingState = {
+  starterBoostersAvailable: boolean;
+  collectionReady: boolean;
+  deckReady: boolean;
+  completed: boolean;
+};
+
+export type PlayerProfile = {
+  id: string;
+  identity: PlayerIdentity;
+  ownedCardIds: string[];
+  deckIds: string[];
+  starterFreeBoostersRemaining: number;
+  openedBoosterIds: string[];
+  onboarding: PlayerOnboardingState;
+};
+
+export type StoredPlayerProfile = Omit<PlayerProfile, "onboarding">;
+
+export function createNewStoredPlayerProfile(id: string, identity: PlayerIdentity): StoredPlayerProfile {
+  return {
+    id,
+    identity,
+    ownedCardIds: [],
+    deckIds: [],
+    starterFreeBoostersRemaining: STARTER_FREE_BOOSTERS,
+    openedBoosterIds: [],
+  };
+}
+
+export function toPlayerProfile(profile: StoredPlayerProfile): PlayerProfile {
+  const ownedCardIds = normalizeStringArray(profile.ownedCardIds);
+  const deckIds = normalizeStringArray(profile.deckIds);
+  const openedBoosterIds = normalizeStringArray(profile.openedBoosterIds);
+  const starterFreeBoostersRemaining = normalizeNonNegativeInteger(profile.starterFreeBoostersRemaining, STARTER_FREE_BOOSTERS);
+
+  return {
+    id: profile.id,
+    identity: profile.identity,
+    ownedCardIds,
+    deckIds,
+    starterFreeBoostersRemaining,
+    openedBoosterIds,
+    onboarding: createOnboardingState({
+      ownedCardIds,
+      deckIds,
+      starterFreeBoostersRemaining,
+    }),
+  };
+}
+
+export function createOnboardingState(profile: Pick<StoredPlayerProfile, "ownedCardIds" | "deckIds" | "starterFreeBoostersRemaining">): PlayerOnboardingState {
+  const collectionReady = profile.ownedCardIds.length > 0;
+  const deckReady = profile.deckIds.length > 0;
+
+  return {
+    starterBoostersAvailable: profile.starterFreeBoostersRemaining > 0,
+    collectionReady,
+    deckReady,
+    completed: collectionReady && deckReady && profile.starterFreeBoostersRemaining === 0,
+  };
+}
+
+export class PlayerIdentityValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PlayerIdentityValidationError";
+  }
+}
+
+export function parsePlayerIdentity(value: unknown): PlayerIdentity {
+  if (!isRecord(value)) {
+    throw new PlayerIdentityValidationError("identity must be an object.");
+  }
+
+  if (value.mode === "telegram") {
+    if ("guestId" in value) {
+      throw new PlayerIdentityValidationError("telegram identity must not include guestId.");
+    }
+
+    return {
+      mode: "telegram",
+      telegramId: parseIdentityId(value.telegramId, "telegramId"),
+    };
+  }
+
+  if (value.mode === "guest") {
+    if ("telegramId" in value) {
+      throw new PlayerIdentityValidationError("guest identity must not include telegramId.");
+    }
+
+    return {
+      mode: "guest",
+      guestId: parseIdentityId(value.guestId, "guestId"),
+    };
+  }
+
+  throw new PlayerIdentityValidationError("identity.mode must be either telegram or guest.");
+}
+
+export function isSamePlayerIdentity(left: PlayerIdentity, right: PlayerIdentity) {
+  if (left.mode !== right.mode) return false;
+  if (left.mode === "telegram" && right.mode === "telegram") return left.telegramId === right.telegramId;
+  if (left.mode === "guest" && right.mode === "guest") return left.guestId === right.guestId;
+  return false;
+}
+
+function parseIdentityId(value: unknown, fieldName: "telegramId" | "guestId") {
+  if (typeof value !== "string") {
+    throw new PlayerIdentityValidationError(`identity.${fieldName} must be a string.`);
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new PlayerIdentityValidationError(`identity.${fieldName} must not be empty.`);
+  }
+
+  if (trimmed.length > 128) {
+    throw new PlayerIdentityValidationError(`identity.${fieldName} must be 128 characters or less.`);
+  }
+
+  if (!/^[A-Za-z0-9:_-]+$/.test(trimmed)) {
+    throw new PlayerIdentityValidationError(`identity.${fieldName} contains unsupported characters.`);
+  }
+
+  return trimmed;
+}
+
+function normalizeStringArray(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter((item): item is string => typeof item === "string" && item.length > 0))];
+}
+
+function normalizeNonNegativeInteger(value: unknown, fallback: number) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return fallback;
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tests/battle.spec.ts
+++ b/tests/battle.spec.ts
@@ -13,43 +13,33 @@ test("keeps the minimum deck locked", async ({ page }) => {
   expect(firstCardId).toBeTruthy();
 
   await expect(page.getByTestId(`deck-remove-${firstCardId}`)).toBeDisabled();
-  await expect.poll(() => readSavedDeckIds(page)).toContain(firstCardId);
 });
 
-test("persists custom deck changes", async ({ page }) => {
+test("ignores legacy deck session storage without deleting it", async ({ page }) => {
+  const legacyDeckIds = [
+    "dahack-1645",
+    "dahack-110",
+    "dahack-820",
+    "dahack-167",
+    "dahack-1727",
+    "dahack-795",
+    "dahack-1383",
+    "dahack-658",
+    "dahack-108",
+    "dahack-363",
+  ];
+  await page.addInitScript(
+    ({ storageKey, deckIds }) => {
+      window.sessionStorage.setItem(storageKey, JSON.stringify(deckIds));
+    },
+    { storageKey: DECK_SESSION_STORAGE_KEY, deckIds: legacyDeckIds },
+  );
+
   await page.goto("/");
 
   const deckCards = page.locator('[data-testid^="deck-card-"]');
   await expect(deckCards).toHaveCount(9);
-  await expect.poll(() => readSavedDeckIds(page)).toHaveLength(9);
-
-  const savedDeckIds = await readSavedDeckIds(page);
-  const extraCardId = await page.evaluate((currentDeckIds) => {
-    const currentDeck = new Set(currentDeckIds);
-    const toggles = [...document.querySelectorAll<HTMLElement>('[data-testid^="collection-toggle-"]')];
-    const extraToggle = toggles.find((toggle) => {
-      const cardId = toggle.dataset.testid?.replace("collection-toggle-", "");
-      return cardId && !currentDeck.has(cardId);
-    });
-
-    return extraToggle?.dataset.testid?.replace("collection-toggle-", "") ?? null;
-  }, savedDeckIds);
-
-  expect(extraCardId).toBeTruthy();
-  await page.getByTestId(`collection-toggle-${extraCardId}`).click({ force: true });
-
-  await expect(deckCards).toHaveCount(10);
-  await expect.poll(() => readSavedDeckIds(page)).toContain(extraCardId);
-
-  await page.reload();
-
-  await expect(deckCards).toHaveCount(10);
-  await expect.poll(() => readSavedDeckIds(page)).toContain(extraCardId);
-
-  await page.getByTestId(`deck-remove-${extraCardId}`).click({ force: true });
-
-  await expect(deckCards).toHaveCount(9);
-  await expect.poll(() => readSavedDeckIds(page)).not.toContain(extraCardId);
+  await expect.poll(() => readSavedDeckIds(page)).toEqual(legacyDeckIds);
 });
 
 test("plays a complete state-machine battle", async ({ page }) => {

--- a/tests/playerProfile.test.ts
+++ b/tests/playerProfile.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import { handlePlayerProfileGet, handlePlayerProfilePost, type PlayerProfileStore } from "../src/features/player/profile/api";
+import { createNewStoredPlayerProfile, isSamePlayerIdentity, type PlayerIdentity, type PlayerProfile, type StoredPlayerProfile } from "../src/features/player/profile/types";
+
+describe("player profile API", () => {
+  test("creates a guest profile with empty durable state and starter boosters", async () => {
+    const store = new MemoryPlayerProfileStore();
+    const response = await postProfile(store, {
+      identity: {
+        mode: "guest",
+        guestId: "guest-alpha",
+      },
+    });
+    const body = await readPlayerResponse(response);
+
+    expect(response.status).toBe(200);
+    expect(body.player).toMatchObject({
+      id: "player-1",
+      identity: {
+        mode: "guest",
+        guestId: "guest-alpha",
+      },
+      ownedCardIds: [],
+      deckIds: [],
+      starterFreeBoostersRemaining: 2,
+      openedBoosterIds: [],
+      onboarding: {
+        starterBoostersAvailable: true,
+        collectionReady: false,
+        deckReady: false,
+        completed: false,
+      },
+    });
+
+    const lookup = await handlePlayerProfileGet(new Request("http://localhost/api/player?mode=guest&guestId=guest-alpha"), store);
+    const lookupBody = await readPlayerResponse(lookup);
+    expect(lookupBody.player.id).toBe(body.player.id);
+  });
+
+  test("loads the same profile for repeated Telegram id lookup", async () => {
+    const store = new MemoryPlayerProfileStore();
+    const first = await postProfile(store, {
+      identity: {
+        mode: "telegram",
+        telegramId: "123456789",
+      },
+    });
+    const second = await postProfile(store, {
+      identity: {
+        mode: "telegram",
+        telegramId: "123456789",
+      },
+    });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect((await readPlayerResponse(second)).player.id).toBe((await readPlayerResponse(first)).player.id);
+    expect(store.createdCount).toBe(1);
+  });
+
+  test("does not import legacy deck or collection values from the request", async () => {
+    const store = new MemoryPlayerProfileStore();
+    const response = await postProfile(store, {
+      identity: {
+        mode: "guest",
+        guestId: "guest-legacy-storage",
+      },
+      deckIds: ["legacy-deck-card"],
+      ownedCardIds: ["legacy-owned-card"],
+      legacyDeckIds: ["legacy-cloud-card"],
+      sessionStorage: {
+        "nexus:deck-session:v1": ["legacy-session-card"],
+      },
+      cloudStorage: {
+        nexus_deck_v1: ["legacy-cloud-storage-card"],
+      },
+    });
+    const body = await readPlayerResponse(response);
+
+    expect(response.status).toBe(200);
+    expect(body.player.ownedCardIds).toEqual([]);
+    expect(body.player.deckIds).toEqual([]);
+    expect(body.player.openedBoosterIds).toEqual([]);
+    expect(body.player.starterFreeBoostersRemaining).toBe(2);
+  });
+
+  test("rejects mixed identity modes", async () => {
+    const response = await postProfile(new MemoryPlayerProfileStore(), {
+      identity: {
+        mode: "telegram",
+        telegramId: "123456789",
+        guestId: "guest-alpha",
+      },
+    });
+    const body = (await response.json()) as { error?: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("invalid_identity");
+  });
+});
+
+class MemoryPlayerProfileStore implements PlayerProfileStore {
+  private readonly profiles: StoredPlayerProfile[] = [];
+  private nextId = 1;
+  createdCount = 0;
+
+  async findOrCreateByIdentity(identity: PlayerIdentity): Promise<StoredPlayerProfile> {
+    const existing = this.profiles.find((profile) => isSamePlayerIdentity(profile.identity, identity));
+    if (existing) return existing;
+
+    const profile = createNewStoredPlayerProfile(`player-${this.nextId}`, identity);
+    this.nextId += 1;
+    this.createdCount += 1;
+    this.profiles.push(profile);
+    return profile;
+  }
+}
+
+function postProfile(store: PlayerProfileStore, body: unknown) {
+  return handlePlayerProfilePost(
+    new Request("http://localhost/api/player", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }),
+    store,
+  );
+}
+
+async function readPlayerResponse(response: Response) {
+  return (await response.json()) as { player: PlayerProfile };
+}

--- a/tests/profile-bootstrap.spec.ts
+++ b/tests/profile-bootstrap.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+const GUEST_ID_STORAGE_KEY = "nexus:player-guest-id:v1";
+const PROFILE_DECK_IDS = [
+  "dahack-1645",
+  "dahack-110",
+  "dahack-820",
+  "dahack-167",
+  "dahack-1727",
+  "dahack-795",
+  "dahack-1383",
+  "dahack-658",
+  "dahack-108",
+];
+const PROFILE_OWNED_CARD_IDS = [...PROFILE_DECK_IDS, "dahack-363"];
+
+test("bootstraps a browser guest profile on first load", async ({ page }) => {
+  const requests: unknown[] = [];
+  await mockPlayerProfile(page, async (route) => {
+    const requestBody = route.request().postDataJSON() as { identity: { mode: "guest"; guestId: string } };
+    requests.push(requestBody);
+
+    expect(requestBody.identity.mode).toBe("guest");
+    expect(requestBody.identity.guestId).toMatch(/^guest_/);
+
+    await fulfillPlayerProfile(route, {
+      id: "player-guest-e2e",
+      identity: requestBody.identity,
+      ownedCardIds: [],
+      deckIds: [],
+      starterFreeBoostersRemaining: 2,
+    });
+  });
+
+  await page.goto("/");
+
+  const profileShell = page.getByTestId("player-profile-shell");
+  await expect(profileShell).toHaveAttribute("data-profile-status", "ready");
+  await expect(profileShell).toHaveAttribute("data-profile-identity-mode", "guest");
+  await expect(profileShell).toHaveAttribute("data-profile-owned-card-count", "0");
+  await expect(profileShell).toHaveAttribute("data-profile-deck-count", "0");
+  await expect(profileShell).toHaveAttribute("data-starter-free-boosters-remaining", "2");
+  await expect(profileShell).toHaveAttribute("data-deck-source", "starter-fallback");
+  await expect(page.locator('[data-testid^="deck-card-"]')).toHaveCount(9);
+
+  expect(requests).toHaveLength(1);
+  const storedGuestId = await page.evaluate((key) => window.localStorage.getItem(key), GUEST_ID_STORAGE_KEY);
+  expect(storedGuestId).toBe((requests[0] as { identity: { guestId: string } }).identity.guestId);
+});
+
+test("bootstraps the Telegram MVP identity from client-provided telegramId", async ({ page }) => {
+  await page.route("https://telegram.org/js/telegram-web-app.js", async (route) => {
+    await route.fulfill({ contentType: "application/javascript", body: "" });
+  });
+  await page.addInitScript(() => {
+    Object.defineProperty(window, "Telegram", {
+      configurable: true,
+      value: {
+        WebApp: {
+          initData: "mvp-client-provided-telegram-id",
+          initDataUnsafe: {
+            user: {
+              id: 99887766,
+              username: "profiletester",
+              first_name: "Profile",
+              last_name: "Tester",
+            },
+          },
+          ready() {},
+          expand() {},
+          disableVerticalSwipes() {},
+          isVersionAtLeast() {
+            return false;
+          },
+        },
+      },
+    });
+  });
+
+  const requests: unknown[] = [];
+  await mockPlayerProfile(page, async (route) => {
+    const requestBody = route.request().postDataJSON() as { identity: { mode: "telegram"; telegramId: string } };
+    requests.push(requestBody);
+
+    await fulfillPlayerProfile(route, {
+      id: "player-telegram-e2e",
+      identity: requestBody.identity,
+      ownedCardIds: PROFILE_OWNED_CARD_IDS,
+      deckIds: PROFILE_DECK_IDS,
+      starterFreeBoostersRemaining: 1,
+    });
+  });
+
+  await page.goto("/");
+
+  await expect.poll(() => requests.length).toBe(1);
+  expect(requests).toHaveLength(1);
+  expect((requests[0] as { identity: { mode: string; telegramId: string } }).identity).toEqual({
+    mode: "telegram",
+    telegramId: "99887766",
+  });
+
+  const profileShell = page.getByTestId("player-profile-shell");
+  await expect(profileShell).toHaveAttribute("data-profile-status", "ready");
+  await expect(profileShell).toHaveAttribute("data-profile-identity-mode", "telegram");
+  await expect(profileShell).toHaveAttribute("data-profile-owned-card-count", String(PROFILE_OWNED_CARD_IDS.length));
+  await expect(profileShell).toHaveAttribute("data-profile-deck-count", String(PROFILE_DECK_IDS.length));
+  await expect(profileShell).toHaveAttribute("data-starter-free-boosters-remaining", "1");
+  await expect(profileShell).toHaveAttribute("data-deck-source", "profile");
+  await expect(page.locator('[data-testid^="deck-card-"]')).toHaveCount(PROFILE_DECK_IDS.length);
+  await expect(page.locator('[data-testid^="collection-card-"]')).toHaveCount(PROFILE_OWNED_CARD_IDS.length);
+});
+
+async function mockPlayerProfile(page: Page, handler: (route: Route) => Promise<void>) {
+  await page.route("**/api/player", handler);
+}
+
+async function fulfillPlayerProfile(
+  route: Route,
+  profile: {
+    id: string;
+    identity: { mode: "guest"; guestId: string } | { mode: "telegram"; telegramId: string };
+    ownedCardIds: string[];
+    deckIds: string[];
+    starterFreeBoostersRemaining: number;
+  },
+) {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      player: {
+        ...profile,
+        openedBoosterIds: [],
+        onboarding: {
+          starterBoostersAvailable: profile.starterFreeBoostersRemaining > 0,
+          collectionReady: profile.ownedCardIds.length > 0,
+          deckReady: profile.deckIds.length > 0,
+          completed: false,
+        },
+      },
+    }),
+  });
+}


### PR DESCRIPTION
Parent PRD: #1
Closes #3

## Summary
- add Mongo-backed player profile storage and /api/player GET/POST bootstrap responses
- bootstrap the game shell through /api/player using browser guest ids or MVP client-provided Telegram ids
- derive collection/deck/starter booster state from the loaded profile, with a temporary non-durable starter fallback for empty pre-onboarding profiles
- add Telegram/guest identity validation plus browser guest-id helper
- start MongoDB by default in Docker Compose with a persistent named volume and MONGODB_URI override support
- ignore legacy deck storage as a source of truth without deleting existing keys

## Known limitations
- Telegram profiles currently trust Telegram.WebApp.initDataUnsafe.user.id from the client for MVP; server-side initData HMAC verification is intentionally deferred.
- Until booster onboarding lands, empty new profiles render a starter fallback deck for the existing battle prototype; that fallback is not imported from CloudStorage/sessionStorage.

## Verification
- bun run test:profile
- bunx playwright test tests/profile-bootstrap.spec.ts tests/battle.spec.ts
- bun run lint
- bun run build
- docker compose config
- MONGODB_URI=mongodb://external.example:27017/custom docker compose config