### PR TITLE
feat(boosters): add catalog and opening engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "bun server.js",
     "lint": "eslint",
-    "test": "bun test tests/playerProfile.test.ts",
+    "test": "bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts",
     "test:profile": "bun test tests/playerProfile.test.ts",
     "test:e2e": "playwright test"
   },

--- a/src/app/api/boosters/route.ts
+++ b/src/app/api/boosters/route.ts
@@ -1,0 +1,12 @@
+import { handleBoosterCatalogGet, handleBoosterCatalogPost } from "@/features/boosters/api";
+import { getMongoPlayerProfileStore } from "@/features/player/profile/mongo";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  return handleBoosterCatalogGet();
+}
+
+export async function POST(request: Request) {
+  return handleBoosterCatalogPost(request, getMongoPlayerProfileStore());
+}

--- a/src/app/api/player/open-booster/route.ts
+++ b/src/app/api/player/open-booster/route.ts
@@ -1,0 +1,8 @@
+import { handleStarterBoosterOpenPost } from "@/features/boosters/api";
+import { getMongoPlayerProfileStore } from "@/features/player/profile/mongo";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  return handleStarterBoosterOpenPost(request, getMongoPlayerProfileStore());
+}

--- a/src/features/boosters/api.ts
+++ b/src/features/boosters/api.ts
@@ -1,0 +1,174 @@
+import { cards as activeCards } from "@/features/battle/model/cards";
+import type { Card } from "@/features/battle/model/types";
+import { PlayerIdentityValidationError, parsePlayerIdentity, toPlayerProfile } from "@/features/player/profile/types";
+import { getBoosterCatalogForPlayer, getBoosterCatalogResponse, validateBoosterCatalog } from "./catalog";
+import { BoosterOpeningError, prepareStarterBoosterOpening, type RandomSource } from "./opening";
+import type { BoosterOpeningRecord, BoosterOpeningStore, StoredBoosterOpeningRecord } from "./types";
+
+export async function handleBoosterCatalogGet() {
+  try {
+    validateBoosterCatalog();
+    return noStoreJson({ boosters: getBoosterCatalogResponse() });
+  } catch (error) {
+    return boosterApiErrorResponse(error);
+  }
+}
+
+export async function handleBoosterCatalogPost(request: Request, store: BoosterOpeningStore) {
+  try {
+    validateBoosterCatalog();
+    const body = await readJsonObject(request);
+    const identity = parsePlayerIdentity(body.identity);
+    const profile = toPlayerProfile(await store.findOrCreateByIdentity(identity));
+
+    return noStoreJson({
+      boosters: getBoosterCatalogForPlayer(profile),
+      player: profile,
+    });
+  } catch (error) {
+    return boosterApiErrorResponse(error);
+  }
+}
+
+export async function handleStarterBoosterOpenPost(
+  request: Request,
+  store: BoosterOpeningStore,
+  options: {
+    rng?: RandomSource;
+    now?: () => Date;
+  } = {},
+) {
+  try {
+    validateBoosterCatalog();
+    const body = await readJsonObject(request);
+    const identity = parsePlayerIdentity(body.identity);
+    const boosterId = parseBoosterId(body.boosterId);
+    const profile = toPlayerProfile(await store.findOrCreateByIdentity(identity));
+    const prepared = prepareStarterBoosterOpening({
+      boosterId,
+      player: profile,
+      rng: options.rng,
+    });
+    const openedAt = options.now?.() ?? new Date();
+    const persisted = await store.saveStarterBoosterOpening({
+      identity,
+      playerId: profile.id,
+      boosterId,
+      cardIds: prepared.cardIds,
+      openedAt,
+    });
+
+    return noStoreJson({
+      booster: prepared.booster,
+      cards: getPersistedOpeningCards(persisted.opening.cardIds),
+      opening: serializeOpeningRecord(persisted.opening),
+      player: toPlayerProfile(persisted.player),
+    });
+  } catch (error) {
+    return boosterApiErrorResponse(error);
+  }
+}
+
+function getPersistedOpeningCards(cardIds: string[]): Card[] {
+  const cardsById = new Map(activeCards.map((card) => [card.id, card]));
+  return cardIds.map((cardId) => {
+    const card = cardsById.get(cardId);
+    if (!card) {
+      throw new BoosterOpeningError("invalid_booster_opening", "Persisted booster opening contains an inactive card.", 500);
+    }
+
+    return card;
+  });
+}
+
+function parseBoosterId(value: unknown) {
+  if (typeof value !== "string") {
+    throw new BoosterOpeningError("invalid_booster_id", "boosterId must be a string.");
+  }
+
+  const boosterId = value.trim();
+  if (!boosterId) {
+    throw new BoosterOpeningError("invalid_booster_id", "boosterId must not be empty.");
+  }
+
+  return boosterId;
+}
+
+function serializeOpeningRecord(opening: StoredBoosterOpeningRecord): BoosterOpeningRecord {
+  return {
+    ...opening,
+    cardIds: [...opening.cardIds],
+    openedAt: opening.openedAt.toISOString(),
+  };
+}
+
+function noStoreJson(body: unknown, init?: ResponseInit) {
+  return Response.json(body, {
+    ...init,
+    headers: {
+      ...init?.headers,
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+function boosterApiErrorResponse(error: unknown) {
+  if (error instanceof PlayerIdentityValidationError) {
+    return noStoreJson(
+      {
+        error: "invalid_identity",
+        message: error.message,
+      },
+      { status: 400 },
+    );
+  }
+
+  if (error instanceof SyntaxError) {
+    return noStoreJson(
+      {
+        error: "invalid_request",
+        message: error.message,
+      },
+      { status: 400 },
+    );
+  }
+
+  if (error instanceof BoosterOpeningError) {
+    return noStoreJson(
+      {
+        error: error.code,
+        message: error.message,
+      },
+      { status: error.status },
+    );
+  }
+
+  console.error("Booster API failed.", error);
+  return noStoreJson(
+    {
+      error: "booster_unavailable",
+      message: "Booster service is unavailable.",
+    },
+    { status: 500 },
+  );
+}
+
+async function readJsonObject(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    throw new SyntaxError("request body must be valid JSON.");
+  }
+
+  if (!isRecord(body)) {
+    throw new SyntaxError("request body must be an object.");
+  }
+
+  return body;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/features/boosters/catalog.ts
+++ b/src/features/boosters/catalog.ts
@@ -1,0 +1,70 @@
+import { clans } from "@/features/battle/model/clans";
+import type { Booster, BoosterCatalogItem, BoosterResponse, PlayerBoosterCatalogProfile } from "./types";
+
+export const boosterCatalog = [
+  { id: "neon-breach", name: "Neon Breach", clans: ["[Da:Hack]", "Aliens"] },
+  { id: "factory-shift", name: "Factory Shift", clans: ["Workers", "Micron"] },
+  { id: "street-kings", name: "Street Kings", clans: ["Street", "Kingpin"] },
+  { id: "carnival-vice", name: "Carnival Vice", clans: ["Circus", "Gamblers"] },
+  { id: "faith-and-fury", name: "Faith & Fury", clans: ["Saints", "Fury"] },
+  { id: "biohazard", name: "Biohazard", clans: ["SymBio", "Deviants"] },
+  { id: "underworld", name: "Underworld", clans: ["Mafia", "Damned"] },
+  { id: "mind-games", name: "Mind Games", clans: ["PSI", "Enigma"] },
+  { id: "toy-factory", name: "Toy Factory", clans: ["Toyz", "Alpha"] },
+  { id: "metro-chase", name: "Metro Chase", clans: ["Metropolis", "Chasers"] },
+  { id: "desert-signal", name: "Desert Signal", clans: ["Халифат", "Nemos"] },
+  { id: "street-plague", name: "Street Plague", clans: ["Street", "Damned"] },
+] as const satisfies readonly Booster[];
+
+export function getBoosterById(boosterId: string) {
+  return boosterCatalog.find((booster) => booster.id === boosterId);
+}
+
+export function serializeBooster(booster: Booster): BoosterResponse {
+  return {
+    id: booster.id,
+    name: booster.name,
+    clans: [...booster.clans],
+  };
+}
+
+export function getBoosterCatalogResponse() {
+  return boosterCatalog.map(serializeBooster);
+}
+
+export function getBoosterCatalogForPlayer(profile: PlayerBoosterCatalogProfile): BoosterCatalogItem[] {
+  const openedBoosterIds = new Set(profile.openedBoosterIds);
+
+  return boosterCatalog.map((booster) => {
+    const opened = openedBoosterIds.has(booster.id);
+    const canOpen = profile.starterFreeBoostersRemaining > 0 && !opened;
+
+    return {
+      ...serializeBooster(booster),
+      starter: {
+        opened,
+        canOpen,
+        disabledReason: canOpen ? undefined : opened ? "already_opened" : "no_starter_boosters_remaining",
+      },
+    };
+  });
+}
+
+export function validateBoosterCatalog() {
+  for (const booster of boosterCatalog) {
+    if (booster.clans.length !== 2) {
+      throw new Error(`Booster ${booster.id} must have exactly two clans.`);
+    }
+
+    const boosterClans: readonly string[] = booster.clans;
+    if (boosterClans.includes("C.O.R.R.")) {
+      throw new Error(`Booster ${booster.id} must not include C.O.R.R.`);
+    }
+
+    for (const clan of booster.clans) {
+      if (!clans[clan]) {
+        throw new Error(`Booster ${booster.id} includes unknown clan ${clan}.`);
+      }
+    }
+  }
+}

--- a/src/features/boosters/opening.ts
+++ b/src/features/boosters/opening.ts
@@ -1,0 +1,180 @@
+import { cards as activeCards } from "@/features/battle/model/cards";
+import type { Card, Rarity } from "@/features/battle/model/types";
+import type { PlayerProfile } from "@/features/player/profile/types";
+import { getBoosterById, serializeBooster } from "./catalog";
+import { STARTER_BOOSTER_CARD_COUNT, STARTER_BOOSTER_WEIGHTED_CARD_COUNT, type PreparedStarterBoosterOpening } from "./types";
+
+export type RandomSource = () => number;
+
+const REQUIRED_STARTER_RARITIES: Rarity[] = ["Legend", "Unique"];
+const WEIGHTED_STARTER_RARITIES: { rarity: Rarity; weight: number }[] = [
+  { rarity: "Common", weight: 72 },
+  { rarity: "Rare", weight: 23 },
+  { rarity: "Unique", weight: 4 },
+  { rarity: "Legend", weight: 1 },
+];
+const FALLBACK_RARITY_ORDER: Rarity[] = ["Common", "Rare", "Unique", "Legend"];
+
+export class BoosterOpeningError extends Error {
+  constructor(
+    readonly code:
+      | "invalid_booster_id"
+      | "starter_booster_unavailable"
+      | "starter_booster_already_opened"
+      | "booster_required_rarity_unavailable"
+      | "booster_pool_exhausted"
+      | "invalid_booster_opening",
+    message: string,
+    readonly status = 400,
+  ) {
+    super(message);
+    this.name = "BoosterOpeningError";
+  }
+}
+
+export function prepareStarterBoosterOpening(input: {
+  boosterId: string;
+  player: Pick<PlayerProfile, "ownedCardIds" | "openedBoosterIds" | "starterFreeBoostersRemaining">;
+  rng?: RandomSource;
+  cardPool?: readonly Card[];
+}): PreparedStarterBoosterOpening {
+  const rng = input.rng ?? Math.random;
+  const booster = getBoosterById(input.boosterId);
+
+  if (!booster) {
+    throw new BoosterOpeningError("invalid_booster_id", "Booster does not exist.", 404);
+  }
+
+  if (input.player.starterFreeBoostersRemaining <= 0) {
+    throw new BoosterOpeningError("starter_booster_unavailable", "No free starter boosters remain.", 409);
+  }
+
+  if (input.player.openedBoosterIds.includes(booster.id)) {
+    throw new BoosterOpeningError("starter_booster_already_opened", "Starter boosters must be different.", 409);
+  }
+
+  const ownedCardIds = new Set(input.player.ownedCardIds);
+  const openedCards: Card[] = [];
+  const candidatePool = createBoosterCardPool(booster.clans, input.cardPool ?? activeCards, ownedCardIds);
+
+  for (const rarity of REQUIRED_STARTER_RARITIES) {
+    openedCards.push(pickRequiredRarityCard(candidatePool, rarity, openedCards, rng));
+  }
+
+  for (let index = 0; index < STARTER_BOOSTER_WEIGHTED_CARD_COUNT; index += 1) {
+    openedCards.push(pickWeightedRarityCard(candidatePool, chooseStarterWeightedRarity(rng), openedCards, rng));
+  }
+
+  validateOpeningCards(openedCards, booster.clans, input.cardPool ?? activeCards, ownedCardIds);
+
+  return {
+    booster: serializeBooster(booster),
+    cards: openedCards,
+    cardIds: openedCards.map((card) => card.id),
+    source: "starter_free",
+  };
+}
+
+export function chooseStarterWeightedRarity(rng: RandomSource): Rarity {
+  const roll = normalizeRandom(rng()) * 100;
+  let cumulative = 0;
+
+  for (const item of WEIGHTED_STARTER_RARITIES) {
+    cumulative += item.weight;
+    if (roll < cumulative) return item.rarity;
+  }
+
+  return "Legend";
+}
+
+function createBoosterCardPool(clans: readonly [string, string], cardPool: readonly Card[], ownedCardIds: Set<string>) {
+  const clanSet = new Set<string>(clans);
+  const seen = new Set<string>();
+
+  return cardPool.filter((card) => {
+    if (!clanSet.has(card.clan)) return false;
+    if (card.clan === "C.O.R.R." || card.id.startsWith("corr-")) return false;
+    if (ownedCardIds.has(card.id) || seen.has(card.id)) return false;
+    seen.add(card.id);
+    return true;
+  });
+}
+
+function pickRequiredRarityCard(pool: readonly Card[], rarity: Rarity, openedCards: readonly Card[], rng: RandomSource) {
+  const bucket = availableCards(pool, openedCards).filter((card) => card.rarity === rarity);
+
+  if (bucket.length === 0) {
+    throw new BoosterOpeningError("booster_required_rarity_unavailable", `No available ${rarity} cards remain for this booster.`, 409);
+  }
+
+  return pickRandomCard(bucket, rng);
+}
+
+function pickWeightedRarityCard(pool: readonly Card[], rarity: Rarity, openedCards: readonly Card[], rng: RandomSource) {
+  const candidates = availableCards(pool, openedCards);
+
+  if (candidates.length === 0) {
+    throw new BoosterOpeningError("booster_pool_exhausted", "No available cards remain for this booster.", 409);
+  }
+
+  const preferredBucket = candidates.filter((card) => card.rarity === rarity);
+  if (preferredBucket.length > 0) return pickRandomCard(preferredBucket, rng);
+
+  for (const fallbackRarity of FALLBACK_RARITY_ORDER) {
+    const fallbackBucket = candidates.filter((card) => card.rarity === fallbackRarity);
+    if (fallbackBucket.length > 0) return pickRandomCard(fallbackBucket, rng);
+  }
+
+  throw new BoosterOpeningError("booster_pool_exhausted", "No available cards remain for this booster.", 409);
+}
+
+function availableCards(pool: readonly Card[], openedCards: readonly Card[]) {
+  const openedCardIds = new Set(openedCards.map((card) => card.id));
+  return pool.filter((card) => !openedCardIds.has(card.id));
+}
+
+function pickRandomCard(cards: readonly Card[], rng: RandomSource) {
+  const index = Math.min(Math.floor(normalizeRandom(rng()) * cards.length), cards.length - 1);
+  return cards[index];
+}
+
+function normalizeRandom(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  if (value <= 0) return 0;
+  if (value >= 1) return 1 - Number.EPSILON;
+  return value;
+}
+
+function validateOpeningCards(openedCards: readonly Card[], clans: readonly [string, string], cardPool: readonly Card[], ownedCardIds: Set<string>) {
+  if (openedCards.length !== STARTER_BOOSTER_CARD_COUNT) {
+    throw new BoosterOpeningError("invalid_booster_opening", "Starter booster opening must contain five cards.", 500);
+  }
+
+  const activeCardIds = new Set(cardPool.map((card) => card.id));
+  const clanSet = new Set<string>(clans);
+  const openedCardIds = new Set<string>();
+  let hasLegend = false;
+  let hasUnique = false;
+
+  for (const card of openedCards) {
+    if (openedCardIds.has(card.id) || ownedCardIds.has(card.id)) {
+      throw new BoosterOpeningError("invalid_booster_opening", "Booster opening contains a duplicate card.", 500);
+    }
+
+    if (!activeCardIds.has(card.id) || !clanSet.has(card.clan)) {
+      throw new BoosterOpeningError("invalid_booster_opening", "Booster opening contains a card outside the booster pool.", 500);
+    }
+
+    if (card.clan === "C.O.R.R." || card.id.startsWith("corr-")) {
+      throw new BoosterOpeningError("invalid_booster_opening", "Booster opening contains a removed clan card.", 500);
+    }
+
+    openedCardIds.add(card.id);
+    hasLegend ||= card.rarity === "Legend";
+    hasUnique ||= card.rarity === "Unique";
+  }
+
+  if (!hasLegend || !hasUnique) {
+    throw new BoosterOpeningError("invalid_booster_opening", "Starter booster opening must include Legend and Unique cards.", 500);
+  }
+}

--- a/src/features/boosters/types.ts
+++ b/src/features/boosters/types.ts
@@ -1,0 +1,67 @@
+import type { Card } from "@/features/battle/model/types";
+import type { PlayerProfile, StoredPlayerProfile } from "@/features/player/profile/types";
+
+export const STARTER_BOOSTER_CARD_COUNT = 5;
+export const STARTER_BOOSTER_WEIGHTED_CARD_COUNT = 3;
+
+export type Booster = {
+  id: string;
+  name: string;
+  clans: readonly [string, string];
+};
+
+export type BoosterResponse = {
+  id: string;
+  name: string;
+  clans: [string, string];
+};
+
+export type BoosterCatalogItem = BoosterResponse & {
+  starter: {
+    opened: boolean;
+    canOpen: boolean;
+    disabledReason?: "already_opened" | "no_starter_boosters_remaining";
+  };
+};
+
+export type BoosterOpeningSource = "starter_free";
+
+export type StoredBoosterOpeningRecord = {
+  id: string;
+  playerId: string;
+  boosterId: string;
+  source: BoosterOpeningSource;
+  cardIds: string[];
+  openedAt: Date;
+};
+
+export type BoosterOpeningRecord = Omit<StoredBoosterOpeningRecord, "openedAt"> & {
+  openedAt: string;
+};
+
+export type PreparedStarterBoosterOpening = {
+  booster: BoosterResponse;
+  cards: Card[];
+  cardIds: string[];
+  source: BoosterOpeningSource;
+};
+
+export type PersistStarterBoosterOpeningInput = {
+  identity: StoredPlayerProfile["identity"];
+  playerId: string;
+  boosterId: string;
+  cardIds: string[];
+  openedAt: Date;
+};
+
+export type PersistedStarterBoosterOpening = {
+  player: StoredPlayerProfile;
+  opening: StoredBoosterOpeningRecord;
+};
+
+export type BoosterOpeningStore = {
+  findOrCreateByIdentity(identity: StoredPlayerProfile["identity"]): Promise<StoredPlayerProfile>;
+  saveStarterBoosterOpening(input: PersistStarterBoosterOpeningInput): Promise<PersistedStarterBoosterOpening>;
+};
+
+export type PlayerBoosterCatalogProfile = Pick<PlayerProfile, "openedBoosterIds" | "starterFreeBoostersRemaining">;

--- a/src/features/player/profile/mongo.ts
+++ b/src/features/player/profile/mongo.ts
@@ -1,14 +1,27 @@
-import { MongoClient, type Collection, type Filter, type WithId } from "mongodb";
+import { MongoClient, MongoServerError, ObjectId, type Collection, type Filter, type WithId } from "mongodb";
+import { BoosterOpeningError } from "@/features/boosters/opening";
+import type { BoosterOpeningSource, PersistStarterBoosterOpeningInput, PersistedStarterBoosterOpening, StoredBoosterOpeningRecord } from "@/features/boosters/types";
 import { createNewStoredPlayerProfile, type PlayerIdentity, type StoredPlayerProfile } from "./types";
 import type { PlayerProfileStore } from "./api";
 
 const DEFAULT_MONGODB_URI = "mongodb://127.0.0.1:27017/nexus-card-battle";
 const DEFAULT_MONGODB_DB = "nexus-card-battle";
 const PLAYERS_COLLECTION = "players";
+const BOOSTER_OPENINGS_COLLECTION = "boosterOpenings";
 
 type MongoPlayerDocument = Omit<StoredPlayerProfile, "id"> & {
   createdAt: Date;
   updatedAt: Date;
+};
+
+type MongoBoosterOpeningDocument = {
+  playerId: string;
+  identity: PlayerIdentity;
+  boosterId: string;
+  source: BoosterOpeningSource;
+  cardIds: string[];
+  openedAt: Date;
+  createdAt: Date;
 };
 
 const mongoGlobal = globalThis as typeof globalThis & {
@@ -23,6 +36,7 @@ export function getMongoPlayerProfileStore() {
 
 export class MongoPlayerProfileStore implements PlayerProfileStore {
   private indexesReady?: Promise<void>;
+  private boosterOpeningIndexesReady?: Promise<void>;
 
   constructor(
     private readonly clientPromise: Promise<MongoClient>,
@@ -60,10 +74,37 @@ export class MongoPlayerProfileStore implements PlayerProfileStore {
     return fromMongoDocument(document);
   }
 
+  async saveStarterBoosterOpening(input: PersistStarterBoosterOpeningInput): Promise<PersistedStarterBoosterOpening> {
+    const players = await this.getPlayersCollection();
+    const openings = await this.getBoosterOpeningsCollection();
+    const now = new Date();
+    const { opening, insertedOpeningId } = await createOrLoadStarterOpening(openings, input, now);
+
+    try {
+      return {
+        player: fromMongoDocument(await applyStarterOpeningToPlayer(players, input.identity, input.boosterId, opening.cardIds, now)),
+        opening: fromMongoOpeningDocument(opening),
+      };
+    } catch (error) {
+      if (insertedOpeningId) {
+        await openings.deleteOne({ _id: insertedOpeningId }).catch(() => undefined);
+      }
+
+      throw error;
+    }
+  }
+
   private async getPlayersCollection() {
     const client = await this.clientPromise;
     const collection = client.db(this.dbName).collection<MongoPlayerDocument>(PLAYERS_COLLECTION);
     await this.ensureIndexes(collection);
+    return collection;
+  }
+
+  private async getBoosterOpeningsCollection() {
+    const client = await this.clientPromise;
+    const collection = client.db(this.dbName).collection<MongoBoosterOpeningDocument>(BOOSTER_OPENINGS_COLLECTION);
+    await this.ensureBoosterOpeningIndexes(collection);
     return collection;
   }
 
@@ -89,6 +130,124 @@ export class MongoPlayerProfileStore implements PlayerProfileStore {
 
     return this.indexesReady;
   }
+
+  private ensureBoosterOpeningIndexes(collection: Collection<MongoBoosterOpeningDocument>) {
+    this.boosterOpeningIndexesReady ??= Promise.all([
+      collection.createIndex(
+        { playerId: 1, boosterId: 1, source: 1 },
+        {
+          name: "uniq_starter_booster_opening",
+          unique: true,
+        },
+      ),
+      collection.createIndex({ playerId: 1, openedAt: -1 }, { name: "idx_booster_openings_player_opened_at" }),
+      collection.createIndex({ boosterId: 1, openedAt: -1 }, { name: "idx_booster_openings_booster_opened_at" }),
+    ]).then(() => undefined);
+
+    return this.boosterOpeningIndexesReady;
+  }
+}
+
+async function applyStarterOpeningToPlayer(
+  players: Collection<MongoPlayerDocument>,
+  identity: PlayerIdentity,
+  boosterId: string,
+  cardIds: string[],
+  now: Date,
+) {
+  const updatedPlayer = await players.findOneAndUpdate(
+    {
+      ...identityFilter(identity),
+      starterFreeBoostersRemaining: { $gt: 0 },
+      openedBoosterIds: { $ne: boosterId },
+      ownedCardIds: { $nin: cardIds },
+    },
+    {
+      $addToSet: {
+        ownedCardIds: { $each: cardIds },
+        deckIds: { $each: cardIds },
+        openedBoosterIds: boosterId,
+      },
+      $inc: {
+        starterFreeBoostersRemaining: -1,
+      },
+      $set: {
+        updatedAt: now,
+      },
+    },
+    {
+      returnDocument: "after",
+    },
+  );
+
+  if (updatedPlayer) {
+    return updatedPlayer;
+  }
+
+  const currentPlayer = await players.findOne(identityFilter(identity));
+  if (currentPlayer && hasAppliedStarterOpening(currentPlayer, boosterId, cardIds)) {
+    return currentPlayer;
+  }
+
+  throw new BoosterOpeningError("starter_booster_unavailable", "Starter booster opening could not be saved for the current player state.", 409);
+}
+
+async function createOrLoadStarterOpening(
+  openings: Collection<MongoBoosterOpeningDocument>,
+  input: PersistStarterBoosterOpeningInput,
+  now: Date,
+): Promise<{ opening: WithId<MongoBoosterOpeningDocument>; insertedOpeningId?: ObjectId }> {
+  const openingId = new ObjectId();
+  const openingDocument: WithId<MongoBoosterOpeningDocument> = {
+    _id: openingId,
+    playerId: input.playerId,
+    identity: input.identity,
+    boosterId: input.boosterId,
+    source: "starter_free",
+    cardIds: input.cardIds,
+    openedAt: input.openedAt,
+    createdAt: now,
+  };
+
+  try {
+    // Compose uses standalone Mongo, so history is written before player state and replayed on duplicate recovery.
+    await openings.insertOne(openingDocument);
+    return {
+      opening: openingDocument,
+      insertedOpeningId: openingId,
+    };
+  } catch (error) {
+    if (!isDuplicateKeyError(error)) {
+      throw error;
+    }
+  }
+
+  const existingOpening = await openings.findOne(starterOpeningFilter(input.playerId, input.boosterId));
+  if (!existingOpening) {
+    throw new BoosterOpeningError("starter_booster_unavailable", "Starter booster opening history could not be recovered.", 409);
+  }
+
+  return {
+    opening: existingOpening,
+  };
+}
+
+function hasAppliedStarterOpening(player: MongoPlayerDocument, boosterId: string, cardIds: string[]) {
+  const ownedCardIds = new Set(player.ownedCardIds);
+  const deckIds = new Set(player.deckIds);
+  return player.openedBoosterIds.includes(boosterId) && cardIds.every((cardId) => ownedCardIds.has(cardId) && deckIds.has(cardId));
+}
+
+function starterOpeningFilter(playerId: string, boosterId: string): Filter<MongoBoosterOpeningDocument> {
+  return {
+    playerId,
+    boosterId,
+    source: "starter_free",
+  };
+}
+
+function isDuplicateKeyError(error: unknown) {
+  return error instanceof MongoServerError && error.code === 11000;
 }
 
 function getMongoClient(uri: string) {
@@ -129,5 +288,16 @@ function fromMongoDocument(document: WithId<MongoPlayerDocument>): StoredPlayerP
     deckIds: document.deckIds,
     starterFreeBoostersRemaining: document.starterFreeBoostersRemaining,
     openedBoosterIds: document.openedBoosterIds,
+  };
+}
+
+function fromMongoOpeningDocument(document: WithId<MongoBoosterOpeningDocument>): StoredBoosterOpeningRecord {
+  return {
+    id: document._id.toHexString(),
+    playerId: document.playerId,
+    boosterId: document.boosterId,
+    source: document.source,
+    cardIds: document.cardIds,
+    openedAt: document.openedAt,
   };
 }

--- a/tests/boosterOpening.test.ts
+++ b/tests/boosterOpening.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, test } from "bun:test";
+import { cards } from "../src/features/battle/model/cards";
+import type { Card, Rarity } from "../src/features/battle/model/types";
+import { handleBoosterCatalogGet, handleBoosterCatalogPost, handleStarterBoosterOpenPost } from "../src/features/boosters/api";
+import { getBoosterById } from "../src/features/boosters/catalog";
+import { BoosterOpeningError, chooseStarterWeightedRarity, prepareStarterBoosterOpening, type RandomSource } from "../src/features/boosters/opening";
+import type { BoosterCatalogItem, BoosterOpeningRecord, BoosterOpeningStore, StoredBoosterOpeningRecord } from "../src/features/boosters/types";
+import { createNewStoredPlayerProfile, isSamePlayerIdentity, type PlayerIdentity, type PlayerProfile, type StoredPlayerProfile } from "../src/features/player/profile/types";
+
+const guestIdentity: PlayerIdentity = {
+  mode: "guest",
+  guestId: "booster-guest",
+};
+
+describe("booster catalog", () => {
+  test("returns twelve curated two-clan boosters without C.O.R.R.", async () => {
+    const response = await handleBoosterCatalogGet();
+    const body = (await response.json()) as { boosters: { id: string; name: string; clans: string[] }[] };
+
+    expect(response.status).toBe(200);
+    expect(body.boosters).toHaveLength(12);
+    expect(body.boosters.map((booster) => booster.name)).toEqual([
+      "Neon Breach",
+      "Factory Shift",
+      "Street Kings",
+      "Carnival Vice",
+      "Faith & Fury",
+      "Biohazard",
+      "Underworld",
+      "Mind Games",
+      "Toy Factory",
+      "Metro Chase",
+      "Desert Signal",
+      "Street Plague",
+    ]);
+
+    for (const booster of body.boosters) {
+      expect(booster.clans).toHaveLength(2);
+      expect(booster.clans).not.toContain("C.O.R.R.");
+    }
+  });
+
+  test("marks the first opened starter booster as disabled while the second remains selectable", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    await openBooster(store, "neon-breach");
+
+    const response = await postCatalog(store, guestIdentity);
+    const body = (await response.json()) as { boosters: BoosterCatalogItem[]; player: PlayerProfile };
+    const opened = body.boosters.find((booster) => booster.id === "neon-breach");
+    const next = body.boosters.find((booster) => booster.id === "factory-shift");
+
+    expect(response.status).toBe(200);
+    expect(body.player.starterFreeBoostersRemaining).toBe(1);
+    expect(opened?.starter).toEqual({
+      opened: true,
+      canOpen: false,
+      disabledReason: "already_opened",
+    });
+    expect(next?.starter).toEqual({
+      opened: false,
+      canOpen: true,
+    });
+  });
+});
+
+describe("starter booster opening", () => {
+  test("guarantees one Legend and one Unique, returns five unique cards from the booster clans, and persists history", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    const response = await openBooster(store, "neon-breach");
+    const body = (await response.json()) as OpenBoosterResponse;
+    const rarities = body.cards.map((card) => card.rarity);
+    const cardIds = body.cards.map((card) => card.id);
+
+    expect(response.status).toBe(200);
+    expect(body.booster.id).toBe("neon-breach");
+    expect(body.cards).toHaveLength(5);
+    expect(rarities).toContain("Legend");
+    expect(rarities).toContain("Unique");
+    expect(new Set(cardIds).size).toBe(5);
+    expect(body.cards.every((card) => body.booster.clans.includes(card.clan))).toBe(true);
+    expect(body.cards.some((card) => card.clan === "C.O.R.R." || card.id.startsWith("corr-"))).toBe(false);
+    expect(body.player.ownedCardIds).toEqual(cardIds);
+    expect(body.player.deckIds).toEqual(cardIds);
+    expect(body.player.openedBoosterIds).toEqual(["neon-breach"]);
+    expect(body.player.starterFreeBoostersRemaining).toBe(1);
+    expect(store.openings).toHaveLength(1);
+    expect(body.opening).toMatchObject({
+      id: "opening-1",
+      playerId: "player-1",
+      boosterId: "neon-breach",
+      source: "starter_free",
+      cardIds,
+      openedAt: "2026-05-02T12:00:00.000Z",
+    });
+  });
+
+  test("uses Common 72%, Rare 23%, Unique 4%, Legend 1% for weighted starter slots", () => {
+    expect(chooseStarterWeightedRarity(() => 0)).toBe("Common");
+    expect(chooseStarterWeightedRarity(() => 0.7199)).toBe("Common");
+    expect(chooseStarterWeightedRarity(() => 0.72)).toBe("Rare");
+    expect(chooseStarterWeightedRarity(() => 0.9499)).toBe("Rare");
+    expect(chooseStarterWeightedRarity(() => 0.95)).toBe("Unique");
+    expect(chooseStarterWeightedRarity(() => 0.9899)).toBe("Unique");
+    expect(chooseStarterWeightedRarity(() => 0.99)).toBe("Legend");
+  });
+
+  test("falls back when a weighted rarity bucket is unavailable without duplicating cards or owned cards", () => {
+    const booster = getBoosterById("neon-breach");
+    if (!booster) throw new Error("Expected neon-breach booster.");
+
+    const boosterClans: readonly string[] = booster.clans;
+    const ownedRareIds = cards.filter((card) => boosterClans.includes(card.clan) && card.rarity === "Rare").map((card) => card.id);
+    const opening = prepareStarterBoosterOpening({
+      boosterId: booster.id,
+      player: {
+        ownedCardIds: ownedRareIds,
+        openedBoosterIds: [],
+        starterFreeBoostersRemaining: 2,
+      },
+      rng: sequenceRng([0, 0, 0.8, 0, 0.8, 0, 0.8, 0]),
+    });
+    const cardIds = opening.cardIds;
+
+    expect(opening.cards).toHaveLength(5);
+    expect(opening.cards.map((card) => card.rarity)).toContain("Legend");
+    expect(opening.cards.map((card) => card.rarity)).toContain("Unique");
+    expect(opening.cards.some((card) => card.rarity === "Rare")).toBe(false);
+    expect(cardIds.some((cardId) => ownedRareIds.includes(cardId))).toBe(false);
+    expect(new Set(cardIds).size).toBe(5);
+  });
+
+  test("rejects unknown boosters and unavailable starter openings", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    const unknown = await openBooster(store, "missing-booster");
+
+    expect(unknown.status).toBe(404);
+    expect(((await unknown.json()) as { error: string }).error).toBe("invalid_booster_id");
+
+    const unavailableStore = new MemoryBoosterOpeningStore();
+    unavailableStore.seedProfile(guestIdentity, {
+      starterFreeBoostersRemaining: 0,
+    });
+    const unavailable = await openBooster(unavailableStore, "neon-breach");
+
+    expect(unavailable.status).toBe(409);
+    expect(((await unavailable.json()) as { error: string }).error).toBe("starter_booster_unavailable");
+    expect(unavailableStore.openings).toHaveLength(0);
+  });
+
+  test("rejects opening the same starter booster twice", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    const first = await openBooster(store, "neon-breach");
+    const second = await openBooster(store, "neon-breach");
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(409);
+    expect(((await second.json()) as { error: string }).error).toBe("starter_booster_already_opened");
+    expect(store.openings).toHaveLength(1);
+  });
+
+  test("does not advance player state when history insert fails", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    await store.findOrCreateByIdentity(guestIdentity);
+    store.failNextHistoryInsert = true;
+
+    const response = await withSuppressedConsoleError(() => openBooster(store, "neon-breach"));
+    const body = (await response.json()) as { error: string };
+    const profile = await store.findOrCreateByIdentity(guestIdentity);
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("booster_unavailable");
+    expect(profile.ownedCardIds).toEqual([]);
+    expect(profile.deckIds).toEqual([]);
+    expect(profile.openedBoosterIds).toEqual([]);
+    expect(profile.starterFreeBoostersRemaining).toBe(2);
+    expect(store.openings).toHaveLength(0);
+  });
+
+  test("recovers a prewritten opening history record before advancing player state", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    const profile = await store.findOrCreateByIdentity(guestIdentity);
+    const pendingOpening = prepareStarterBoosterOpening({
+      boosterId: "neon-breach",
+      player: {
+        ownedCardIds: [],
+        openedBoosterIds: [],
+        starterFreeBoostersRemaining: 2,
+      },
+      rng: sequenceRng(Array.from({ length: 16 }, () => 0)),
+    });
+    store.seedOpening({
+      playerId: profile.id,
+      boosterId: "neon-breach",
+      cardIds: pendingOpening.cardIds,
+      openedAt: new Date("2026-05-02T11:59:00.000Z"),
+    });
+
+    const response = await openBooster(store, "neon-breach");
+    const body = (await response.json()) as OpenBoosterResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.opening).toMatchObject({
+      id: "opening-1",
+      boosterId: "neon-breach",
+      cardIds: pendingOpening.cardIds,
+      openedAt: "2026-05-02T11:59:00.000Z",
+    });
+    expect(body.cards.map((card) => card.id)).toEqual(pendingOpening.cardIds);
+    expect(body.player.ownedCardIds).toEqual(pendingOpening.cardIds);
+    expect(body.player.deckIds).toEqual(pendingOpening.cardIds);
+    expect(body.player.openedBoosterIds).toEqual(["neon-breach"]);
+    expect(body.player.starterFreeBoostersRemaining).toBe(1);
+    expect(store.openings).toHaveLength(1);
+  });
+});
+
+class MemoryBoosterOpeningStore implements BoosterOpeningStore {
+  private readonly profiles: StoredPlayerProfile[] = [];
+  readonly openings: StoredBoosterOpeningRecord[] = [];
+  private nextProfileId = 1;
+  private nextOpeningId = 1;
+  failNextHistoryInsert = false;
+
+  async findOrCreateByIdentity(identity: PlayerIdentity): Promise<StoredPlayerProfile> {
+    const existing = this.profiles.find((profile) => isSamePlayerIdentity(profile.identity, identity));
+    if (existing) return existing;
+
+    const profile = createNewStoredPlayerProfile(`player-${this.nextProfileId}`, identity);
+    this.nextProfileId += 1;
+    this.profiles.push(profile);
+    return profile;
+  }
+
+  async saveStarterBoosterOpening(input: {
+    identity: PlayerIdentity;
+    playerId: string;
+    boosterId: string;
+    cardIds: string[];
+    openedAt: Date;
+  }) {
+    const profileIndex = this.profiles.findIndex((profile) => isSamePlayerIdentity(profile.identity, input.identity));
+    const profile = this.profiles[profileIndex];
+    let opening = this.openings.find((item) => item.playerId === input.playerId && item.boosterId === input.boosterId && item.source === "starter_free");
+    let createdOpening = false;
+
+    if (!profile) {
+      throw new BoosterOpeningError("starter_booster_unavailable", "Starter booster opening could not be saved for the current player state.", 409);
+    }
+
+    if (!opening) {
+      if (this.failNextHistoryInsert) {
+        this.failNextHistoryInsert = false;
+        throw new Error("Simulated boosterOpening insert failure.");
+      }
+
+      opening = {
+        id: `opening-${this.nextOpeningId}`,
+        playerId: input.playerId,
+        boosterId: input.boosterId,
+        source: "starter_free",
+        cardIds: input.cardIds,
+        openedAt: input.openedAt,
+      };
+      this.nextOpeningId += 1;
+      this.openings.push(opening);
+      createdOpening = true;
+    }
+
+    if (hasAppliedOpening(profile, input.boosterId, opening.cardIds)) {
+      return {
+        player: profile,
+        opening,
+      };
+    }
+
+    if (profile.starterFreeBoostersRemaining <= 0 || profile.openedBoosterIds.includes(input.boosterId) || opening.cardIds.some((cardId) => profile.ownedCardIds.includes(cardId))) {
+      if (createdOpening) {
+        this.removeOpening(opening.id);
+      }
+      throw new BoosterOpeningError("starter_booster_unavailable", "Starter booster opening could not be saved for the current player state.", 409);
+    }
+
+    const updatedProfile: StoredPlayerProfile = {
+      ...profile,
+      ownedCardIds: unique([...profile.ownedCardIds, ...opening.cardIds]),
+      deckIds: unique([...profile.deckIds, ...opening.cardIds]),
+      starterFreeBoostersRemaining: profile.starterFreeBoostersRemaining - 1,
+      openedBoosterIds: [...profile.openedBoosterIds, input.boosterId],
+    };
+
+    this.profiles[profileIndex] = updatedProfile;
+
+    return {
+      player: updatedProfile,
+      opening,
+    };
+  }
+
+  seedProfile(identity: PlayerIdentity, profile: Partial<StoredPlayerProfile>) {
+    const stored = {
+      ...createNewStoredPlayerProfile(`player-${this.nextProfileId}`, identity),
+      ...profile,
+      identity,
+    };
+    this.nextProfileId += 1;
+    this.profiles.push(stored);
+    return stored;
+  }
+
+  seedOpening(input: { playerId: string; boosterId: string; cardIds: string[]; openedAt: Date }) {
+    const opening: StoredBoosterOpeningRecord = {
+      id: `opening-${this.nextOpeningId}`,
+      playerId: input.playerId,
+      boosterId: input.boosterId,
+      source: "starter_free",
+      cardIds: input.cardIds,
+      openedAt: input.openedAt,
+    };
+    this.nextOpeningId += 1;
+    this.openings.push(opening);
+    return opening;
+  }
+
+  private removeOpening(openingId: string) {
+    const openingIndex = this.openings.findIndex((opening) => opening.id === openingId);
+    if (openingIndex >= 0) {
+      this.openings.splice(openingIndex, 1);
+    }
+  }
+}
+
+function openBooster(store: BoosterOpeningStore, boosterId: string) {
+  return handleStarterBoosterOpenPost(
+    postRequest("http://localhost/api/player/open-booster", {
+      identity: guestIdentity,
+      boosterId,
+    }),
+    store,
+    {
+      rng: sequenceRng(Array.from({ length: 16 }, () => 0)),
+      now: () => new Date("2026-05-02T12:00:00.000Z"),
+    },
+  );
+}
+
+function postCatalog(store: BoosterOpeningStore, identity: PlayerIdentity) {
+  return handleBoosterCatalogPost(
+    postRequest("http://localhost/api/boosters", {
+      identity,
+    }),
+    store,
+  );
+}
+
+function postRequest(url: string, body: unknown) {
+  return new Request(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function sequenceRng(values: number[]): RandomSource {
+  let index = 0;
+  return () => values[index++] ?? 0;
+}
+
+function unique(values: string[]) {
+  return [...new Set(values)];
+}
+
+function hasAppliedOpening(profile: StoredPlayerProfile, boosterId: string, cardIds: string[]) {
+  const ownedCardIds = new Set(profile.ownedCardIds);
+  const deckIds = new Set(profile.deckIds);
+  return profile.openedBoosterIds.includes(boosterId) && cardIds.every((cardId) => ownedCardIds.has(cardId) && deckIds.has(cardId));
+}
+
+async function withSuppressedConsoleError<T>(callback: () => Promise<T>) {
+  const originalConsoleError = console.error;
+  console.error = () => undefined;
+
+  try {
+    return await callback();
+  } finally {
+    console.error = originalConsoleError;
+  }
+}
+
+type OpenBoosterResponse = {
+  booster: {
+    id: string;
+    name: string;
+    clans: [string, string];
+  };
+  cards: (Card & { rarity: Rarity })[];
+  opening: BoosterOpeningRecord;
+  player: PlayerProfile;
+};


### PR DESCRIPTION
## Summary
- Adds the curated 12-booster catalog API, including player-specific starter availability state.
- Adds the starter booster opening engine with guaranteed Legend/Unique cards, weighted remaining slots, duplicate/owned-card avoidance, and fallback selection.
- Persists starter openings by updating player owned/deck/opened state and appending boosterOpenings history records.

## Verification
- bun test tests/boosterOpening.test.ts
- bun run test
- bun run lint
- bun run build
- docker compose config
- bunx playwright test tests/data-regression.spec.ts

Closes #4
Parent: #1