### PR TITLE
fix(profile): fail fast when Mongo is unavailable

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     trace: "on-first-retry",
   },
   webServer: {
-    command: "bun run dev -- --hostname 127.0.0.1",
+    command: "MONGODB_SERVER_SELECTION_TIMEOUT_MS=200 bun run dev -- --hostname 127.0.0.1",
     url: "http://127.0.0.1:3000",
     reuseExistingServer: true,
     timeout: 120_000,

--- a/src/features/player/profile/mongo.ts
+++ b/src/features/player/profile/mongo.ts
@@ -6,6 +6,7 @@ import type { PlayerProfileStore } from "./api";
 
 const DEFAULT_MONGODB_URI = "mongodb://127.0.0.1:27017/nexus-card-battle";
 const DEFAULT_MONGODB_DB = "nexus-card-battle";
+const DEFAULT_MONGODB_SERVER_SELECTION_TIMEOUT_MS = 1_500;
 const PLAYERS_COLLECTION = "players";
 const BOOSTER_OPENINGS_COLLECTION = "boosterOpenings";
 
@@ -29,8 +30,8 @@ const mongoGlobal = globalThis as typeof globalThis & {
 };
 
 export function getMongoPlayerProfileStore() {
-  const { uri, dbName } = getMongoConfig();
-  const clientPromise = getMongoClient(uri);
+  const { uri, dbName, serverSelectionTimeoutMS } = getMongoConfig();
+  const clientPromise = getMongoClient(uri, serverSelectionTimeoutMS);
   return new MongoPlayerProfileStore(clientPromise, dbName);
 }
 
@@ -250,8 +251,10 @@ function isDuplicateKeyError(error: unknown) {
   return error instanceof MongoServerError && error.code === 11000;
 }
 
-function getMongoClient(uri: string) {
-  mongoGlobal.__nexusPlayerMongoClientPromise ??= new MongoClient(uri).connect();
+function getMongoClient(uri: string, serverSelectionTimeoutMS: number) {
+  mongoGlobal.__nexusPlayerMongoClientPromise ??= new MongoClient(uri, {
+    serverSelectionTimeoutMS,
+  }).connect();
   return mongoGlobal.__nexusPlayerMongoClientPromise;
 }
 
@@ -260,6 +263,10 @@ function getMongoConfig() {
   return {
     uri,
     dbName: process.env.MONGODB_DB || parseDatabaseName(uri) || DEFAULT_MONGODB_DB,
+    serverSelectionTimeoutMS: parsePositiveInteger(
+      process.env.MONGODB_SERVER_SELECTION_TIMEOUT_MS,
+      DEFAULT_MONGODB_SERVER_SELECTION_TIMEOUT_MS,
+    ),
   };
 }
 
@@ -270,6 +277,13 @@ function parseDatabaseName(uri: string) {
   } catch {
     return undefined;
   }
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number) {
+  if (!value) return fallback;
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function identityFilter(identity: PlayerIdentity): Filter<MongoPlayerDocument> {

--- a/src/features/player/profile/mongo.ts
+++ b/src/features/player/profile/mongo.ts
@@ -25,8 +25,13 @@ type MongoBoosterOpeningDocument = {
   createdAt: Date;
 };
 
+type MongoClientPromiseCache = {
+  key: string;
+  promise: Promise<MongoClient>;
+};
+
 const mongoGlobal = globalThis as typeof globalThis & {
-  __nexusPlayerMongoClientPromise?: Promise<MongoClient>;
+  __nexusPlayerMongoClientPromise?: MongoClientPromiseCache;
 };
 
 export function getMongoPlayerProfileStore() {
@@ -252,10 +257,25 @@ function isDuplicateKeyError(error: unknown) {
 }
 
 function getMongoClient(uri: string, serverSelectionTimeoutMS: number) {
-  mongoGlobal.__nexusPlayerMongoClientPromise ??= new MongoClient(uri, {
+  const key = `${uri}|${serverSelectionTimeoutMS}`;
+  if (mongoGlobal.__nexusPlayerMongoClientPromise?.key === key) {
+    return mongoGlobal.__nexusPlayerMongoClientPromise.promise;
+  }
+
+  const promise = new MongoClient(uri, {
     serverSelectionTimeoutMS,
-  }).connect();
-  return mongoGlobal.__nexusPlayerMongoClientPromise;
+  })
+    .connect()
+    .catch((error) => {
+      if (mongoGlobal.__nexusPlayerMongoClientPromise?.promise === promise) {
+        mongoGlobal.__nexusPlayerMongoClientPromise = undefined;
+      }
+
+      throw error;
+    });
+
+  mongoGlobal.__nexusPlayerMongoClientPromise = { key, promise };
+  return promise;
 }
 
 function getMongoConfig() {


### PR DESCRIPTION
## Summary
- make Mongo profile lookup fail fast when MongoDB is unavailable so the client fallback state is usable outside Docker
- allow overriding the Mongo server-selection timeout through MONGODB_SERVER_SELECTION_TIMEOUT_MS
- lower the Playwright webServer timeout for Mongo fallback to keep legacy E2E stable when local Mongo is not running

## Verification
- bun run lint
- bun run test:profile
- docker compose config --quiet
- MONGODB_URI=mongodb://external.example:27017/custom docker compose config --quiet
- bun run build
- bunx playwright test tests/realtime.spec.ts --grep "pairs two tabs" --workers=1
- bun run test:e2e

Follow-up for #3 / #11
Parent: #1