### PR TITLE
feat(onboarding): starter booster reveal flow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,6 +103,43 @@ a {
   }
 }
 
+@keyframes starter-reveal-in {
+  from {
+    opacity: 0;
+    transform: translateY(18px) rotate(-2deg) scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) rotate(0deg) scale(1);
+  }
+}
+
+@keyframes starter-chip-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.starter-reveal-card {
+  animation: starter-reveal-in 360ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.starter-reveal-chip {
+  animation: starter-chip-in 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .starter-reveal-card,
+  .starter-reveal-chip {
+    animation: none;
+  }
+}
+
 @keyframes nexus-duel-throw-player {
   0% {
     opacity: 0;

--- a/src/features/boosters/client.ts
+++ b/src/features/boosters/client.ts
@@ -1,6 +1,11 @@
 import type { Card } from "@/features/battle/model/types";
 import type { PlayerIdentity, PlayerProfile } from "@/features/player/profile/types";
-import type { BoosterOpeningRecord, BoosterResponse } from "./types";
+import type { BoosterCatalogItem, BoosterOpeningRecord, BoosterResponse } from "./types";
+
+export type StarterBoosterCatalogResponse = {
+  boosters: BoosterCatalogItem[];
+  player: PlayerProfile;
+};
 
 export type OpenStarterBoosterResponse = {
   booster: BoosterResponse;
@@ -8,6 +13,32 @@ export type OpenStarterBoosterResponse = {
   opening: BoosterOpeningRecord;
   player: PlayerProfile;
 };
+
+export async function fetchStarterBoosterCatalog(identity: PlayerIdentity): Promise<StarterBoosterCatalogResponse> {
+  const response = await fetch("/api/boosters", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ identity }),
+  });
+  const body = (await response.json().catch(() => undefined)) as Partial<StarterBoosterCatalogResponse> & {
+    message?: string;
+  };
+
+  if (!response.ok) {
+    throw new Error(body?.message || `Starter booster catalog could not be loaded: ${response.status}`);
+  }
+
+  if (!Array.isArray(body?.boosters) || !body.player) {
+    throw new Error("Starter booster catalog response is incomplete.");
+  }
+
+  return {
+    boosters: body.boosters,
+    player: body.player,
+  };
+}
 
 export async function openStarterBooster(identity: PlayerIdentity, boosterId: string): Promise<OpenStarterBoosterResponse> {
   const response = await fetch("/api/player/open-booster", {

--- a/src/features/boosters/client.ts
+++ b/src/features/boosters/client.ts
@@ -1,0 +1,38 @@
+import type { Card } from "@/features/battle/model/types";
+import type { PlayerIdentity, PlayerProfile } from "@/features/player/profile/types";
+import type { BoosterOpeningRecord, BoosterResponse } from "./types";
+
+export type OpenStarterBoosterResponse = {
+  booster: BoosterResponse;
+  cards: Card[];
+  opening: BoosterOpeningRecord;
+  player: PlayerProfile;
+};
+
+export async function openStarterBooster(identity: PlayerIdentity, boosterId: string): Promise<OpenStarterBoosterResponse> {
+  const response = await fetch("/api/player/open-booster", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ identity, boosterId }),
+  });
+  const body = (await response.json().catch(() => undefined)) as Partial<OpenStarterBoosterResponse> & {
+    message?: string;
+  };
+
+  if (!response.ok) {
+    throw new Error(body?.message || `Starter booster could not be opened: ${response.status}`);
+  }
+
+  if (!body?.booster || !Array.isArray(body.cards) || !body.player || !body.opening) {
+    throw new Error("Starter booster response is incomplete.");
+  }
+
+  return {
+    booster: body.booster,
+    cards: body.cards,
+    opening: body.opening,
+    player: body.player,
+  };
+}

--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -63,7 +63,8 @@ export function GameRoot() {
     profileStatus === "ready" &&
     Boolean(playerIdentity) &&
     Boolean(playerProfile) &&
-    (playerProfile?.starterFreeBoostersRemaining ?? 0) > 0;
+    (playerProfile?.starterFreeBoostersRemaining ?? 0) > 0 &&
+    !playerProfile?.onboarding.completed;
 
   useEffect(() => {
     const telegramPlayerHandle = window.setTimeout(() => setTelegramPlayer(readTelegramPlayer()), 0);
@@ -149,6 +150,10 @@ export function GameRoot() {
     },
     [collectionIds],
   );
+  const handleStarterProfileChange = useCallback((nextProfile: PlayerProfile) => {
+    deckTouchedRef.current = false;
+    setPlayerProfile(nextProfile);
+  }, []);
 
   if (screen === "battle") {
     return (
@@ -192,10 +197,7 @@ export function GameRoot() {
           profileStatus={profileStatus}
           profileIdentityMode={playerIdentity.mode}
           deckSource={deckSource}
-          onProfileChange={(nextProfile) => {
-            deckTouchedRef.current = false;
-            setPlayerProfile(nextProfile);
-          }}
+          onProfileChange={handleStarterProfileChange}
         />
         <TelegramLandscapeOverlay active={telegramLandscapePromptActive} />
       </>

--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -12,7 +12,7 @@ import { CollectionDeckScreen } from "./collection/CollectionDeckScreen";
 import { StarterBoosterOnboarding } from "./onboarding/StarterBoosterOnboarding";
 
 type BattleMode = "ai" | "human";
-type ProfileStatus = "loading" | "ready" | "fallback";
+type ProfileStatus = "loading" | "ready" | "unavailable";
 type DeckSource = "profile" | "starter-fallback";
 type TelegramWindow = Window & {
   Telegram?: {
@@ -51,6 +51,7 @@ export function GameRoot() {
   const [playerProfile, setPlayerProfile] = useState<PlayerProfile | null>(null);
   const [playerIdentity, setPlayerIdentity] = useState<PlayerIdentity | null>(null);
   const [profileStatus, setProfileStatus] = useState<ProfileStatus>("loading");
+  const [profileRetryKey, setProfileRetryKey] = useState(0);
   const [telegramPlayer, setTelegramPlayer] = useState<TelegramPlayer>(() => readTelegramPlayer());
   const [telegramLandscapePromptActive, setTelegramLandscapePromptActive] = useState(false);
   const deckTouchedRef = useRef(false);
@@ -88,13 +89,14 @@ export function GameRoot() {
       .catch(() => {
         if (disposed) return;
         setPlayerIdentity(identity);
-        setProfileStatus("fallback");
+        setPlayerProfile(null);
+        setProfileStatus("unavailable");
       });
 
     return () => {
       disposed = true;
     };
-  }, []);
+  }, [profileRetryKey]);
 
   useEffect(() => {
     if (deckTouchedRef.current) return;
@@ -154,6 +156,12 @@ export function GameRoot() {
     deckTouchedRef.current = false;
     setPlayerProfile(nextProfile);
   }, []);
+  const retryProfileLoad = useCallback(() => {
+    deckTouchedRef.current = false;
+    setPlayerProfile(null);
+    setProfileStatus("loading");
+    setProfileRetryKey((current) => current + 1);
+  }, []);
 
   if (screen === "battle") {
     return (
@@ -183,6 +191,15 @@ export function GameRoot() {
     return (
       <>
         <ProfileLoadingScreen />
+        <TelegramLandscapeOverlay active={telegramLandscapePromptActive} />
+      </>
+    );
+  }
+
+  if (profileStatus === "unavailable") {
+    return (
+      <>
+        <ProfileUnavailableScreen profileIdentityMode={playerIdentity?.mode} onRetry={retryProfileLoad} />
         <TelegramLandscapeOverlay active={telegramLandscapePromptActive} />
       </>
     );
@@ -224,6 +241,48 @@ export function GameRoot() {
       />
       <TelegramLandscapeOverlay active={telegramLandscapePromptActive} />
     </>
+  );
+}
+
+function ProfileUnavailableScreen({
+  profileIdentityMode,
+  onRetry,
+}: {
+  profileIdentityMode?: "telegram" | "guest";
+  onRetry: () => void;
+}) {
+  return (
+    <main
+      className="grid min-h-screen place-items-center bg-[#080907] px-4 text-[#f7efd7]"
+      data-testid="player-profile-shell"
+      data-profile-status="unavailable"
+      data-profile-identity-mode={profileIdentityMode ?? "unknown"}
+      data-profile-owned-card-count="0"
+      data-profile-deck-count="0"
+      data-deck-source="starter-fallback"
+      data-starter-free-boosters-remaining="0"
+    >
+      <section
+        className="grid w-full max-w-[460px] gap-3 rounded-md border border-[#ef735a]/45 bg-[linear-gradient(180deg,rgba(36,20,16,0.94),rgba(9,11,11,0.97))] p-4 text-left shadow-[0_18px_42px_rgba(0,0,0,0.42)]"
+        data-testid="profile-unavailable"
+      >
+        <b className="text-[11px] font-black uppercase tracking-[0.16em] text-[#efcf6f]">Профіль недоступний</b>
+        <strong className="text-[clamp(24px,6vw,34px)] font-black uppercase leading-none text-[#fff0ad]">
+          Не вдалося завантажити гравця
+        </strong>
+        <p className="text-sm font-bold leading-snug text-[#d6c5a0]">
+          Стартові бустери та колода відкриваються тільки після збереженого профілю.
+        </p>
+        <button
+          className="min-h-[42px] justify-self-start rounded-md border-2 border-black/55 bg-[linear-gradient(180deg,#fff26d,#e2b72e_56%,#966414)] px-5 text-sm font-black uppercase text-[#17100a] transition hover:brightness-110"
+          type="button"
+          onClick={onRetry}
+          data-testid="profile-retry"
+        >
+          Спробувати ще раз
+        </button>
+      </section>
+    </main>
   );
 }
 

--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -9,6 +9,7 @@ import type { PlayerIdentity, PlayerProfile } from "@/features/player/profile/ty
 import type { TelegramPlayer } from "@/shared/lib/telegram";
 import { PLAYER_DECK_SIZE } from "../model/randomDeck";
 import { CollectionDeckScreen } from "./collection/CollectionDeckScreen";
+import { StarterBoosterOnboarding } from "./onboarding/StarterBoosterOnboarding";
 
 type BattleMode = "ai" | "human";
 type ProfileStatus = "loading" | "ready" | "fallback";
@@ -58,6 +59,11 @@ export function GameRoot() {
   const deckSource: DeckSource = profileDeckIds.length > 0 ? "profile" : "starter-fallback";
   const starterFreeBoostersRemaining = playerProfile?.starterFreeBoostersRemaining ?? 0;
   const playerName = telegramPlayer.name;
+  const showStarterOnboarding =
+    profileStatus === "ready" &&
+    Boolean(playerIdentity) &&
+    Boolean(playerProfile) &&
+    (playerProfile?.starterFreeBoostersRemaining ?? 0) > 0;
 
   useEffect(() => {
     const telegramPlayerHandle = window.setTimeout(() => setTelegramPlayer(readTelegramPlayer()), 0);
@@ -168,6 +174,34 @@ export function GameRoot() {
     );
   }
 
+  if (profileStatus === "loading") {
+    return (
+      <>
+        <ProfileLoadingScreen />
+        <TelegramLandscapeOverlay active={telegramLandscapePromptActive} />
+      </>
+    );
+  }
+
+  if (showStarterOnboarding && playerIdentity && playerProfile) {
+    return (
+      <>
+        <StarterBoosterOnboarding
+          identity={playerIdentity}
+          profile={playerProfile}
+          profileStatus={profileStatus}
+          profileIdentityMode={playerIdentity.mode}
+          deckSource={deckSource}
+          onProfileChange={(nextProfile) => {
+            deckTouchedRef.current = false;
+            setPlayerProfile(nextProfile);
+          }}
+        />
+        <TelegramLandscapeOverlay active={telegramLandscapePromptActive} />
+      </>
+    );
+  }
+
   return (
     <>
       <CollectionDeckScreen
@@ -188,6 +222,26 @@ export function GameRoot() {
       />
       <TelegramLandscapeOverlay active={telegramLandscapePromptActive} />
     </>
+  );
+}
+
+function ProfileLoadingScreen() {
+  return (
+    <main
+      className="grid min-h-screen place-items-center bg-[#080907] px-4 text-[#f7efd7]"
+      data-testid="player-profile-shell"
+      data-profile-status="loading"
+      data-profile-identity-mode="unknown"
+      data-profile-owned-card-count="0"
+      data-profile-deck-count="0"
+      data-deck-source="starter-fallback"
+      data-starter-free-boosters-remaining="0"
+    >
+      <section className="grid w-full max-w-[420px] gap-3 rounded-md border border-[#d4aa4d]/45 bg-[linear-gradient(180deg,rgba(28,27,19,0.94),rgba(9,11,11,0.97))] p-4 text-center shadow-[0_18px_42px_rgba(0,0,0,0.42)]">
+        <b className="text-[11px] font-black uppercase tracking-[0.16em] text-[#d6b66d]">Нексус</b>
+        <span className="text-lg font-black uppercase text-[#fff0ad]">Завантаження профілю</span>
+      </section>
+    </main>
   );
 }
 

--- a/src/features/game/ui/collection/CollectionDeckScreen.tsx
+++ b/src/features/game/ui/collection/CollectionDeckScreen.tsx
@@ -12,7 +12,7 @@ import { PLAYER_DECK_SIZE } from "../../model/randomDeck";
 type Props = {
   collectionIds: string[];
   deckIds: string[];
-  profileStatus: "loading" | "ready" | "fallback";
+  profileStatus: "loading" | "ready" | "unavailable";
   profileIdentityMode?: "telegram" | "guest";
   profileOwnedCardCount: number;
   profileDeckCount: number;

--- a/src/features/game/ui/onboarding/StarterBoosterOnboarding.tsx
+++ b/src/features/game/ui/onboarding/StarterBoosterOnboarding.tsx
@@ -1,0 +1,460 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { getBoosterCatalogForPlayer } from "@/features/boosters/catalog";
+import { openStarterBooster } from "@/features/boosters/client";
+import type { BoosterCatalogItem, BoosterResponse } from "@/features/boosters/types";
+import type { Card, Rarity } from "@/features/battle/model/types";
+import { BattleCard } from "@/features/battle/ui/components/BattleCard";
+import { STARTER_FREE_BOOSTERS, type PlayerIdentity, type PlayerProfile } from "@/features/player/profile/types";
+import { cn } from "@/shared/lib/cn";
+
+type ProfileStatus = "loading" | "ready" | "fallback";
+type Phase = "catalog" | "opening" | "reveal";
+
+type Props = {
+  identity: PlayerIdentity;
+  profile: PlayerProfile;
+  profileStatus: ProfileStatus;
+  profileIdentityMode?: "telegram" | "guest";
+  deckSource: "profile" | "starter-fallback";
+  onProfileChange: (profile: PlayerProfile) => void;
+};
+
+type RevealState = {
+  booster: BoosterResponse;
+  cards: Card[];
+  player: PlayerProfile;
+};
+
+const REVEAL_STEP_MS = 460;
+const boosterAccents = [
+  ["#ffe08a", "#65d7e9"],
+  ["#ef735a", "#a8df5a"],
+  ["#f0b14a", "#d26a8a"],
+  ["#79d3a6", "#efcf6f"],
+  ["#c6b4ff", "#f48c58"],
+  ["#9bd1ff", "#d7e35e"],
+] as const;
+const rarityLabels: Record<Rarity, string> = {
+  Common: "Звичайна",
+  Rare: "Рідкісна",
+  Unique: "Унікальна",
+  Legend: "Легендарна",
+};
+
+export function StarterBoosterOnboarding({
+  identity,
+  profile,
+  profileStatus,
+  profileIdentityMode,
+  deckSource,
+  onProfileChange,
+}: Props) {
+  const [optimisticProfile, setOptimisticProfile] = useState<PlayerProfile | null>(null);
+  const [phase, setPhase] = useState<Phase>("catalog");
+  const [openingBoosterId, setOpeningBoosterId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reveal, setReveal] = useState<RevealState | null>(null);
+  const [revealedCount, setRevealedCount] = useState(0);
+  const visibleProfile = optimisticProfile ?? profile;
+  const boosters = useMemo(() => getBoosterCatalogForPlayer(visibleProfile), [visibleProfile]);
+  const openedCount = visibleProfile.openedBoosterIds.length;
+  const progressCount = Math.max(0, STARTER_FREE_BOOSTERS - visibleProfile.starterFreeBoostersRemaining);
+  const canChoose = phase === "catalog";
+
+  useEffect(() => {
+    if (phase !== "reveal" || !reveal) return;
+
+    const timer = window.setInterval(() => {
+      setRevealedCount((current) => {
+        if (current >= reveal.cards.length) {
+          window.clearInterval(timer);
+          return current;
+        }
+
+        return current + 1;
+      });
+    }, REVEAL_STEP_MS);
+
+    return () => window.clearInterval(timer);
+  }, [phase, reveal]);
+
+  async function handleOpenBooster(booster: BoosterCatalogItem) {
+    if (!canChoose || !booster.starter.canOpen) return;
+
+    setError(null);
+    setOpeningBoosterId(booster.id);
+    setPhase("opening");
+
+    try {
+      const response = await openStarterBooster(identity, booster.id);
+      if (response.cards.length === 0) {
+        throw new Error("Starter booster did not return cards.");
+      }
+
+      setReveal({
+        booster: response.booster,
+        cards: response.cards,
+        player: response.player,
+      });
+      setRevealedCount(1);
+      setPhase("reveal");
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : "Бустер зараз недоступний.");
+      setOpeningBoosterId(null);
+      setPhase("catalog");
+    }
+  }
+
+  function returnToCatalog() {
+    if (reveal) {
+      setOptimisticProfile(reveal.player);
+      onProfileChange(reveal.player);
+    }
+
+    setOpeningBoosterId(null);
+    setReveal(null);
+    setRevealedCount(0);
+    setPhase("catalog");
+  }
+
+  return (
+    <main
+      className="min-h-screen bg-[#080907] text-[#f7efd7]"
+      data-testid="player-profile-shell"
+      data-profile-status={profileStatus}
+      data-profile-identity-mode={profileIdentityMode ?? "unknown"}
+      data-profile-owned-card-count={visibleProfile.ownedCardIds.length}
+      data-profile-deck-count={visibleProfile.deckIds.length}
+      data-deck-source={deckSource}
+      data-starter-free-boosters-remaining={visibleProfile.starterFreeBoostersRemaining}
+    >
+      <div className="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,rgba(16,17,12,0.95),rgba(5,8,9,0.98)),url('/nexus-assets/backgrounds/arena-bar-1024x576.png')] bg-cover bg-center px-4 py-4 max-[620px]:px-2">
+        <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,rgba(255,224,138,0.1),transparent_18%,transparent_78%,rgba(101,215,233,0.1))]" />
+
+        <section
+          className="relative z-10 mx-auto grid min-h-[calc(100dvh-32px)] max-w-[1280px] grid-rows-[auto_minmax(0,1fr)] gap-3"
+          data-testid="starter-onboarding-shell"
+          data-phase={phase}
+          data-opened-booster-count={openedCount}
+          data-progress-count={progressCount}
+        >
+          <header className="grid grid-cols-[minmax(220px,0.8fr)_minmax(280px,1.1fr)_auto] items-stretch gap-3 rounded-md border border-[#d4aa4d]/45 bg-[linear-gradient(180deg,rgba(28,27,19,0.94),rgba(9,11,11,0.97))] p-3 shadow-[0_18px_42px_rgba(0,0,0,0.42),inset_0_1px_0_rgba(255,242,181,0.12)] max-[980px]:grid-cols-1 max-[620px]:p-2">
+            <div className="grid content-center gap-1">
+              <b className="text-[11px] font-black uppercase tracking-[0.16em] text-[#d6b66d]">Стартова роздача</b>
+              <h1 className="text-[clamp(28px,6vw,54px)] font-black uppercase leading-none text-[#fff0ad] [text-shadow:0_3px_0_rgba(0,0,0,0.72)]">
+                Нексус
+              </h1>
+            </div>
+
+            <StarterProgress profile={visibleProfile} />
+
+            <div className="grid min-w-[240px] grid-cols-3 gap-2 max-[980px]:min-w-0">
+              <Metric label="Бустерів" value={`${progressCount}/${STARTER_FREE_BOOSTERS}`} />
+              <Metric label="Карт" value={visibleProfile.ownedCardIds.length} testId="starter-owned-count" />
+              <Metric label="Ще" value={visibleProfile.starterFreeBoostersRemaining} />
+            </div>
+          </header>
+
+          {phase === "reveal" && reveal ? (
+            <StarterReveal reveal={reveal} revealedCount={revealedCount} onDone={returnToCatalog} />
+          ) : (
+            <section className="grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] gap-3">
+              <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-3 max-[760px]:grid-cols-1">
+                <div className="min-w-0">
+                  <strong className="block text-[clamp(24px,4vw,38px)] font-black uppercase leading-none text-[#fff4c4]">
+                    {openedCount === 0 ? "Обери перший бустер" : "Другий бустер чекає"}
+                  </strong>
+                  <p className="mt-2 max-w-[760px] text-sm font-bold leading-snug text-[#cbbd99] max-[520px]:text-xs">
+                    Відкритий бустер записується одразу, а потім п’ять збережених карт виходять у швидкому показі.
+                  </p>
+                </div>
+
+                <div className="grid min-w-[210px] gap-1 rounded-md border border-white/10 bg-black/34 px-3 py-2 text-right max-[760px]:min-w-0 max-[760px]:text-left">
+                  <span className="text-[10px] font-black uppercase tracking-[0.14em] text-[#8ed8e6]">Стан</span>
+                  <b className="text-sm font-black uppercase text-[#fff0ad]" data-testid="starter-state-label">
+                    {openedCount === 0 ? "Перший вибір" : "Другий вибір"}
+                  </b>
+                </div>
+              </div>
+
+              {phase === "opening" ? (
+                <div
+                  className="rounded-md border border-[#65d7e9]/35 bg-[#0d2d32]/70 px-4 py-3 text-sm font-black uppercase tracking-[0.08em] text-[#c7f8ff]"
+                  data-testid="starter-opening-pending"
+                >
+                  Записуємо бустер у профіль...
+                </div>
+              ) : null}
+
+              {error ? (
+                <div
+                  className="rounded-md border border-[#ef735a]/45 bg-[#3a1512]/80 px-4 py-3 text-sm font-bold text-[#ffd5ca]"
+                  data-testid="starter-booster-error"
+                >
+                  {error}
+                </div>
+              ) : null}
+
+              <div
+                className="booster-catalog-grid grid min-h-0 grid-cols-[repeat(auto-fit,minmax(178px,1fr))] gap-2.5 overflow-y-auto pr-1 max-[430px]:grid-cols-2 max-[430px]:gap-2"
+                data-testid="starter-booster-catalog"
+              >
+                {boosters.map((booster, index) => (
+                  <BoosterTile
+                    key={booster.id}
+                    booster={booster}
+                    index={index}
+                    busy={phase === "opening"}
+                    opening={openingBoosterId === booster.id}
+                    onOpen={() => handleOpenBooster(booster)}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function StarterProgress({ profile }: { profile: PlayerProfile }) {
+  const openedCount = profile.openedBoosterIds.length;
+
+  return (
+    <section
+      className="grid content-center gap-2 rounded border border-white/10 bg-black/30 px-3 py-2"
+      data-testid="starter-progress"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-[10px] font-black uppercase tracking-[0.14em] text-[#a99d85]">Прогрес старту</span>
+        <b className="text-sm font-black uppercase text-[#ffe08a]">{profile.starterFreeBoostersRemaining} лишилось</b>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        {Array.from({ length: STARTER_FREE_BOOSTERS }, (_, index) => {
+          const filled = index < openedCount;
+          return (
+            <span
+              key={index}
+              className={cn(
+                "h-3 rounded-sm border transition",
+                filled
+                  ? "border-[#ffe08a]/70 bg-[linear-gradient(90deg,#ffe08a,#65d7e9)]"
+                  : "border-white/12 bg-white/[0.05]",
+              )}
+              data-testid={`starter-progress-slot-${index + 1}`}
+              data-filled={filled}
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function BoosterTile({
+  booster,
+  index,
+  busy,
+  opening,
+  onOpen,
+}: {
+  booster: BoosterCatalogItem;
+  index: number;
+  busy: boolean;
+  opening: boolean;
+  onOpen: () => void;
+}) {
+  const [toneA, toneB] = boosterAccents[index % boosterAccents.length];
+  const opened = booster.starter.opened;
+  const disabled = busy || !booster.starter.canOpen;
+  const style = {
+    "--booster-a": toneA,
+    "--booster-b": toneB,
+  } as CSSProperties;
+
+  return (
+    <article
+      className={cn(
+        "group relative min-h-[178px] overflow-hidden rounded-md border bg-[linear-gradient(145deg,color-mix(in_srgb,var(--booster-a),#111_24%),rgba(8,10,10,0.96)_42%,color-mix(in_srgb,var(--booster-b),#050809_32%))] p-3 shadow-[0_14px_30px_rgba(0,0,0,0.32),inset_0_1px_0_rgba(255,255,255,0.12)] transition max-[430px]:min-h-[166px] max-[430px]:p-2",
+        opened
+          ? "border-[#ffe08a]/65 brightness-75"
+          : booster.starter.canOpen
+            ? "border-white/14 hover:-translate-y-0.5 hover:border-[#fff0ad]/70 hover:brightness-110"
+            : "border-white/10 opacity-70",
+      )}
+      style={style}
+      data-testid={`starter-booster-card-${booster.id}`}
+      data-opened={opened}
+      data-can-open={booster.starter.canOpen}
+    >
+      <div className="pointer-events-none absolute inset-2 rounded border border-white/12" />
+      <div className="pointer-events-none absolute -right-8 -top-12 h-28 w-28 rotate-12 border-[14px] border-[color-mix(in_srgb,var(--booster-a),transparent_38%)]" />
+      <div className="relative z-[1] grid h-full min-h-[152px] grid-rows-[auto_1fr_auto] gap-3 max-[430px]:min-h-[144px]">
+        <div className="flex items-start justify-between gap-2">
+          <span className="rounded-sm border border-black/35 bg-[#fff0ad] px-1.5 py-1 text-[10px] font-black uppercase leading-none text-[#17100a]">
+            {String(index + 1).padStart(2, "0")}
+          </span>
+          <span
+            className={cn(
+              "rounded-sm border px-1.5 py-1 text-[10px] font-black uppercase leading-none",
+              opened
+                ? "border-[#ffe08a]/60 bg-[#ffe08a] text-[#17100a]"
+                : "border-white/15 bg-black/34 text-[#f6ebd1]",
+            )}
+          >
+            {opened ? "Відкрито" : "Новий"}
+          </span>
+        </div>
+
+        <div className="grid content-end gap-2">
+          <strong className="text-[clamp(18px,3vw,25px)] font-black uppercase leading-[0.95] text-[#fff4c4] [text-shadow:0_2px_0_rgba(0,0,0,0.72)]">
+            {booster.name}
+          </strong>
+          <div className="grid gap-1">
+            {booster.clans.map((clan) => (
+              <span
+                key={clan}
+                className="truncate rounded-sm border border-white/12 bg-black/32 px-2 py-1 text-[11px] font-black uppercase tracking-[0.04em] text-[#efe3c5]"
+              >
+                {clan}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <button
+          className={cn(
+            "min-h-[38px] rounded border-2 px-3 text-xs font-black uppercase transition",
+            disabled
+              ? "cursor-not-allowed border-white/10 bg-black/28 text-[#7c735f]"
+              : "border-black/55 bg-[linear-gradient(180deg,#fff26d,#e2b72e_56%,#966414)] text-[#17100a] hover:brightness-110",
+          )}
+          type="button"
+          disabled={disabled}
+          onClick={onOpen}
+          data-testid={`starter-booster-open-${booster.id}`}
+        >
+          {opening ? "Запис..." : opened ? "Недоступно" : "Відкрити"}
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function StarterReveal({
+  reveal,
+  revealedCount,
+  onDone,
+}: {
+  reveal: RevealState;
+  revealedCount: number;
+  onDone: () => void;
+}) {
+  const safeCount = Math.min(Math.max(revealedCount, 1), reveal.cards.length);
+  const activeCard = reveal.cards[safeCount - 1];
+  const visibleCards = reveal.cards.slice(0, revealedCount);
+  const complete = revealedCount >= reveal.cards.length;
+
+  return (
+    <section
+      className="starter-reveal-stage grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] gap-3 rounded-md border border-[#d4aa4d]/42 bg-[linear-gradient(180deg,rgba(24,22,15,0.92),rgba(5,7,8,0.96))] p-4 shadow-[inset_0_0_70px_rgba(0,0,0,0.28)] max-[620px]:p-2"
+      data-testid="starter-reveal-shell"
+      data-revealed-count={revealedCount}
+    >
+      <div className="flex items-end justify-between gap-3 max-[620px]:grid">
+        <div>
+          <b className="text-[11px] font-black uppercase tracking-[0.16em] text-[#65d7e9]">{reveal.booster.name}</b>
+          <h2 className="mt-1 text-[clamp(24px,5vw,42px)] font-black uppercase leading-none text-[#fff0ad]">
+            Карта {safeCount} з {reveal.cards.length}
+          </h2>
+        </div>
+        <span className="rounded border border-white/10 bg-black/34 px-3 py-2 text-xs font-black uppercase tracking-[0.08em] text-[#cbbd99]">
+          Збережено в профіль
+        </span>
+      </div>
+
+      <div className="grid min-h-0 grid-cols-[minmax(230px,330px)_minmax(0,1fr)] items-center gap-4 max-[760px]:grid-cols-1 max-[760px]:items-start">
+        <div
+          className="starter-reveal-card justify-self-center"
+          data-testid="starter-reveal-active-card"
+          data-card-id={activeCard.id}
+        >
+          <BattleCard card={activeCard} className="w-[min(260px,66vw)] !min-h-[352px] max-[430px]:w-[min(218px,70vw)] max-[430px]:!min-h-[302px]" />
+        </div>
+
+        <aside className="grid min-w-0 gap-3">
+          <div className="min-w-0">
+            <strong className="block truncate text-[clamp(26px,5vw,46px)] font-black uppercase leading-none text-[#fff6d0]">
+              {activeCard.name}
+            </strong>
+            <span className="mt-1 block text-xs font-black uppercase tracking-[0.12em] text-[#9ed6e4]">
+              {activeCard.clan} · {rarityLabels[activeCard.rarity]}
+            </span>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <Metric label="Сила" value={activeCard.power} />
+            <Metric label="Урон" value={activeCard.damage} />
+          </div>
+
+          <dl className="grid gap-2">
+            <RevealDetail label="Уміння" title={activeCard.ability.name} description={activeCard.ability.description} />
+            <RevealDetail label="Бонус" title={activeCard.bonus.name} description={activeCard.bonus.description} />
+          </dl>
+        </aside>
+      </div>
+
+      <div className="grid gap-3">
+        <div className="grid grid-cols-5 gap-2 max-[620px]:gap-1.5" data-testid="starter-reveal-list">
+          {visibleCards.map((card, index) => (
+            <article
+              key={card.id}
+              className="starter-reveal-chip min-w-0 rounded border border-white/10 bg-black/34 px-2 py-2"
+              data-testid={`starter-reveal-card-${index + 1}`}
+              data-card-id={card.id}
+            >
+              <b className="block truncate text-xs font-black uppercase text-[#fff0ad] max-[430px]:text-[10px]">{card.name}</b>
+              <span className="mt-1 block truncate text-[10px] font-black uppercase text-[#9ed6e4] max-[430px]:text-[9px]">
+                {rarityLabels[card.rarity]}
+              </span>
+            </article>
+          ))}
+        </div>
+
+        {complete ? (
+          <button
+            className="justify-self-end rounded-md border-2 border-black/55 bg-[linear-gradient(180deg,#fff26d,#e2b72e_56%,#966414)] px-5 py-3 text-sm font-black uppercase text-[#17100a] transition hover:brightness-110 max-[620px]:w-full"
+            type="button"
+            onClick={onDone}
+            data-testid="starter-reveal-continue"
+          >
+            До каталогу
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function RevealDetail({ label, title, description }: { label: string; title: string; description: string }) {
+  return (
+    <div className="rounded border border-white/10 bg-white/[0.04] p-2">
+      <dt className="text-[10px] font-black uppercase tracking-[0.12em] text-[#d4b06a]">{label}</dt>
+      <dd className="mt-1 text-sm font-black text-[#fff7df]">{title}</dd>
+      <dd className="mt-1 line-clamp-3 text-xs font-bold leading-snug text-[#bdb197]">{description}</dd>
+    </div>
+  );
+}
+
+function Metric({ label, value, testId }: { label: string; value: number | string; testId?: string }) {
+  return (
+    <div className="rounded border border-white/10 bg-black/36 px-2 py-2" data-testid={testId}>
+      <b className="block text-xl font-black leading-none text-[#ffe08a]">{value}</b>
+      <span className="mt-1 block text-[10px] font-black uppercase tracking-[0.1em] text-[#a99d85]">{label}</span>
+    </div>
+  );
+}

--- a/src/features/game/ui/onboarding/StarterBoosterOnboarding.tsx
+++ b/src/features/game/ui/onboarding/StarterBoosterOnboarding.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import type { CSSProperties } from "react";
-import { useEffect, useMemo, useState } from "react";
-import { getBoosterCatalogForPlayer } from "@/features/boosters/catalog";
-import { openStarterBooster } from "@/features/boosters/client";
+import { useEffect, useState } from "react";
+import { fetchStarterBoosterCatalog, openStarterBooster } from "@/features/boosters/client";
 import type { BoosterCatalogItem, BoosterResponse } from "@/features/boosters/types";
 import type { Card, Rarity } from "@/features/battle/model/types";
 import { BattleCard } from "@/features/battle/ui/components/BattleCard";
@@ -12,6 +11,7 @@ import { cn } from "@/shared/lib/cn";
 
 type ProfileStatus = "loading" | "ready" | "fallback";
 type Phase = "catalog" | "opening" | "reveal";
+type CatalogStatus = "loading" | "ready" | "error";
 
 type Props = {
   identity: PlayerIdentity;
@@ -58,11 +58,39 @@ export function StarterBoosterOnboarding({
   const [error, setError] = useState<string | null>(null);
   const [reveal, setReveal] = useState<RevealState | null>(null);
   const [revealedCount, setRevealedCount] = useState(0);
-  const visibleProfile = optimisticProfile ?? profile;
-  const boosters = useMemo(() => getBoosterCatalogForPlayer(visibleProfile), [visibleProfile]);
-  const openedCount = visibleProfile.openedBoosterIds.length;
-  const progressCount = Math.max(0, STARTER_FREE_BOOSTERS - visibleProfile.starterFreeBoostersRemaining);
-  const canChoose = phase === "catalog";
+  const [catalogStatus, setCatalogStatus] = useState<CatalogStatus>("loading");
+  const [catalogError, setCatalogError] = useState<string | null>(null);
+  const [catalogProfile, setCatalogProfile] = useState<PlayerProfile | null>(null);
+  const [boosters, setBoosters] = useState<BoosterCatalogItem[]>([]);
+  const [catalogRefreshKey, setCatalogRefreshKey] = useState(0);
+  const profileForDisplay = optimisticProfile ?? catalogProfile ?? profile;
+  const openedCount = profileForDisplay.openedBoosterIds.length;
+  const progressCount = Math.max(0, STARTER_FREE_BOOSTERS - profileForDisplay.starterFreeBoostersRemaining);
+  const canChoose = phase === "catalog" && catalogStatus === "ready";
+
+  useEffect(() => {
+    let disposed = false;
+
+    void fetchStarterBoosterCatalog(identity)
+      .then((response) => {
+        if (disposed) return;
+        setBoosters(response.boosters);
+        setCatalogProfile(response.player);
+        setOptimisticProfile(response.player);
+        setCatalogError(null);
+        setCatalogStatus("ready");
+        onProfileChange(response.player);
+      })
+      .catch((caughtError) => {
+        if (disposed) return;
+        setCatalogError(caughtError instanceof Error ? caughtError.message : "Каталог бустерів зараз недоступний.");
+        setCatalogStatus("error");
+      });
+
+    return () => {
+      disposed = true;
+    };
+  }, [catalogRefreshKey, identity, onProfileChange]);
 
   useEffect(() => {
     if (phase !== "reveal" || !reveal) return;
@@ -117,7 +145,11 @@ export function StarterBoosterOnboarding({
     setOpeningBoosterId(null);
     setReveal(null);
     setRevealedCount(0);
+    setCatalogStatus("loading");
+    setCatalogError(null);
+    setBoosters([]);
     setPhase("catalog");
+    setCatalogRefreshKey((current) => current + 1);
   }
 
   return (
@@ -126,10 +158,10 @@ export function StarterBoosterOnboarding({
       data-testid="player-profile-shell"
       data-profile-status={profileStatus}
       data-profile-identity-mode={profileIdentityMode ?? "unknown"}
-      data-profile-owned-card-count={visibleProfile.ownedCardIds.length}
-      data-profile-deck-count={visibleProfile.deckIds.length}
+      data-profile-owned-card-count={profileForDisplay.ownedCardIds.length}
+      data-profile-deck-count={profileForDisplay.deckIds.length}
       data-deck-source={deckSource}
-      data-starter-free-boosters-remaining={visibleProfile.starterFreeBoostersRemaining}
+      data-starter-free-boosters-remaining={profileForDisplay.starterFreeBoostersRemaining}
     >
       <div className="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,rgba(16,17,12,0.95),rgba(5,8,9,0.98)),url('/nexus-assets/backgrounds/arena-bar-1024x576.png')] bg-cover bg-center px-4 py-4 max-[620px]:px-2">
         <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(90deg,rgba(255,224,138,0.1),transparent_18%,transparent_78%,rgba(101,215,233,0.1))]" />
@@ -138,6 +170,7 @@ export function StarterBoosterOnboarding({
           className="relative z-10 mx-auto grid min-h-[calc(100dvh-32px)] max-w-[1280px] grid-rows-[auto_minmax(0,1fr)] gap-3"
           data-testid="starter-onboarding-shell"
           data-phase={phase}
+          data-catalog-status={catalogStatus}
           data-opened-booster-count={openedCount}
           data-progress-count={progressCount}
         >
@@ -149,12 +182,12 @@ export function StarterBoosterOnboarding({
               </h1>
             </div>
 
-            <StarterProgress profile={visibleProfile} />
+            <StarterProgress profile={profileForDisplay} />
 
             <div className="grid min-w-[240px] grid-cols-3 gap-2 max-[980px]:min-w-0">
               <Metric label="Бустерів" value={`${progressCount}/${STARTER_FREE_BOOSTERS}`} />
-              <Metric label="Карт" value={visibleProfile.ownedCardIds.length} testId="starter-owned-count" />
-              <Metric label="Ще" value={visibleProfile.starterFreeBoostersRemaining} />
+              <Metric label="Карт" value={profileForDisplay.ownedCardIds.length} testId="starter-owned-count" />
+              <Metric label="Ще" value={profileForDisplay.starterFreeBoostersRemaining} />
             </div>
           </header>
 
@@ -189,6 +222,24 @@ export function StarterBoosterOnboarding({
                 </div>
               ) : null}
 
+              {catalogStatus === "loading" ? (
+                <div
+                  className="rounded-md border border-[#d4aa4d]/35 bg-black/34 px-4 py-3 text-sm font-black uppercase tracking-[0.08em] text-[#ffe08a]"
+                  data-testid="starter-catalog-loading"
+                >
+                  Завантажуємо каталог бустерів...
+                </div>
+              ) : null}
+
+              {catalogStatus === "error" ? (
+                <div
+                  className="rounded-md border border-[#ef735a]/45 bg-[#3a1512]/80 px-4 py-3 text-sm font-bold text-[#ffd5ca]"
+                  data-testid="starter-catalog-error"
+                >
+                  {catalogError}
+                </div>
+              ) : null}
+
               {error ? (
                 <div
                   className="rounded-md border border-[#ef735a]/45 bg-[#3a1512]/80 px-4 py-3 text-sm font-bold text-[#ffd5ca]"
@@ -198,21 +249,23 @@ export function StarterBoosterOnboarding({
                 </div>
               ) : null}
 
-              <div
-                className="booster-catalog-grid grid min-h-0 grid-cols-[repeat(auto-fit,minmax(178px,1fr))] gap-2.5 overflow-y-auto pr-1 max-[430px]:grid-cols-2 max-[430px]:gap-2"
-                data-testid="starter-booster-catalog"
-              >
-                {boosters.map((booster, index) => (
-                  <BoosterTile
-                    key={booster.id}
-                    booster={booster}
-                    index={index}
-                    busy={phase === "opening"}
-                    opening={openingBoosterId === booster.id}
-                    onOpen={() => handleOpenBooster(booster)}
-                  />
-                ))}
-              </div>
+              {catalogStatus === "ready" ? (
+                <div
+                  className="booster-catalog-grid grid min-h-0 grid-cols-[repeat(auto-fit,minmax(178px,1fr))] gap-2.5 overflow-y-auto pr-1 max-[430px]:grid-cols-2 max-[430px]:gap-2"
+                  data-testid="starter-booster-catalog"
+                >
+                  {boosters.map((booster, index) => (
+                    <BoosterTile
+                      key={booster.id}
+                      booster={booster}
+                      index={index}
+                      busy={phase === "opening"}
+                      opening={openingBoosterId === booster.id}
+                      onOpen={() => handleOpenBooster(booster)}
+                    />
+                  ))}
+                </div>
+              ) : null}
             </section>
           )}
         </section>

--- a/src/features/game/ui/onboarding/StarterBoosterOnboarding.tsx
+++ b/src/features/game/ui/onboarding/StarterBoosterOnboarding.tsx
@@ -9,7 +9,7 @@ import { BattleCard } from "@/features/battle/ui/components/BattleCard";
 import { STARTER_FREE_BOOSTERS, type PlayerIdentity, type PlayerProfile } from "@/features/player/profile/types";
 import { cn } from "@/shared/lib/cn";
 
-type ProfileStatus = "loading" | "ready" | "fallback";
+type ProfileStatus = "loading" | "ready" | "unavailable";
 type Phase = "catalog" | "opening" | "reveal";
 type CatalogStatus = "loading" | "ready" | "error";
 

--- a/tests/battle.spec.ts
+++ b/tests/battle.spec.ts
@@ -1,8 +1,10 @@
 import { expect, test, type Page } from "@playwright/test";
+import { mockDeckReadyProfile } from "./fixtures/playerProfile";
 
 const DECK_SESSION_STORAGE_KEY = "nexus:deck-session:v1";
 
 test("keeps the minimum deck locked", async ({ page }) => {
+  await mockDeckReadyProfile(page);
   await page.goto("/");
 
   const deckCards = page.locator('[data-testid^="deck-card-"]');
@@ -16,6 +18,7 @@ test("keeps the minimum deck locked", async ({ page }) => {
 });
 
 test("ignores legacy deck session storage without deleting it", async ({ page }) => {
+  await mockDeckReadyProfile(page);
   const legacyDeckIds = [
     "dahack-1645",
     "dahack-110",
@@ -43,6 +46,7 @@ test("ignores legacy deck session storage without deleting it", async ({ page })
 });
 
 test("plays a complete state-machine battle", async ({ page }) => {
+  await mockDeckReadyProfile(page);
   await page.goto("/");
 
   await expect(page.getByTestId("collection-search")).toBeVisible();

--- a/tests/fixtures/playerProfile.ts
+++ b/tests/fixtures/playerProfile.ts
@@ -1,0 +1,62 @@
+import type { Page, Route } from "@playwright/test";
+import type { PlayerIdentity } from "../../src/features/player/profile/types";
+
+export const PROFILE_DECK_IDS = [
+  "dahack-1645",
+  "dahack-110",
+  "dahack-820",
+  "dahack-167",
+  "dahack-1727",
+  "dahack-795",
+  "dahack-1383",
+  "dahack-658",
+  "dahack-108",
+];
+export const PROFILE_OWNED_CARD_IDS = [...PROFILE_DECK_IDS, "dahack-363"];
+
+export type TestPlayerProfileInput = {
+  id: string;
+  identity: PlayerIdentity;
+  ownedCardIds: string[];
+  deckIds: string[];
+  starterFreeBoostersRemaining: number;
+  openedBoosterIds?: string[];
+};
+
+export async function mockDeckReadyProfile(page: Page, options: Partial<TestPlayerProfileInput> = {}) {
+  await page.route("**/api/player", async (route) => {
+    const requestBody = route.request().postDataJSON() as { identity?: PlayerIdentity };
+    const identity = options.identity ?? requestBody.identity ?? { mode: "guest", guestId: "guest-deck-ready-e2e" };
+
+    await fulfillPlayerProfile(route, {
+      id: options.id ?? "player-deck-ready-e2e",
+      identity,
+      ownedCardIds: options.ownedCardIds ?? PROFILE_OWNED_CARD_IDS,
+      deckIds: options.deckIds ?? PROFILE_DECK_IDS,
+      starterFreeBoostersRemaining: options.starterFreeBoostersRemaining ?? 0,
+      openedBoosterIds: options.openedBoosterIds ?? ["neon-breach", "factory-shift"],
+    });
+  });
+}
+
+export async function fulfillPlayerProfile(route: Route, profile: TestPlayerProfileInput) {
+  const collectionReady = profile.ownedCardIds.length > 0;
+  const deckReady = profile.deckIds.length > 0;
+
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      player: {
+        ...profile,
+        openedBoosterIds: profile.openedBoosterIds ?? [],
+        onboarding: {
+          starterBoostersAvailable: profile.starterFreeBoostersRemaining > 0,
+          collectionReady,
+          deckReady,
+          completed: collectionReady && deckReady && profile.starterFreeBoostersRemaining === 0,
+        },
+      },
+    }),
+  });
+}

--- a/tests/fixtures/playerProfile.ts
+++ b/tests/fixtures/playerProfile.ts
@@ -1,4 +1,5 @@
 import type { Page, Route } from "@playwright/test";
+import { getBoosterCatalogForPlayer } from "../../src/features/boosters/catalog";
 import type { PlayerIdentity } from "../../src/features/player/profile/types";
 
 export const PROFILE_DECK_IDS = [
@@ -40,23 +41,41 @@ export async function mockDeckReadyProfile(page: Page, options: Partial<TestPlay
 }
 
 export async function fulfillPlayerProfile(route: Route, profile: TestPlayerProfileInput) {
-  const collectionReady = profile.ownedCardIds.length > 0;
-  const deckReady = profile.deckIds.length > 0;
-
   await route.fulfill({
     status: 200,
     contentType: "application/json",
     body: JSON.stringify({
-      player: {
-        ...profile,
-        openedBoosterIds: profile.openedBoosterIds ?? [],
-        onboarding: {
-          starterBoostersAvailable: profile.starterFreeBoostersRemaining > 0,
-          collectionReady,
-          deckReady,
-          completed: collectionReady && deckReady && profile.starterFreeBoostersRemaining === 0,
-        },
-      },
+      player: createPlayerProfileBody(profile),
     }),
   });
+}
+
+export async function fulfillBoosterCatalog(route: Route, profile: TestPlayerProfileInput) {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      boosters: getBoosterCatalogForPlayer({
+        openedBoosterIds: profile.openedBoosterIds ?? [],
+        starterFreeBoostersRemaining: profile.starterFreeBoostersRemaining,
+      }),
+      player: createPlayerProfileBody(profile),
+    }),
+  });
+}
+
+function createPlayerProfileBody(profile: TestPlayerProfileInput) {
+  const collectionReady = profile.ownedCardIds.length > 0;
+  const deckReady = profile.deckIds.length > 0;
+
+  return {
+    ...profile,
+    openedBoosterIds: profile.openedBoosterIds ?? [],
+    onboarding: {
+      starterBoostersAvailable: profile.starterFreeBoostersRemaining > 0,
+      collectionReady,
+      deckReady,
+      completed: collectionReady && deckReady && profile.starterFreeBoostersRemaining === 0,
+    },
+  };
 }

--- a/tests/mobile-layout.spec.ts
+++ b/tests/mobile-layout.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
+import { mockDeckReadyProfile } from "./fixtures/playerProfile";
 
 const VIEWPORTS = [
   { name: "phone portrait", width: 350, height: 760 },
@@ -178,6 +179,7 @@ test("keeps the desktop board compact on tall screens", async ({ page }) => {
 for (const viewport of COLLECTION_VIEWPORTS) {
   test(`keeps the collection deck builder aligned on ${viewport.name}`, async ({ page }) => {
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await mockDeckReadyProfile(page);
     await page.goto("/");
 
     await expect(page.getByTestId("collection-search")).toBeVisible();
@@ -303,6 +305,7 @@ for (const viewport of SELECTION_VIEWPORTS) {
 }
 
 async function openBattle(page: Page) {
+  await mockDeckReadyProfile(page);
   await page.goto("/");
   await page.getByTestId("play-selected-deck").click();
   await expect(page.getByTestId("phase-overlay")).toBeHidden({ timeout: 15_000 });

--- a/tests/onboarding-reveal.spec.ts
+++ b/tests/onboarding-reveal.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test, type Route } from "@playwright/test";
+import { cards } from "../src/features/battle/model/cards";
+import type { Card } from "../src/features/battle/model/types";
+import type { PlayerIdentity } from "../src/features/player/profile/types";
+import { fulfillPlayerProfile, type TestPlayerProfileInput } from "./fixtures/playerProfile";
+
+const GUEST_ID_STORAGE_KEY = "nexus:player-guest-id:v1";
+const identity: PlayerIdentity = {
+  mode: "guest",
+  guestId: "starter-reveal-e2e",
+};
+const neonClans = new Set(["[Da:Hack]", "Aliens"]);
+const openedCards = cards.filter((card) => neonClans.has(card.clan)).slice(0, 5);
+
+test("opens the first starter booster, reveals saved cards, and reloads into the second-booster state", async ({ page }) => {
+  expect(openedCards).toHaveLength(5);
+
+  let profile = createProfile();
+  let openRequestCount = 0;
+  let resolveOpenRoute: (route: Route) => void = () => undefined;
+  const openRoutePromise = new Promise<Route>((resolve) => {
+    resolveOpenRoute = resolve;
+  });
+
+  await page.addInitScript(
+    ({ key, guestId }) => {
+      window.localStorage.setItem(key, guestId);
+    },
+    { key: GUEST_ID_STORAGE_KEY, guestId: identity.guestId },
+  );
+  await page.route("**/api/player", async (route) => {
+    await fulfillPlayerProfile(route, profile);
+  });
+  await page.route("**/api/player/open-booster", async (route) => {
+    openRequestCount += 1;
+    resolveOpenRoute(route);
+  });
+
+  await page.goto("/");
+
+  const shell = page.getByTestId("starter-onboarding-shell");
+  await expect(shell).toBeVisible();
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-owned-card-count", "0");
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-starter-free-boosters-remaining", "2");
+  await expect(shell).toHaveAttribute("data-opened-booster-count", "0");
+  await expect(page.locator('[data-testid^="starter-booster-card-"]')).toHaveCount(12);
+  await expect(page.getByTestId("collection-search")).toHaveCount(0);
+
+  await page.getByTestId("starter-booster-open-neon-breach").click();
+  const openRoute = await openRoutePromise;
+  const openBody = openRoute.request().postDataJSON() as { identity: PlayerIdentity; boosterId: string };
+
+  expect(openRequestCount).toBe(1);
+  expect(openBody).toEqual({ identity, boosterId: "neon-breach" });
+  await expect(shell).toHaveAttribute("data-phase", "opening");
+  await expect(page.getByTestId("starter-opening-pending")).toBeVisible();
+  await expect(page.getByTestId("starter-reveal-shell")).toHaveCount(0);
+
+  profile = createProfile({
+    ownedCardIds: openedCards.map((card) => card.id),
+    deckIds: openedCards.map((card) => card.id),
+    starterFreeBoostersRemaining: 1,
+    openedBoosterIds: ["neon-breach"],
+  });
+  await fulfillOpenBooster(openRoute, openedCards, profile);
+
+  await expect(page.getByTestId("starter-reveal-shell")).toBeVisible();
+  await expect(page.locator('[data-testid^="starter-reveal-card-"]')).toHaveCount(5, { timeout: 6_000 });
+  await expect(page.getByTestId("starter-reveal-active-card")).toHaveAttribute("data-card-id", openedCards[4].id);
+  await expect(page.getByTestId("starter-reveal-continue")).toBeVisible();
+
+  await page.getByTestId("starter-reveal-continue").click();
+
+  await expect(shell).toHaveAttribute("data-phase", "catalog");
+  await expect(shell).toHaveAttribute("data-opened-booster-count", "1");
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-owned-card-count", "5");
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-deck-count", "5");
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-starter-free-boosters-remaining", "1");
+  await expect(page.getByTestId("starter-state-label")).toHaveText("Другий вибір");
+  await expect(page.getByTestId("starter-booster-card-neon-breach")).toHaveAttribute("data-opened", "true");
+  await expect(page.getByTestId("starter-booster-open-neon-breach")).toBeDisabled();
+  await expect(page.getByTestId("starter-booster-open-factory-shift")).toBeEnabled();
+
+  await page.reload();
+
+  await expect(page.getByTestId("starter-onboarding-shell")).toBeVisible();
+  await expect(page.getByTestId("starter-onboarding-shell")).toHaveAttribute("data-opened-booster-count", "1");
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-owned-card-count", "5");
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-deck-count", "5");
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-starter-free-boosters-remaining", "1");
+  await expect(page.getByTestId("starter-booster-open-neon-breach")).toBeDisabled();
+  await expect(page.getByTestId("starter-booster-open-factory-shift")).toBeEnabled();
+});
+
+function createProfile(overrides: Partial<TestPlayerProfileInput> = {}): TestPlayerProfileInput {
+  return {
+    id: "player-starter-reveal-e2e",
+    identity,
+    ownedCardIds: [],
+    deckIds: [],
+    starterFreeBoostersRemaining: 2,
+    openedBoosterIds: [],
+    ...overrides,
+  };
+}
+
+async function fulfillOpenBooster(route: Route, openingCards: Card[], player: TestPlayerProfileInput) {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      booster: {
+        id: "neon-breach",
+        name: "Neon Breach",
+        clans: ["[Da:Hack]", "Aliens"],
+      },
+      cards: openingCards,
+      opening: {
+        id: "opening-starter-reveal-e2e",
+        playerId: player.id,
+        boosterId: "neon-breach",
+        source: "starter_free",
+        cardIds: openingCards.map((card) => card.id),
+        openedAt: "2026-05-02T12:00:00.000Z",
+      },
+      player: {
+        ...player,
+        onboarding: {
+          starterBoostersAvailable: player.starterFreeBoostersRemaining > 0,
+          collectionReady: player.ownedCardIds.length > 0,
+          deckReady: player.deckIds.length > 0,
+          completed: player.ownedCardIds.length > 0 && player.deckIds.length > 0 && player.starterFreeBoostersRemaining === 0,
+        },
+      },
+    }),
+  });
+}

--- a/tests/onboarding-reveal.spec.ts
+++ b/tests/onboarding-reveal.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, type Route } from "@playwright/test";
 import { cards } from "../src/features/battle/model/cards";
 import type { Card } from "../src/features/battle/model/types";
 import type { PlayerIdentity } from "../src/features/player/profile/types";
-import { fulfillPlayerProfile, type TestPlayerProfileInput } from "./fixtures/playerProfile";
+import { fulfillBoosterCatalog, fulfillPlayerProfile, type TestPlayerProfileInput } from "./fixtures/playerProfile";
 
 const GUEST_ID_STORAGE_KEY = "nexus:player-guest-id:v1";
 const identity: PlayerIdentity = {
@@ -16,6 +16,7 @@ test("opens the first starter booster, reveals saved cards, and reloads into the
   expect(openedCards).toHaveLength(5);
 
   let profile = createProfile();
+  let catalogRequestCount = 0;
   let openRequestCount = 0;
   let resolveOpenRoute: (route: Route) => void = () => undefined;
   const openRoutePromise = new Promise<Route>((resolve) => {
@@ -31,6 +32,12 @@ test("opens the first starter booster, reveals saved cards, and reloads into the
   await page.route("**/api/player", async (route) => {
     await fulfillPlayerProfile(route, profile);
   });
+  await page.route("**/api/boosters", async (route) => {
+    const catalogBody = route.request().postDataJSON() as { identity: PlayerIdentity };
+    catalogRequestCount += 1;
+    expect(catalogBody.identity).toEqual(identity);
+    await fulfillBoosterCatalog(route, profile);
+  });
   await page.route("**/api/player/open-booster", async (route) => {
     openRequestCount += 1;
     resolveOpenRoute(route);
@@ -43,6 +50,7 @@ test("opens the first starter booster, reveals saved cards, and reloads into the
   await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-owned-card-count", "0");
   await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-starter-free-boosters-remaining", "2");
   await expect(shell).toHaveAttribute("data-opened-booster-count", "0");
+  await expect(shell).toHaveAttribute("data-catalog-status", "ready");
   await expect(page.locator('[data-testid^="starter-booster-card-"]')).toHaveCount(12);
   await expect(page.getByTestId("collection-search")).toHaveCount(0);
 
@@ -80,6 +88,7 @@ test("opens the first starter booster, reveals saved cards, and reloads into the
   await expect(page.getByTestId("starter-booster-card-neon-breach")).toHaveAttribute("data-opened", "true");
   await expect(page.getByTestId("starter-booster-open-neon-breach")).toBeDisabled();
   await expect(page.getByTestId("starter-booster-open-factory-shift")).toBeEnabled();
+  expect(catalogRequestCount).toBeGreaterThanOrEqual(2);
 
   await page.reload();
 

--- a/tests/profile-bootstrap.spec.ts
+++ b/tests/profile-bootstrap.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test, type Page, type Route } from "@playwright/test";
-import { fulfillPlayerProfile, PROFILE_DECK_IDS, PROFILE_OWNED_CARD_IDS } from "./fixtures/playerProfile";
+import { fulfillBoosterCatalog, fulfillPlayerProfile, PROFILE_DECK_IDS, PROFILE_OWNED_CARD_IDS, type TestPlayerProfileInput } from "./fixtures/playerProfile";
 
 const GUEST_ID_STORAGE_KEY = "nexus:player-guest-id:v1";
 
 test("bootstraps a browser guest profile on first load", async ({ page }) => {
   const requests: unknown[] = [];
+  let profile: TestPlayerProfileInput | undefined;
   await mockPlayerProfile(page, async (route) => {
     const requestBody = route.request().postDataJSON() as { identity: { mode: "guest"; guestId: string } };
     requests.push(requestBody);
@@ -12,14 +13,19 @@ test("bootstraps a browser guest profile on first load", async ({ page }) => {
     expect(requestBody.identity.mode).toBe("guest");
     expect(requestBody.identity.guestId).toMatch(/^guest_/);
 
-    await fulfillPlayerProfile(route, {
+    profile = {
       id: "player-guest-e2e",
       identity: requestBody.identity,
       ownedCardIds: [],
       deckIds: [],
       starterFreeBoostersRemaining: 2,
       openedBoosterIds: [],
-    });
+    };
+    await fulfillPlayerProfile(route, profile);
+  });
+  await page.route("**/api/boosters", async (route) => {
+    if (!profile) throw new Error("Profile must load before booster catalog.");
+    await fulfillBoosterCatalog(route, profile);
   });
 
   await page.goto("/");

--- a/tests/profile-bootstrap.spec.ts
+++ b/tests/profile-bootstrap.spec.ts
@@ -1,18 +1,7 @@
 import { expect, test, type Page, type Route } from "@playwright/test";
+import { fulfillPlayerProfile, PROFILE_DECK_IDS, PROFILE_OWNED_CARD_IDS } from "./fixtures/playerProfile";
 
 const GUEST_ID_STORAGE_KEY = "nexus:player-guest-id:v1";
-const PROFILE_DECK_IDS = [
-  "dahack-1645",
-  "dahack-110",
-  "dahack-820",
-  "dahack-167",
-  "dahack-1727",
-  "dahack-795",
-  "dahack-1383",
-  "dahack-658",
-  "dahack-108",
-];
-const PROFILE_OWNED_CARD_IDS = [...PROFILE_DECK_IDS, "dahack-363"];
 
 test("bootstraps a browser guest profile on first load", async ({ page }) => {
   const requests: unknown[] = [];
@@ -29,6 +18,7 @@ test("bootstraps a browser guest profile on first load", async ({ page }) => {
       ownedCardIds: [],
       deckIds: [],
       starterFreeBoostersRemaining: 2,
+      openedBoosterIds: [],
     });
   });
 
@@ -41,7 +31,11 @@ test("bootstraps a browser guest profile on first load", async ({ page }) => {
   await expect(profileShell).toHaveAttribute("data-profile-deck-count", "0");
   await expect(profileShell).toHaveAttribute("data-starter-free-boosters-remaining", "2");
   await expect(profileShell).toHaveAttribute("data-deck-source", "starter-fallback");
-  await expect(page.locator('[data-testid^="deck-card-"]')).toHaveCount(9);
+  await expect(page.getByTestId("starter-onboarding-shell")).toBeVisible();
+  await expect(page.getByTestId("starter-onboarding-shell")).toHaveAttribute("data-opened-booster-count", "0");
+  await expect(page.locator('[data-testid^="starter-booster-card-"]')).toHaveCount(12);
+  await expect(page.getByTestId("collection-search")).toHaveCount(0);
+  await expect(page.locator('[data-testid^="deck-card-"]')).toHaveCount(0);
 
   expect(requests).toHaveLength(1);
   const storedGuestId = await page.evaluate((key) => window.localStorage.getItem(key), GUEST_ID_STORAGE_KEY);
@@ -87,7 +81,8 @@ test("bootstraps the Telegram MVP identity from client-provided telegramId", asy
       identity: requestBody.identity,
       ownedCardIds: PROFILE_OWNED_CARD_IDS,
       deckIds: PROFILE_DECK_IDS,
-      starterFreeBoostersRemaining: 1,
+      starterFreeBoostersRemaining: 0,
+      openedBoosterIds: ["neon-breach", "factory-shift"],
     });
   });
 
@@ -105,7 +100,7 @@ test("bootstraps the Telegram MVP identity from client-provided telegramId", asy
   await expect(profileShell).toHaveAttribute("data-profile-identity-mode", "telegram");
   await expect(profileShell).toHaveAttribute("data-profile-owned-card-count", String(PROFILE_OWNED_CARD_IDS.length));
   await expect(profileShell).toHaveAttribute("data-profile-deck-count", String(PROFILE_DECK_IDS.length));
-  await expect(profileShell).toHaveAttribute("data-starter-free-boosters-remaining", "1");
+  await expect(profileShell).toHaveAttribute("data-starter-free-boosters-remaining", "0");
   await expect(profileShell).toHaveAttribute("data-deck-source", "profile");
   await expect(page.locator('[data-testid^="deck-card-"]')).toHaveCount(PROFILE_DECK_IDS.length);
   await expect(page.locator('[data-testid^="collection-card-"]')).toHaveCount(PROFILE_OWNED_CARD_IDS.length);
@@ -113,32 +108,4 @@ test("bootstraps the Telegram MVP identity from client-provided telegramId", asy
 
 async function mockPlayerProfile(page: Page, handler: (route: Route) => Promise<void>) {
   await page.route("**/api/player", handler);
-}
-
-async function fulfillPlayerProfile(
-  route: Route,
-  profile: {
-    id: string;
-    identity: { mode: "guest"; guestId: string } | { mode: "telegram"; telegramId: string };
-    ownedCardIds: string[];
-    deckIds: string[];
-    starterFreeBoostersRemaining: number;
-  },
-) {
-  await route.fulfill({
-    status: 200,
-    contentType: "application/json",
-    body: JSON.stringify({
-      player: {
-        ...profile,
-        openedBoosterIds: [],
-        onboarding: {
-          starterBoostersAvailable: profile.starterFreeBoostersRemaining > 0,
-          collectionReady: profile.ownedCardIds.length > 0,
-          deckReady: profile.deckIds.length > 0,
-          completed: false,
-        },
-      },
-    }),
-  });
 }

--- a/tests/profile-bootstrap.spec.ts
+++ b/tests/profile-bootstrap.spec.ts
@@ -48,6 +48,58 @@ test("bootstraps a browser guest profile on first load", async ({ page }) => {
   expect(storedGuestId).toBe((requests[0] as { identity: { guestId: string } }).identity.guestId);
 });
 
+test("blocks collection access and retries when profile bootstrap fails", async ({ page }) => {
+  let profileRequests = 0;
+  let catalogRequests = 0;
+  let profile: TestPlayerProfileInput | undefined;
+
+  await mockPlayerProfile(page, async (route) => {
+    profileRequests += 1;
+    const requestBody = route.request().postDataJSON() as { identity: { mode: "guest"; guestId: string } };
+
+    if (profileRequests === 1) {
+      await route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ error: "profile_unavailable" }) });
+      return;
+    }
+
+    profile = {
+      id: "player-retry-e2e",
+      identity: requestBody.identity,
+      ownedCardIds: [],
+      deckIds: [],
+      starterFreeBoostersRemaining: 2,
+      openedBoosterIds: [],
+    };
+    await fulfillPlayerProfile(route, profile);
+  });
+  await page.route("**/api/boosters", async (route) => {
+    catalogRequests += 1;
+    if (!profile) throw new Error("Profile must load before booster catalog.");
+    await fulfillBoosterCatalog(route, profile);
+  });
+
+  await page.goto("/");
+
+  const profileShell = page.getByTestId("player-profile-shell");
+  await expect(profileShell).toHaveAttribute("data-profile-status", "unavailable");
+  await expect(page.getByTestId("profile-unavailable")).toBeVisible();
+  await expect(page.getByTestId("profile-retry")).toBeVisible();
+  await expect(page.getByTestId("collection-search")).toHaveCount(0);
+  await expect(page.getByTestId("play-selected-deck")).toHaveCount(0);
+  await expect(page.locator('[data-testid^="deck-card-"]')).toHaveCount(0);
+  await expect(page.getByTestId("starter-onboarding-shell")).toHaveCount(0);
+  expect(catalogRequests).toBe(0);
+
+  await page.getByTestId("profile-retry").click();
+
+  await expect(profileShell).toHaveAttribute("data-profile-status", "ready");
+  await expect(page.getByTestId("starter-onboarding-shell")).toBeVisible();
+  await expect(page.locator('[data-testid^="starter-booster-card-"]')).toHaveCount(12);
+  await expect(page.getByTestId("collection-search")).toHaveCount(0);
+  expect(profileRequests).toBe(2);
+  expect(catalogRequests).toBeGreaterThanOrEqual(1);
+});
+
 test("bootstraps the Telegram MVP identity from client-provided telegramId", async ({ page }) => {
   await page.route("https://telegram.org/js/telegram-web-app.js", async (route) => {
     await route.fulfill({ contentType: "application/javascript", body: "" });

--- a/tests/realtime.spec.ts
+++ b/tests/realtime.spec.ts
@@ -1,9 +1,12 @@
 import { expect, test, type Page } from "@playwright/test";
 import { cards } from "../src/features/battle/model/cards";
+import { mockDeckReadyProfile } from "./fixtures/playerProfile";
 
 test("pairs two tabs and resolves the first human round", async ({ context, page }) => {
   const first = page;
   const second = await context.newPage();
+  await mockDeckReadyProfile(first);
+  await mockDeckReadyProfile(second);
 
   await first.goto("/");
   await second.goto("/");


### PR DESCRIPTION
## Summary
- route fresh starter profiles into the booster onboarding catalog instead of the collection deck builder
- add a backend-first starter booster open flow with a five-card reveal slideshow and second-booster catalog state
- update E2E fixtures so existing battle/collection tests use deck-ready profiles, plus add reload persistence coverage for issue #5

## Verification
- bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts
- bun run lint
- bun run build
- bunx playwright test tests/onboarding-reveal.spec.ts tests/profile-bootstrap.spec.ts
- bunx playwright test

Closes #5
Refs #1