### PR TITLE
feat(onboarding): complete deck-ready starter flow

### DIFF
--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -4,8 +4,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cards } from "@/features/battle/model/cards";
 import { BattleGame } from "@/features/battle/ui/BattleGame";
 import { RealtimeBattleGame } from "@/features/battle/ui/RealtimeBattleGame";
+import { STARTER_BOOSTER_CARD_COUNT } from "@/features/boosters/types";
 import { fetchPlayerProfile, resolveClientPlayerIdentity } from "@/features/player/profile/client";
-import type { PlayerIdentity, PlayerProfile } from "@/features/player/profile/types";
+import { STARTER_FREE_BOOSTERS, type PlayerIdentity, type PlayerProfile } from "@/features/player/profile/types";
 import type { TelegramPlayer } from "@/shared/lib/telegram";
 import { PLAYER_DECK_SIZE } from "../model/randomDeck";
 import { CollectionDeckScreen } from "./collection/CollectionDeckScreen";
@@ -14,6 +15,7 @@ import { StarterBoosterOnboarding } from "./onboarding/StarterBoosterOnboarding"
 type BattleMode = "ai" | "human";
 type ProfileStatus = "loading" | "ready" | "unavailable";
 type DeckSource = "profile" | "starter-fallback";
+const STARTER_KIT_CARD_COUNT = STARTER_FREE_BOOSTERS * STARTER_BOOSTER_CARD_COUNT;
 type TelegramWindow = Window & {
   Telegram?: {
     WebApp?: {
@@ -52,6 +54,7 @@ export function GameRoot() {
   const [playerIdentity, setPlayerIdentity] = useState<PlayerIdentity | null>(null);
   const [profileStatus, setProfileStatus] = useState<ProfileStatus>("loading");
   const [profileRetryKey, setProfileRetryKey] = useState(0);
+  const [starterDeckReadyVisible, setStarterDeckReadyVisible] = useState(false);
   const [telegramPlayer, setTelegramPlayer] = useState<TelegramPlayer>(() => readTelegramPlayer());
   const [telegramLandscapePromptActive, setTelegramLandscapePromptActive] = useState(false);
   const deckTouchedRef = useRef(false);
@@ -64,8 +67,8 @@ export function GameRoot() {
     profileStatus === "ready" &&
     Boolean(playerIdentity) &&
     Boolean(playerProfile) &&
-    (playerProfile?.starterFreeBoostersRemaining ?? 0) > 0 &&
-    !playerProfile?.onboarding.completed;
+    (starterDeckReadyVisible ||
+      ((playerProfile?.starterFreeBoostersRemaining ?? 0) > 0 && !playerProfile?.onboarding.completed));
 
   useEffect(() => {
     const telegramPlayerHandle = window.setTimeout(() => setTelegramPlayer(readTelegramPlayer()), 0);
@@ -155,9 +158,27 @@ export function GameRoot() {
   const handleStarterProfileChange = useCallback((nextProfile: PlayerProfile) => {
     deckTouchedRef.current = false;
     setPlayerProfile(nextProfile);
+    setStarterDeckReadyVisible(isStarterKitReady(nextProfile));
   }, []);
+  const handleStarterDeckPlay = useCallback((starterDeckIds: string[]) => {
+    deckTouchedRef.current = true;
+    setDeckIds(starterDeckIds);
+    setStarterDeckReadyVisible(false);
+    setBattleMode("ai");
+    setScreen("battle");
+  }, []);
+  const handleStarterDeckEdit = useCallback(
+    (starterDeckIds: string[]) => {
+      deckTouchedRef.current = true;
+      setDeckIds(sanitizeDeckIds(starterDeckIds, collectionIds));
+      setStarterDeckReadyVisible(false);
+      setScreen("collection");
+    },
+    [collectionIds],
+  );
   const retryProfileLoad = useCallback(() => {
     deckTouchedRef.current = false;
+    setStarterDeckReadyVisible(false);
     setPlayerProfile(null);
     setProfileStatus("loading");
     setProfileRetryKey((current) => current + 1);
@@ -215,6 +236,8 @@ export function GameRoot() {
           profileIdentityMode={playerIdentity.mode}
           deckSource={deckSource}
           onProfileChange={handleStarterProfileChange}
+          onPlayDeck={handleStarterDeckPlay}
+          onEditDeck={handleStarterDeckEdit}
         />
         <TelegramLandscapeOverlay active={telegramLandscapePromptActive} />
       </>
@@ -411,6 +434,14 @@ function getCollectionIdsForProfile(profile: PlayerProfile | null, allCardIds: s
 function getDeckIdsForProfile(profile: PlayerProfile | null, collectionIds: string[]) {
   if (!profile || profile.deckIds.length === 0) return [];
   return unique(profile.deckIds).filter((cardId) => collectionIds.includes(cardId));
+}
+
+function isStarterKitReady(profile: PlayerProfile) {
+  return (
+    profile.starterFreeBoostersRemaining === 0 &&
+    profile.openedBoosterIds.length >= STARTER_FREE_BOOSTERS &&
+    profile.deckIds.length >= STARTER_KIT_CARD_COUNT
+  );
 }
 
 function sanitizeDeckIds(deckIds: string[], collectionIds: string[]) {

--- a/src/features/game/ui/onboarding/StarterBoosterOnboarding.tsx
+++ b/src/features/game/ui/onboarding/StarterBoosterOnboarding.tsx
@@ -2,15 +2,16 @@
 
 import type { CSSProperties } from "react";
 import { useEffect, useState } from "react";
+import { cards as cardCatalog } from "@/features/battle/model/cards";
 import { fetchStarterBoosterCatalog, openStarterBooster } from "@/features/boosters/client";
-import type { BoosterCatalogItem, BoosterResponse } from "@/features/boosters/types";
+import { STARTER_BOOSTER_CARD_COUNT, type BoosterCatalogItem, type BoosterResponse } from "@/features/boosters/types";
 import type { Card, Rarity } from "@/features/battle/model/types";
 import { BattleCard } from "@/features/battle/ui/components/BattleCard";
 import { STARTER_FREE_BOOSTERS, type PlayerIdentity, type PlayerProfile } from "@/features/player/profile/types";
 import { cn } from "@/shared/lib/cn";
 
 type ProfileStatus = "loading" | "ready" | "unavailable";
-type Phase = "catalog" | "opening" | "reveal";
+type Phase = "catalog" | "opening" | "reveal" | "deck-ready";
 type CatalogStatus = "loading" | "ready" | "error";
 
 type Props = {
@@ -20,6 +21,8 @@ type Props = {
   profileIdentityMode?: "telegram" | "guest";
   deckSource: "profile" | "starter-fallback";
   onProfileChange: (profile: PlayerProfile) => void;
+  onPlayDeck: (deckIds: string[]) => void;
+  onEditDeck: (deckIds: string[]) => void;
 };
 
 type RevealState = {
@@ -29,6 +32,7 @@ type RevealState = {
 };
 
 const REVEAL_STEP_MS = 460;
+const STARTER_KIT_CARD_COUNT = STARTER_FREE_BOOSTERS * STARTER_BOOSTER_CARD_COUNT;
 const boosterAccents = [
   ["#ffe08a", "#65d7e9"],
   ["#ef735a", "#a8df5a"],
@@ -51,6 +55,8 @@ export function StarterBoosterOnboarding({
   profileIdentityMode,
   deckSource,
   onProfileChange,
+  onPlayDeck,
+  onEditDeck,
 }: Props) {
   const [optimisticProfile, setOptimisticProfile] = useState<PlayerProfile | null>(null);
   const [phase, setPhase] = useState<Phase>("catalog");
@@ -136,10 +142,18 @@ export function StarterBoosterOnboarding({
     }
   }
 
-  function returnToCatalog() {
-    if (reveal) {
-      setOptimisticProfile(reveal.player);
-      onProfileChange(reveal.player);
+  function finishReveal() {
+    if (!reveal) return;
+
+    setOptimisticProfile(reveal.player);
+    onProfileChange(reveal.player);
+
+    if (isStarterKitReady(reveal.player)) {
+      setOpeningBoosterId(null);
+      setReveal(null);
+      setRevealedCount(0);
+      setPhase("deck-ready");
+      return;
     }
 
     setOpeningBoosterId(null);
@@ -191,8 +205,10 @@ export function StarterBoosterOnboarding({
             </div>
           </header>
 
-          {phase === "reveal" && reveal ? (
-            <StarterReveal reveal={reveal} revealedCount={revealedCount} onDone={returnToCatalog} />
+          {phase === "deck-ready" ? (
+            <StarterDeckReady profile={profileForDisplay} onPlayDeck={onPlayDeck} onEditDeck={onEditDeck} />
+          ) : phase === "reveal" && reveal ? (
+            <StarterReveal reveal={reveal} revealedCount={revealedCount} onDone={finishReveal} />
           ) : (
             <section className="grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] gap-3">
               <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-3 max-[760px]:grid-cols-1">
@@ -271,6 +287,136 @@ export function StarterBoosterOnboarding({
         </section>
       </div>
     </main>
+  );
+}
+
+function StarterDeckReady({
+  profile,
+  onPlayDeck,
+  onEditDeck,
+}: {
+  profile: PlayerProfile;
+  onPlayDeck: (deckIds: string[]) => void;
+  onEditDeck: (deckIds: string[]) => void;
+}) {
+  const deckCards = profile.deckIds
+    .map((cardId) => cardCatalog.find((card) => card.id === cardId))
+    .filter(Boolean) as Card[];
+  const clans = new Set(deckCards.map((card) => card.clan));
+  const totalPower = deckCards.reduce((sum, card) => sum + card.power, 0);
+  const totalDamage = deckCards.reduce((sum, card) => sum + card.damage, 0);
+  const deckReady = deckCards.length >= STARTER_KIT_CARD_COUNT;
+
+  return (
+    <section
+      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-3"
+      data-testid="starter-deck-ready-shell"
+      data-card-count={deckCards.length}
+      data-profile-deck-count={profile.deckIds.length}
+      data-opened-booster-count={profile.openedBoosterIds.length}
+    >
+      <div className="grid grid-cols-[minmax(0,1fr)_280px] gap-3 rounded-md border border-[#d4aa4d]/45 bg-[linear-gradient(180deg,rgba(29,29,20,0.94),rgba(8,10,10,0.98))] p-4 shadow-[0_18px_42px_rgba(0,0,0,0.4),inset_0_1px_0_rgba(255,242,181,0.12)] max-[860px]:grid-cols-1 max-[520px]:p-3">
+        <div className="min-w-0">
+          <b className="text-[11px] font-black uppercase tracking-[0.16em] text-[#65d7e9]">Стартовий комплект закрито</b>
+          <h2 className="mt-1 text-[clamp(28px,5vw,50px)] font-black uppercase leading-none text-[#fff0ad] [text-shadow:0_3px_0_rgba(0,0,0,0.72)]">
+            Колода готова
+          </h2>
+          <p className="mt-2 max-w-[760px] text-sm font-bold leading-snug text-[#cbbd99] max-[520px]:text-xs">
+            Два різні бустери вже записали карти в профіль. Можна одразу зіграти AI-бій або підкрутити склад.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <Metric label="Карт" value={`${deckCards.length}/${STARTER_KIT_CARD_COUNT}`} />
+          <Metric label="Бустерів" value={`${profile.openedBoosterIds.length}/${STARTER_FREE_BOOSTERS}`} />
+          <Metric label="Фракцій" value={clans.size} />
+          <Metric label="Сила" value={totalPower} />
+        </div>
+      </div>
+
+      <div className="grid min-h-0 grid-cols-[minmax(0,1fr)_260px] gap-3 max-[960px]:grid-cols-1">
+        <section className="grid min-h-0 content-start gap-2 overflow-y-auto rounded-md border border-[#d4aa4d]/32 bg-[rgba(5,8,10,0.74)] p-3 shadow-[inset_0_0_68px_rgba(0,0,0,0.3)] max-[520px]:p-2">
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(142px,1fr))] gap-2 max-[430px]:grid-cols-2 max-[430px]:gap-1.5">
+            {deckCards.map((card, index) => (
+              <StarterDeckReadyCard key={`${card.id}-${index}`} card={card} index={index} />
+            ))}
+          </div>
+        </section>
+
+        <aside className="grid content-start gap-3 rounded-md border border-white/10 bg-black/42 p-3">
+          <div className="grid grid-cols-2 gap-2">
+            <Metric label="Урон" value={totalDamage} />
+            <Metric label="Легенд." value={deckCards.filter((card) => card.rarity === "Legend").length} />
+          </div>
+
+          <button
+            className={cn(
+              "min-h-[48px] rounded-md border-2 px-5 text-sm font-black uppercase transition",
+              deckReady
+                ? "border-black/60 bg-[linear-gradient(180deg,#fff26d,#e3b51e_54%,#a66d12)] text-[#1a1408] hover:brightness-110"
+                : "cursor-not-allowed border-white/10 bg-white/5 text-[#7e7668]",
+            )}
+            type="button"
+            disabled={!deckReady}
+            onClick={() => onPlayDeck(profile.deckIds)}
+            data-testid="starter-deck-ready-play"
+          >
+            Грати
+          </button>
+
+          <button
+            className="min-h-[48px] rounded-md border-2 border-[#65d7e9]/60 bg-[linear-gradient(180deg,#68e5f5,#218aa3_56%,#0d4151)] px-5 text-sm font-black uppercase text-[#061116] transition hover:brightness-110"
+            type="button"
+            onClick={() => onEditDeck(profile.deckIds)}
+            data-testid="starter-deck-ready-edit"
+          >
+            Редагувати колоду
+          </button>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function StarterDeckReadyCard({ card, index }: { card: Card; index: number }) {
+  const style = {
+    "--card-accent": card.accent,
+  } as CSSProperties;
+
+  return (
+    <article
+      className="grid min-h-[118px] grid-rows-[auto_1fr_auto] gap-2 rounded-md border border-[color-mix(in_srgb,var(--card-accent),#000_38%)] bg-[linear-gradient(160deg,color-mix(in_srgb,var(--card-accent),#101010_64%),rgba(6,8,10,0.95)_52%)] p-2 shadow-[0_12px_26px_rgba(0,0,0,0.32),inset_0_1px_0_rgba(255,255,255,0.08)] max-[430px]:min-h-[112px]"
+      style={style}
+      data-testid={`starter-deck-ready-card-${index + 1}`}
+      data-card-id={card.id}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <b className="grid aspect-square w-7 place-items-center rounded-sm border border-black/35 bg-[#fff0ad] text-xs font-black text-[#17100a]">
+          {index + 1}
+        </b>
+        <span className="truncate rounded-sm border border-white/12 bg-black/34 px-1.5 py-1 text-[10px] font-black uppercase text-[#9ed6e4]">
+          {rarityLabels[card.rarity]}
+        </span>
+      </div>
+
+      <div className="min-w-0 self-end">
+        <strong className="block truncate text-base font-black uppercase leading-tight text-[#fff4c4] max-[430px]:text-sm">
+          {card.name}
+        </strong>
+        <span className="mt-1 block truncate text-[10px] font-black uppercase tracking-[0.06em] text-[#cbbd99]">
+          {card.clan}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-1 text-center">
+        <span className="rounded-sm border border-white/10 bg-black/30 px-1 py-1 text-[10px] font-black uppercase text-[#ffe08a]">
+          С {card.power}
+        </span>
+        <span className="rounded-sm border border-white/10 bg-black/30 px-1 py-1 text-[10px] font-black uppercase text-[#efcf6f]">
+          У {card.damage}
+        </span>
+      </div>
+    </article>
   );
 }
 
@@ -411,6 +557,7 @@ function StarterReveal({
   const activeCard = reveal.cards[safeCount - 1];
   const visibleCards = reveal.cards.slice(0, revealedCount);
   const complete = revealedCount >= reveal.cards.length;
+  const deckReadyAfterReveal = isStarterKitReady(reveal.player);
 
   return (
     <section
@@ -485,7 +632,7 @@ function StarterReveal({
             onClick={onDone}
             data-testid="starter-reveal-continue"
           >
-            До каталогу
+            {deckReadyAfterReveal ? "До колоди" : "До каталогу"}
           </button>
         ) : null}
       </div>
@@ -509,5 +656,13 @@ function Metric({ label, value, testId }: { label: string; value: number | strin
       <b className="block text-xl font-black leading-none text-[#ffe08a]">{value}</b>
       <span className="mt-1 block text-[10px] font-black uppercase tracking-[0.1em] text-[#a99d85]">{label}</span>
     </div>
+  );
+}
+
+function isStarterKitReady(profile: PlayerProfile) {
+  return (
+    profile.starterFreeBoostersRemaining === 0 &&
+    profile.openedBoosterIds.length >= STARTER_FREE_BOOSTERS &&
+    profile.deckIds.length >= STARTER_KIT_CARD_COUNT
   );
 }

--- a/tests/boosterOpening.test.ts
+++ b/tests/boosterOpening.test.ts
@@ -158,6 +158,26 @@ describe("starter booster opening", () => {
     expect(store.openings).toHaveLength(1);
   });
 
+  test("appends a different second starter booster into the saved ten-card deck", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    const first = await openBooster(store, "neon-breach");
+    const firstBody = (await first.json()) as OpenBoosterResponse;
+    const second = await openBooster(store, "factory-shift");
+    const secondBody = (await second.json()) as OpenBoosterResponse;
+    const firstCardIds = firstBody.cards.map((card) => card.id);
+    const secondCardIds = secondBody.cards.map((card) => card.id);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(secondBody.player.ownedCardIds).toEqual([...firstCardIds, ...secondCardIds]);
+    expect(secondBody.player.deckIds).toEqual([...firstCardIds, ...secondCardIds]);
+    expect(secondBody.player.deckIds).toHaveLength(10);
+    expect(new Set(secondBody.player.deckIds).size).toBe(10);
+    expect(secondBody.player.openedBoosterIds).toEqual(["neon-breach", "factory-shift"]);
+    expect(secondBody.player.starterFreeBoostersRemaining).toBe(0);
+    expect(store.openings).toHaveLength(2);
+  });
+
   test("does not advance player state when history insert fails", async () => {
     const store = new MemoryBoosterOpeningStore();
     await store.findOrCreateByIdentity(guestIdentity);

--- a/tests/onboarding-reveal.spec.ts
+++ b/tests/onboarding-reveal.spec.ts
@@ -1,6 +1,7 @@
-import { expect, test, type Route } from "@playwright/test";
+import { expect, test, type Page, type Route } from "@playwright/test";
 import { cards } from "../src/features/battle/model/cards";
 import type { Card } from "../src/features/battle/model/types";
+import { getBoosterById } from "../src/features/boosters/catalog";
 import type { PlayerIdentity } from "../src/features/player/profile/types";
 import { fulfillBoosterCatalog, fulfillPlayerProfile, type TestPlayerProfileInput } from "./fixtures/playerProfile";
 
@@ -9,86 +10,41 @@ const identity: PlayerIdentity = {
   mode: "guest",
   guestId: "starter-reveal-e2e",
 };
-const neonClans = new Set(["[Da:Hack]", "Aliens"]);
-const openedCards = cards.filter((card) => neonClans.has(card.clan)).slice(0, 5);
+const firstBoosterId = "neon-breach";
+const secondBoosterId = "factory-shift";
+const firstOpenedCards = getCardsForClans(["[Da:Hack]", "Aliens"]);
+const secondOpenedCards = getCardsForClans(["Workers", "Micron"]);
+const fullStarterDeckIds = [...firstOpenedCards, ...secondOpenedCards].map((card) => card.id);
 
-test("opens the first starter booster, reveals saved cards, and reloads into the second-booster state", async ({ page }) => {
-  expect(openedCards).toHaveLength(5);
+test("opens two different starter boosters, reveals saved cards, and edits the ten-card deck-ready state", async ({ page }) => {
+  expect(firstOpenedCards).toHaveLength(5);
+  expect(secondOpenedCards).toHaveLength(5);
 
-  let profile = createProfile();
-  let catalogRequestCount = 0;
-  let openRequestCount = 0;
-  let resolveOpenRoute: (route: Route) => void = () => undefined;
-  const openRoutePromise = new Promise<Route>((resolve) => {
-    resolveOpenRoute = resolve;
-  });
-
-  await page.addInitScript(
-    ({ key, guestId }) => {
-      window.localStorage.setItem(key, guestId);
-    },
-    { key: GUEST_ID_STORAGE_KEY, guestId: identity.guestId },
-  );
-  await page.route("**/api/player", async (route) => {
-    await fulfillPlayerProfile(route, profile);
-  });
-  await page.route("**/api/boosters", async (route) => {
-    const catalogBody = route.request().postDataJSON() as { identity: PlayerIdentity };
-    catalogRequestCount += 1;
-    expect(catalogBody.identity).toEqual(identity);
-    await fulfillBoosterCatalog(route, profile);
-  });
-  await page.route("**/api/player/open-booster", async (route) => {
-    openRequestCount += 1;
-    resolveOpenRoute(route);
-  });
+  const harness = await setupStarterOnboarding(page);
 
   await page.goto("/");
+  await expectInitialStarterCatalog(page);
 
-  const shell = page.getByTestId("starter-onboarding-shell");
-  await expect(shell).toBeVisible();
-  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-owned-card-count", "0");
-  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-starter-free-boosters-remaining", "2");
-  await expect(shell).toHaveAttribute("data-opened-booster-count", "0");
-  await expect(shell).toHaveAttribute("data-catalog-status", "ready");
-  await expect(page.locator('[data-testid^="starter-booster-card-"]')).toHaveCount(12);
-  await expect(page.getByTestId("collection-search")).toHaveCount(0);
-
-  await page.getByTestId("starter-booster-open-neon-breach").click();
-  const openRoute = await openRoutePromise;
-  const openBody = openRoute.request().postDataJSON() as { identity: PlayerIdentity; boosterId: string };
-
-  expect(openRequestCount).toBe(1);
-  expect(openBody).toEqual({ identity, boosterId: "neon-breach" });
-  await expect(shell).toHaveAttribute("data-phase", "opening");
-  await expect(page.getByTestId("starter-opening-pending")).toBeVisible();
-  await expect(page.getByTestId("starter-reveal-shell")).toHaveCount(0);
-
-  profile = createProfile({
-    ownedCardIds: openedCards.map((card) => card.id),
-    deckIds: openedCards.map((card) => card.id),
+  await openBoosterAndReveal(page, harness, firstBoosterId, firstOpenedCards, {
+    ownedCardIds: firstOpenedCards.map((card) => card.id),
+    deckIds: firstOpenedCards.map((card) => card.id),
     starterFreeBoostersRemaining: 1,
-    openedBoosterIds: ["neon-breach"],
+    openedBoosterIds: [firstBoosterId],
   });
-  await fulfillOpenBooster(openRoute, openedCards, profile);
-
-  await expect(page.getByTestId("starter-reveal-shell")).toBeVisible();
-  await expect(page.locator('[data-testid^="starter-reveal-card-"]')).toHaveCount(5, { timeout: 6_000 });
-  await expect(page.getByTestId("starter-reveal-active-card")).toHaveAttribute("data-card-id", openedCards[4].id);
-  await expect(page.getByTestId("starter-reveal-continue")).toBeVisible();
 
   await page.getByTestId("starter-reveal-continue").click();
 
+  const shell = page.getByTestId("starter-onboarding-shell");
   await expect(shell).toHaveAttribute("data-phase", "catalog");
   await expect(shell).toHaveAttribute("data-opened-booster-count", "1");
   await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-owned-card-count", "5");
   await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-deck-count", "5");
   await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-starter-free-boosters-remaining", "1");
   await expect(page.getByTestId("starter-state-label")).toHaveText("Другий вибір");
-  await expect(page.getByTestId("starter-booster-card-neon-breach")).toHaveAttribute("data-opened", "true");
-  await expect(page.getByTestId("starter-booster-open-neon-breach")).toBeDisabled();
-  await expect(page.getByTestId("starter-booster-open-factory-shift")).toBeEnabled();
-  expect(catalogRequestCount).toBeGreaterThanOrEqual(2);
+  await expect(page.getByTestId(`starter-booster-card-${firstBoosterId}`)).toHaveAttribute("data-opened", "true");
+  await expect(page.getByTestId(`starter-booster-open-${firstBoosterId}`)).toBeDisabled();
+  await expect(page.getByTestId(`starter-booster-open-${secondBoosterId}`)).toBeEnabled();
+  expect(harness.catalogRequestCount()).toBeGreaterThanOrEqual(2);
 
   await page.reload();
 
@@ -97,9 +53,155 @@ test("opens the first starter booster, reveals saved cards, and reloads into the
   await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-owned-card-count", "5");
   await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-deck-count", "5");
   await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-starter-free-boosters-remaining", "1");
-  await expect(page.getByTestId("starter-booster-open-neon-breach")).toBeDisabled();
-  await expect(page.getByTestId("starter-booster-open-factory-shift")).toBeEnabled();
+  await expect(page.getByTestId(`starter-booster-open-${firstBoosterId}`)).toBeDisabled();
+  await expect(page.getByTestId(`starter-booster-open-${secondBoosterId}`)).toBeEnabled();
+
+  await openBoosterAndReveal(page, harness, secondBoosterId, secondOpenedCards, {
+    ownedCardIds: fullStarterDeckIds,
+    deckIds: fullStarterDeckIds,
+    starterFreeBoostersRemaining: 0,
+    openedBoosterIds: [firstBoosterId, secondBoosterId],
+  });
+
+  await page.getByTestId("starter-reveal-continue").click();
+  await expectDeckReady(page);
+
+  await page.getByTestId("starter-deck-ready-edit").click();
+  await expect(page.getByTestId("collection-search")).toBeVisible();
+  await expect(page.locator('[data-testid^="deck-card-"]')).toHaveCount(10);
+  await expect(page.getByTestId("play-selected-deck")).toBeEnabled();
 });
+
+test("starts an AI battle from the ten-card starter deck-ready state", async ({ page }) => {
+  const harness = await setupStarterOnboarding(page, "starter-reveal-play-e2e");
+
+  await page.goto("/");
+  await expectInitialStarterCatalog(page);
+
+  await openBoosterAndReveal(page, harness, firstBoosterId, firstOpenedCards, {
+    ownedCardIds: firstOpenedCards.map((card) => card.id),
+    deckIds: firstOpenedCards.map((card) => card.id),
+    starterFreeBoostersRemaining: 1,
+    openedBoosterIds: [firstBoosterId],
+  });
+  await page.getByTestId("starter-reveal-continue").click();
+
+  await openBoosterAndReveal(page, harness, secondBoosterId, secondOpenedCards, {
+    ownedCardIds: fullStarterDeckIds,
+    deckIds: fullStarterDeckIds,
+    starterFreeBoostersRemaining: 0,
+    openedBoosterIds: [firstBoosterId, secondBoosterId],
+  });
+  await page.getByTestId("starter-reveal-continue").click();
+  await expectDeckReady(page);
+
+  await page.getByTestId("starter-deck-ready-play").click();
+  await expect(page.getByTestId("round-status")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator('[data-testid^="player-card-"]')).toHaveCount(4);
+});
+
+async function setupStarterOnboarding(page: Page, guestId = identity.guestId) {
+  const activeIdentity: PlayerIdentity = { mode: "guest", guestId };
+  let profile = createProfile({ identity: activeIdentity });
+  let catalogRequestCount = 0;
+  let openRequestCount = 0;
+  const openRoutes: Route[] = [];
+  const openRouteWaiters: ((route: Route) => void)[] = [];
+
+  await page.addInitScript(
+    ({ key, value }) => {
+      window.localStorage.setItem(key, value);
+    },
+    { key: GUEST_ID_STORAGE_KEY, value: guestId },
+  );
+  await page.route("**/api/player", async (route) => {
+    await fulfillPlayerProfile(route, profile);
+  });
+  await page.route("**/api/boosters", async (route) => {
+    const catalogBody = route.request().postDataJSON() as { identity: PlayerIdentity };
+    catalogRequestCount += 1;
+    expect(catalogBody.identity).toEqual(activeIdentity);
+    await fulfillBoosterCatalog(route, profile);
+  });
+  await page.route("**/api/player/open-booster", async (route) => {
+    openRequestCount += 1;
+    const waiter = openRouteWaiters.shift();
+    if (waiter) {
+      waiter(route);
+      return;
+    }
+
+    openRoutes.push(route);
+  });
+
+  return {
+    identity: activeIdentity,
+    setProfile(nextProfile: Partial<TestPlayerProfileInput>) {
+      profile = createProfile({ identity: activeIdentity, ...nextProfile });
+    },
+    waitForOpenRoute() {
+      const route = openRoutes.shift();
+      if (route) return Promise.resolve(route);
+
+      return new Promise<Route>((resolve) => {
+        openRouteWaiters.push(resolve);
+      });
+    },
+    catalogRequestCount: () => catalogRequestCount,
+    openRequestCount: () => openRequestCount,
+  };
+}
+
+async function expectInitialStarterCatalog(page: Page) {
+  const shell = page.getByTestId("starter-onboarding-shell");
+  await expect(shell).toBeVisible();
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-owned-card-count", "0");
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-starter-free-boosters-remaining", "2");
+  await expect(shell).toHaveAttribute("data-opened-booster-count", "0");
+  await expect(shell).toHaveAttribute("data-catalog-status", "ready");
+  await expect(page.locator('[data-testid^="starter-booster-card-"]')).toHaveCount(12);
+  await expect(page.getByTestId("collection-search")).toHaveCount(0);
+}
+
+async function openBoosterAndReveal(
+  page: Page,
+  harness: Awaited<ReturnType<typeof setupStarterOnboarding>>,
+  boosterId: string,
+  openingCards: Card[],
+  nextProfile: Partial<TestPlayerProfileInput>,
+) {
+  const openRoutePromise = harness.waitForOpenRoute();
+  await page.getByTestId(`starter-booster-open-${boosterId}`).click();
+  const openRoute = await openRoutePromise;
+  const openBody = openRoute.request().postDataJSON() as { identity: PlayerIdentity; boosterId: string };
+
+  expect(openBody).toEqual({ identity: harness.identity, boosterId });
+  await expect(page.getByTestId("starter-onboarding-shell")).toHaveAttribute("data-phase", "opening");
+  await expect(page.getByTestId("starter-opening-pending")).toBeVisible();
+  await expect(page.getByTestId("starter-reveal-shell")).toHaveCount(0);
+
+  harness.setProfile(nextProfile);
+  await fulfillOpenBooster(openRoute, boosterId, openingCards, createProfile({ identity: harness.identity, ...nextProfile }));
+
+  await expect(page.getByTestId("starter-reveal-shell")).toBeVisible();
+  await expect(page.locator('[data-testid^="starter-reveal-card-"]')).toHaveCount(5, { timeout: 6_000 });
+  await expect(page.getByTestId("starter-reveal-active-card")).toHaveAttribute("data-card-id", openingCards[4].id);
+  await expect(page.getByTestId("starter-reveal-continue")).toBeVisible();
+}
+
+async function expectDeckReady(page: Page) {
+  const readyShell = page.getByTestId("starter-deck-ready-shell");
+  await expect(readyShell).toBeVisible();
+  await expect(readyShell).toHaveAttribute("data-card-count", "10");
+  await expect(readyShell).toHaveAttribute("data-profile-deck-count", "10");
+  await expect(readyShell).toHaveAttribute("data-opened-booster-count", "2");
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-owned-card-count", "10");
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-deck-count", "10");
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-starter-free-boosters-remaining", "0");
+  await expect(page.locator('[data-testid^="starter-deck-ready-card-"]')).toHaveCount(10);
+  await expect(page.getByTestId("starter-deck-ready-play")).toBeEnabled();
+  await expect(page.getByTestId("starter-deck-ready-edit")).toBeEnabled();
+}
 
 function createProfile(overrides: Partial<TestPlayerProfileInput> = {}): TestPlayerProfileInput {
   return {
@@ -113,21 +215,24 @@ function createProfile(overrides: Partial<TestPlayerProfileInput> = {}): TestPla
   };
 }
 
-async function fulfillOpenBooster(route: Route, openingCards: Card[], player: TestPlayerProfileInput) {
+async function fulfillOpenBooster(route: Route, boosterId: string, openingCards: Card[], player: TestPlayerProfileInput) {
+  const booster = getBoosterById(boosterId);
+  if (!booster) throw new Error(`Unknown test booster ${boosterId}.`);
+
   await route.fulfill({
     status: 200,
     contentType: "application/json",
     body: JSON.stringify({
       booster: {
-        id: "neon-breach",
-        name: "Neon Breach",
-        clans: ["[Da:Hack]", "Aliens"],
+        id: booster.id,
+        name: booster.name,
+        clans: booster.clans,
       },
       cards: openingCards,
       opening: {
-        id: "opening-starter-reveal-e2e",
+        id: `opening-${boosterId}-starter-reveal-e2e`,
         playerId: player.id,
-        boosterId: "neon-breach",
+        boosterId,
         source: "starter_free",
         cardIds: openingCards.map((card) => card.id),
         openedAt: "2026-05-02T12:00:00.000Z",
@@ -143,4 +248,9 @@ async function fulfillOpenBooster(route: Route, openingCards: Card[], player: Te
       },
     }),
   });
+}
+
+function getCardsForClans(clans: string[]) {
+  const clanSet = new Set(clans);
+  return cards.filter((card) => clanSet.has(card.clan)).slice(0, 5);
 }


### PR DESCRIPTION
## Summary
- Keep starter onboarding mounted after the second reveal and show a compact ten-card deck-ready state.
- Wire deck-ready actions to start an AI battle with the saved starter deck or open the existing deck editor.
- Extend backend/unit and Playwright coverage for different second boosters, ten saved deck cards, and deck-ready actions.

## Verification
- bun install
- bun test tests/boosterOpening.test.ts
- bun run lint
- bun run test:e2e -- onboarding-reveal.spec.ts
- bun run test
- bun run build
- bun run test:e2e

Parent: #1
Closes #6