### PR TITLE
feat(battle): route AI and PvP through saved owned decks

### DIFF
--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -65,10 +65,7 @@ export function GameRoot() {
   const ownedCardIds = useMemo(() => getOwnedCardIdsForProfile(playerProfile, allCardIds), [allCardIds, playerProfile]);
   const profileDeckIds = useMemo(() => getDeckIdsForProfile(playerProfile, ownedCardIds), [ownedCardIds, playerProfile]);
   const deckSource: DeckSource = profileDeckIds.length > 0 ? "profile" : "starter-fallback";
-  const deckReadyToPlay =
-    profileDeckIds.length >= PLAYER_DECK_SIZE &&
-    sameStringArray(deckIds, profileDeckIds) &&
-    deckSaveStatus !== "saving";
+  const deckReadyToPlay = isSavedOwnedDeckReady(profileDeckIds, deckIds, deckSaveStatus);
   const starterFreeBoostersRemaining = playerProfile?.starterFreeBoostersRemaining ?? 0;
   const playerName = telegramPlayer.name;
   const showStarterOnboarding =
@@ -196,15 +193,17 @@ export function GameRoot() {
     lastConfirmedDeckIdsRef.current = getConfirmedDeckIds(nextProfile, allCardIds);
     setPlayerProfile(nextProfile);
     setDeckSaveStatus("idle");
-    setStarterDeckReadyVisible(isStarterKitReady(nextProfile));
+    setStarterDeckReadyVisible(isStarterKitReady(nextProfile, allCardIds));
   }, [allCardIds]);
-  const handleStarterDeckPlay = useCallback((starterDeckIds: string[]) => {
+  const handleStarterDeckPlay = useCallback(() => {
+    if (profileDeckIds.length < PLAYER_DECK_SIZE) return;
+
     deckTouchedRef.current = true;
-    setDeckIds(starterDeckIds);
+    setDeckIds(profileDeckIds);
     setStarterDeckReadyVisible(false);
     setBattleMode("ai");
     setScreen("battle");
-  }, []);
+  }, [profileDeckIds]);
   const handleStarterDeckEdit = useCallback(
     (starterDeckIds: string[]) => {
       deckTouchedRef.current = true;
@@ -490,11 +489,23 @@ function getConfirmedDeckIds(profile: PlayerProfile, allCardIds: string[]) {
   return getDeckIdsForProfile(profile, getOwnedCardIdsForProfile(profile, allCardIds));
 }
 
-function isStarterKitReady(profile: PlayerProfile) {
+function isSavedOwnedDeckReady(
+  savedOwnedDeckIds: string[],
+  currentDeckIds: string[],
+  deckSaveStatus: DeckSaveStatus,
+) {
+  return (
+    savedOwnedDeckIds.length >= PLAYER_DECK_SIZE &&
+    sameStringArray(currentDeckIds, savedOwnedDeckIds) &&
+    deckSaveStatus !== "saving"
+  );
+}
+
+function isStarterKitReady(profile: PlayerProfile, allCardIds: string[]) {
   return (
     profile.starterFreeBoostersRemaining === 0 &&
     profile.openedBoosterIds.length >= STARTER_FREE_BOOSTERS &&
-    profile.deckIds.length >= STARTER_KIT_CARD_COUNT
+    getConfirmedDeckIds(profile, allCardIds).length >= STARTER_KIT_CARD_COUNT
   );
 }
 

--- a/src/features/game/ui/onboarding/StarterBoosterOnboarding.tsx
+++ b/src/features/game/ui/onboarding/StarterBoosterOnboarding.tsx
@@ -301,13 +301,14 @@ function StarterDeckReady({
   onPlayDeck: (deckIds: string[]) => void;
   onEditDeck: (deckIds: string[]) => void;
 }) {
-  const deckCards = profile.deckIds
+  const savedOwnedDeckIds = getSavedOwnedDeckIds(profile);
+  const deckCards = savedOwnedDeckIds
     .map((cardId) => cardCatalog.find((card) => card.id === cardId))
     .filter(Boolean) as Card[];
   const clans = new Set(deckCards.map((card) => card.clan));
   const totalPower = deckCards.reduce((sum, card) => sum + card.power, 0);
   const totalDamage = deckCards.reduce((sum, card) => sum + card.damage, 0);
-  const deckReady = deckCards.length >= STARTER_KIT_CARD_COUNT;
+  const deckReady = savedOwnedDeckIds.length >= STARTER_KIT_CARD_COUNT;
 
   return (
     <section
@@ -360,7 +361,7 @@ function StarterDeckReady({
             )}
             type="button"
             disabled={!deckReady}
-            onClick={() => onPlayDeck(profile.deckIds)}
+            onClick={() => onPlayDeck(savedOwnedDeckIds)}
             data-testid="starter-deck-ready-play"
           >
             Грати
@@ -369,7 +370,7 @@ function StarterDeckReady({
           <button
             className="min-h-[48px] rounded-md border-2 border-[#65d7e9]/60 bg-[linear-gradient(180deg,#68e5f5,#218aa3_56%,#0d4151)] px-5 text-sm font-black uppercase text-[#061116] transition hover:brightness-110"
             type="button"
-            onClick={() => onEditDeck(profile.deckIds)}
+            onClick={() => onEditDeck(savedOwnedDeckIds)}
             data-testid="starter-deck-ready-edit"
           >
             Редагувати колоду
@@ -665,6 +666,17 @@ function isStarterKitReady(profile: PlayerProfile) {
   return (
     profile.starterFreeBoostersRemaining === 0 &&
     profile.openedBoosterIds.length >= STARTER_FREE_BOOSTERS &&
-    profile.deckIds.length >= STARTER_KIT_CARD_COUNT
+    getSavedOwnedDeckIds(profile).length >= STARTER_KIT_CARD_COUNT
   );
+}
+
+function getSavedOwnedDeckIds(profile: PlayerProfile) {
+  const knownCardIds = new Set(cardCatalog.map((card) => card.id));
+  const ownedCardIds = new Set(profile.ownedCardIds);
+
+  return unique(profile.deckIds).filter((cardId) => knownCardIds.has(cardId) && ownedCardIds.has(cardId));
+}
+
+function unique(values: string[]) {
+  return [...new Set(values)];
 }

--- a/tests/battle.spec.ts
+++ b/tests/battle.spec.ts
@@ -1,7 +1,16 @@
 import { expect, test, type Page } from "@playwright/test";
+import { cards } from "../src/features/battle/model/cards";
 import { mockDeckReadyProfile } from "./fixtures/playerProfile";
 
 const DECK_SESSION_STORAGE_KEY = "nexus:deck-session:v1";
+const PROFILE_ONLY_DECK_IDS = cards
+  .filter((card) => card.clan === "Workers")
+  .slice(0, 9)
+  .map((card) => card.id);
+const PROFILE_ONLY_OWNED_CARD_IDS = [
+  ...PROFILE_ONLY_DECK_IDS,
+  cards.find((card) => card.clan === "Workers" && !PROFILE_ONLY_DECK_IDS.includes(card.id))?.id,
+].filter((cardId): cardId is string => Boolean(cardId));
 
 test("keeps the minimum deck locked", async ({ page }) => {
   await mockDeckReadyProfile(page);
@@ -15,6 +24,23 @@ test("keeps the minimum deck locked", async ({ page }) => {
   expect(firstCardId).toBeTruthy();
 
   await expect(page.getByTestId(`deck-remove-${firstCardId}`)).toBeDisabled();
+});
+
+test("keeps starter-fallback decks visible but unavailable for AI and PvP", async ({ page }) => {
+  await mockDeckReadyProfile(page, {
+    ownedCardIds: PROFILE_ONLY_OWNED_CARD_IDS,
+    deckIds: [],
+    starterFreeBoostersRemaining: 0,
+    openedBoosterIds: ["neon-breach", "factory-shift"],
+  });
+
+  await page.goto("/");
+
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-deck-source", "starter-fallback");
+  await expect(page.locator('[data-testid^="deck-card-"]')).toHaveCount(9);
+  await expect(page.getByTestId("play-selected-deck")).toBeDisabled();
+  await expect(page.getByTestId("play-human-match")).toBeDisabled();
+  await expect(page.getByTestId("round-status")).toHaveCount(0);
 });
 
 test("ignores legacy deck session storage without deleting it", async ({ page }) => {
@@ -42,6 +68,33 @@ test("ignores legacy deck session storage without deleting it", async ({ page })
 
   const deckCards = page.locator('[data-testid^="deck-card-"]');
   await expect(deckCards).toHaveCount(9);
+  await expect.poll(() => readSavedDeckIds(page)).toEqual(legacyDeckIds);
+});
+
+test("starts AI battles from the saved owned profile deck", async ({ page }) => {
+  const legacyDeckIds = cards
+    .filter((card) => card.clan === "Toyz")
+    .slice(0, 9)
+    .map((card) => card.id);
+
+  await mockDeckReadyProfile(page, {
+    ownedCardIds: PROFILE_ONLY_OWNED_CARD_IDS,
+    deckIds: PROFILE_ONLY_DECK_IDS,
+  });
+  await page.addInitScript(
+    ({ storageKey, deckIds }) => {
+      window.sessionStorage.setItem(storageKey, JSON.stringify(deckIds));
+      window.localStorage.setItem("nexus_deck_v1", JSON.stringify(deckIds));
+    },
+    { storageKey: DECK_SESSION_STORAGE_KEY, deckIds: legacyDeckIds },
+  );
+
+  await page.goto("/");
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-deck-source", "profile");
+  await page.getByTestId("play-selected-deck").click();
+
+  await expect(page.getByTestId("round-status")).toBeVisible({ timeout: 10_000 });
+  await expectPlayerHandToUseDeck(page, PROFILE_ONLY_DECK_IDS);
   await expect.poll(() => readSavedDeckIds(page)).toEqual(legacyDeckIds);
 });
 
@@ -164,4 +217,16 @@ async function readSavedDeckIds(page: Page) {
     const raw = window.sessionStorage.getItem(storageKey);
     return raw ? (JSON.parse(raw) as string[]) : [];
   }, DECK_SESSION_STORAGE_KEY);
+}
+
+async function expectPlayerHandToUseDeck(page: Page, deckIds: string[]) {
+  const playerCards = page.locator('[data-testid^="player-card-"]');
+  await expect(playerCards).toHaveCount(4);
+
+  const handIds = await playerCards.evaluateAll((elements) =>
+    elements.map((element) => element.getAttribute("data-testid")?.replace("player-card-", "")),
+  );
+
+  expect(handIds).toHaveLength(4);
+  expect(handIds.every((cardId) => Boolean(cardId) && deckIds.includes(cardId))).toBe(true);
 }

--- a/tests/onboarding-reveal.spec.ts
+++ b/tests/onboarding-reveal.spec.ts
@@ -75,6 +75,7 @@ test("opens two different starter boosters, reveals saved cards, and edits the t
   await expect(page.getByTestId("collection-search")).toBeVisible();
   await expect(page.locator('[data-testid^="deck-card-"]')).toHaveCount(10);
   await expect(page.getByTestId("play-selected-deck")).toBeEnabled();
+  await expect(page.getByTestId("play-human-match")).toBeEnabled();
 });
 
 test("starts an AI battle from the ten-card starter deck-ready state", async ({ page }) => {
@@ -103,6 +104,7 @@ test("starts an AI battle from the ten-card starter deck-ready state", async ({ 
   await page.getByTestId("starter-deck-ready-play").click();
   await expect(page.getByTestId("round-status")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator('[data-testid^="player-card-"]')).toHaveCount(4);
+  await expectPlayerHandToUseDeck(page, fullStarterDeckIds);
 });
 
 async function setupStarterOnboarding(page: Page, guestId = identity.guestId) {
@@ -267,4 +269,16 @@ async function fulfillOpenBooster(route: Route, boosterId: string, openingCards:
 function getCardsForClans(clans: string[]) {
   const clanSet = new Set(clans);
   return cards.filter((card) => clanSet.has(card.clan)).slice(0, 5);
+}
+
+async function expectPlayerHandToUseDeck(page: Page, deckIds: string[]) {
+  const playerCards = page.locator('[data-testid^="player-card-"]');
+  await expect(playerCards).toHaveCount(4);
+
+  const handIds = await playerCards.evaluateAll((elements) =>
+    elements.map((element) => element.getAttribute("data-testid")?.replace("player-card-", "")),
+  );
+
+  expect(handIds).toHaveLength(4);
+  expect(handIds.every((cardId) => Boolean(cardId) && deckIds.includes(cardId))).toBe(true);
 }

--- a/tests/realtime.spec.ts
+++ b/tests/realtime.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test, type Page } from "@playwright/test";
 import { cards } from "../src/features/battle/model/cards";
-import { mockDeckReadyProfile } from "./fixtures/playerProfile";
+import { mockDeckReadyProfile, PROFILE_DECK_IDS } from "./fixtures/playerProfile";
+
+const PROTOCOL_OWNED_COLLECTION_IDS = cards.slice(0, 10).map((card) => card.id);
+const PROTOCOL_OWNED_DECK_IDS = PROTOCOL_OWNED_COLLECTION_IDS.slice(0, 9);
 
 test("pairs two tabs and resolves the first human round", async ({ context, page }) => {
   const first = page;
@@ -11,14 +14,18 @@ test("pairs two tabs and resolves the first human round", async ({ context, page
   await first.goto("/");
   await second.goto("/");
 
-  await expect(first.getByTestId("play-human-match")).toBeEnabled();
-  await expect(second.getByTestId("play-human-match")).toBeEnabled();
+  await expect(first.getByTestId("player-profile-shell")).toHaveAttribute("data-deck-source", "profile", { timeout: 15_000 });
+  await expect(second.getByTestId("player-profile-shell")).toHaveAttribute("data-deck-source", "profile", { timeout: 15_000 });
+  await expect(first.getByTestId("play-human-match")).toBeEnabled({ timeout: 15_000 });
+  await expect(second.getByTestId("play-human-match")).toBeEnabled({ timeout: 15_000 });
 
   await first.getByTestId("play-human-match").click();
   await second.getByTestId("play-human-match").click();
 
   await expect(first.getByTestId("round-status")).toBeVisible({ timeout: 12_000 });
   await expect(second.getByTestId("round-status")).toBeVisible({ timeout: 12_000 });
+  await expectPlayerHandToUseDeck(first, PROFILE_DECK_IDS);
+  await expectPlayerHandToUseDeck(second, PROFILE_DECK_IDS);
 
   const firstMover = await resolveFirstMover(first, second);
   const secondMover = firstMover === first ? second : first;
@@ -38,7 +45,7 @@ test("pairs two tabs and resolves the first human round", async ({ context, page
 
 test("forfeits the active PvP player when their turn times out", async ({ baseURL }) => {
   const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
-  const deckIds = cards.slice(0, 9).map((card) => card.id);
+  const deckIds = PROTOCOL_OWNED_DECK_IDS;
   const first = await connectRealtimeClient(wsUrl, "Timer A", deckIds);
   const second = await connectRealtimeClient(wsUrl, "Timer B", deckIds);
 
@@ -68,7 +75,7 @@ test("forfeits the active PvP player when their turn times out", async ({ baseUR
 
 test("does not leak the first PvP mover energy before reveal", async ({ baseURL }) => {
   const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
-  const deckIds = cards.slice(0, 9).map((card) => card.id);
+  const deckIds = PROTOCOL_OWNED_DECK_IDS;
   const first = await connectRealtimeClient(wsUrl, "Secret A", deckIds);
   const second = await connectRealtimeClient(wsUrl, "Secret B", deckIds);
 
@@ -104,7 +111,7 @@ test("does not leak the first PvP mover energy before reveal", async ({ baseURL 
 
 test("rejects removed PvP card ids before matchmaking", async ({ baseURL }) => {
   const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
-  const deckIds = cards.slice(0, 9).map((card) => card.id);
+  const deckIds = PROTOCOL_OWNED_DECK_IDS;
   const staleDeckIds = ["corr-1285", ...deckIds.slice(0, 8)];
   const staleDeckClient = await connectRealtimeClient(wsUrl, "Stale Deck", staleDeckIds);
 
@@ -133,7 +140,7 @@ test("rejects removed PvP card ids before matchmaking", async ({ baseURL }) => {
 
 test("rejects PvP decks below the nine-card minimum", async ({ baseURL }) => {
   const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
-  const shortDeckIds = cards.slice(0, 8).map((card) => card.id);
+  const shortDeckIds = PROTOCOL_OWNED_DECK_IDS.slice(0, 8);
   const client = await connectRealtimeClient(wsUrl, "Short Deck", shortDeckIds);
 
   const error = await client.waitFor("error", { timeoutMs: 2_000 });
@@ -146,7 +153,7 @@ test("rejects PvP decks below the nine-card minimum", async ({ baseURL }) => {
 
 test("rejects PvP deck cards outside the provided collection", async ({ baseURL }) => {
   const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
-  const deckIds = cards.slice(0, 9).map((card) => card.id);
+  const deckIds = PROTOCOL_OWNED_DECK_IDS;
   const missingCollectionCardId = deckIds[8];
   const client = await connectRealtimeClient(wsUrl, "Non Owned Deck", deckIds, {
     collectionIds: deckIds.slice(0, 8),
@@ -297,4 +304,16 @@ async function connectRealtimeClient(url: string, name: string, deckIds: string[
 async function expectNoRealtimeMessage(client: RealtimeClient, type: string) {
   await new Promise((resolve) => setTimeout(resolve, 200));
   expect(client.messages().some((message) => message.type === type)).toBe(false);
+}
+
+async function expectPlayerHandToUseDeck(page: Page, deckIds: string[]) {
+  const playerCards = page.locator('[data-testid^="player-card-"]');
+  await expect(playerCards).toHaveCount(4);
+
+  const handIds = await playerCards.evaluateAll((elements) =>
+    elements.map((element) => element.getAttribute("data-testid")?.replace("player-card-", "")),
+  );
+
+  expect(handIds).toHaveLength(4);
+  expect(handIds.every((cardId) => Boolean(cardId) && deckIds.includes(cardId))).toBe(true);
 }


### PR DESCRIPTION
## Summary
- Gate battle entry on the confirmed saved owned profile deck, including the starter deck-ready shortcut.
- Render/play/edit starter deck-ready state from known owned saved deck ids instead of raw profile deck ids.
- Add focused coverage for starter fallback non-playability, AI saved-deck entry, PvP saved-deck entry, onboarding deck-ready entry, and owned-deck protocol WS validation.

## Verification
- `bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts`
- `bunx playwright test tests/realtime.spec.ts`
- `bun run test:e2e`
- `bun run lint`
- `bun run build`
- `git diff --check`

## Notes
- Parent: #1
- Closes #8
- Residual: WS validation still validates against client-supplied `collectionIds`; adding server-loaded profile ownership to the socket join path is intentionally left as a larger follow-up.
