### PR TITLE
fix(pvp): validate socket joins against saved profiles

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     trace: "on-first-retry",
   },
   webServer: {
-    command: "MONGODB_SERVER_SELECTION_TIMEOUT_MS=200 bun run dev -- --hostname 127.0.0.1",
+    command: "NEXUS_TEST_PROFILE_STORE=1 MONGODB_SERVER_SELECTION_TIMEOUT_MS=200 bun run dev -- --hostname 127.0.0.1",
     url: "http://127.0.0.1:3000",
     reuseExistingServer: true,
     timeout: 120_000,

--- a/server.js
+++ b/server.js
@@ -527,7 +527,8 @@ function parseSocketPlayerIdentity(value) {
 
 function validateProfileBattleLoadout(profile) {
   const deckIds = getProfileCardIds(profile.deckIds);
-  const collectionIds = getProfileCardIds(profile.ownedCardIds);
+  const rawOwnedCardIds = getProfileCardIds(profile.ownedCardIds);
+  const collectionIds = unique(rawOwnedCardIds.filter((cardId) => activeCardIds.has(cardId)));
   const duplicateDeckIds = duplicateValues(deckIds);
 
   if (duplicateDeckIds.length > 0) {
@@ -539,16 +540,11 @@ function validateProfileBattleLoadout(profile) {
     return { error: deckError };
   }
 
-  const collectionError = validateKnownCardIds(collectionIds, "owned collection");
-  if (collectionError) {
-    return { error: collectionError };
-  }
-
   if (deckIds.length < MIN_DECK_SIZE) {
     return { error: `Saved deck must contain at least ${MIN_DECK_SIZE} cards.` };
   }
 
-  const missingOwnedIds = getMissingCollectionDeckIds(deckIds, collectionIds);
+  const missingOwnedIds = getMissingCollectionDeckIds(deckIds, rawOwnedCardIds);
   if (missingOwnedIds.length > 0) {
     return { error: `Saved deck contains non-owned card ids: ${missingOwnedIds.join(", ")}` };
   }
@@ -591,6 +587,10 @@ function duplicateValues(values) {
   }
 
   return [...duplicates];
+}
+
+function unique(values) {
+  return [...new Set(values)];
 }
 
 function sanitizeMove(value) {

--- a/server.js
+++ b/server.js
@@ -4,6 +4,12 @@ const crypto = require("node:crypto");
 const next = require("next");
 const { WebSocketServer } = require("ws");
 const { cards } = require("./src/features/battle/model/cards.ts");
+const { getMongoPlayerProfileStore } = require("./src/features/player/profile/mongo.ts");
+const {
+  createNewStoredPlayerProfile,
+  isSamePlayerIdentity,
+  parsePlayerIdentity,
+} = require("./src/features/player/profile/types.ts");
 
 const dev = process.argv.includes("--dev") || process.env.NODE_ENV === "development";
 const hostname = getCliValue("--hostname") || process.env.HOSTNAME || "0.0.0.0";
@@ -14,6 +20,7 @@ let requestHandler = (_request, response) => {
   response.end("Server is starting.");
 };
 const server = createServer((request, response) => {
+  if (handleTestProfileRequest(request, response)) return;
   requestHandler(request, response);
 });
 const app = next({ dev, hostname, port, httpServer: server });
@@ -21,6 +28,7 @@ const handle = app.getRequestHandler();
 
 const sessions = new Map();
 const matches = new Map();
+const testPlayerProfileStore = process.env.NEXUS_TEST_PROFILE_STORE === "1" ? createMemoryPlayerProfileStore() : null;
 let waitingSessionId = null;
 const BATTLE_HAND_SIZE = 4;
 const MIN_DECK_SIZE = 9;
@@ -116,7 +124,10 @@ function handleSocketMessage(session, message) {
   }
 
   if (message.type === "join_human") {
-    joinHumanQueue(session, message);
+    joinHumanQueue(session, message).catch((error) => {
+      console.error("PvP join failed.", error);
+      sendError(session, "Player profile is unavailable.");
+    });
     return;
   }
 
@@ -145,39 +156,61 @@ function handleSocketMessage(session, message) {
   }
 }
 
-function joinHumanQueue(session, message) {
-  const deckIds = sanitizeStringArray(message.deckIds);
-  const collectionIds = sanitizeStringArray(message.collectionIds);
+async function joinHumanQueue(session, message) {
+  const clientDeckIds = sanitizeStringArray(message.deckIds);
+  const clientCollectionIds = sanitizeStringArray(message.collectionIds);
   session.user = sanitizeUser(message.user);
 
-  const deckError = validateKnownCardIds(deckIds, "deck");
+  const deckError = validateKnownCardIds(clientDeckIds, "deck");
   if (deckError) {
     sendError(session, deckError);
     return;
   }
 
-  const collectionError = validateKnownCardIds(collectionIds, "collection");
+  const collectionError = validateKnownCardIds(clientCollectionIds, "collection");
   if (collectionError) {
     sendError(session, collectionError);
     return;
   }
 
-  if (deckIds.length < MIN_DECK_SIZE) {
+  if (Array.isArray(message.deckIds) && clientDeckIds.length < MIN_DECK_SIZE) {
     sendError(session, `Deck must contain at least ${MIN_DECK_SIZE} cards.`);
     return;
   }
 
-  const missingCollectionIds = getMissingCollectionDeckIds(deckIds, collectionIds);
+  const missingCollectionIds = Array.isArray(message.collectionIds)
+    ? getMissingCollectionDeckIds(clientDeckIds, clientCollectionIds)
+    : [];
   if (missingCollectionIds.length > 0) {
     sendError(session, `Deck contains cards outside the collection: ${missingCollectionIds.join(", ")}`);
     return;
   }
 
+  const identity = parseSocketPlayerIdentity(message.identity);
+  if (!identity) {
+    sendError(session, "Player identity is required for PvP.");
+    return;
+  }
+
+  const profile = await getPlayerProfileStore().findOrCreateByIdentity(identity);
+  const profileLoadout = validateProfileBattleLoadout(profile);
+  if (profileLoadout.error) {
+    sendError(session, profileLoadout.error);
+    return;
+  }
+
+  if (clientDeckIds.length > 0 && !sameStringArray(clientDeckIds, profileLoadout.deckIds)) {
+    sendError(session, "PvP deck must match the saved profile deck.");
+    return;
+  }
+
+  if (!sessions.has(session.id) || !isOpen(session.ws)) return;
+
   leaveMatch(session);
   cancelQueue(session, { silent: true });
 
-  session.queuedDeckIds = deckIds;
-  session.queuedCollectionIds = collectionIds;
+  session.queuedDeckIds = profileLoadout.deckIds;
+  session.queuedCollectionIds = profileLoadout.collectionIds;
 
   if (waitingSessionId && waitingSessionId !== session.id) {
     const opponent = sessions.get(waitingSessionId);
@@ -480,8 +513,56 @@ function sendError(session, message) {
   send(session, { type: "error", message });
 }
 
+function getPlayerProfileStore() {
+  return testPlayerProfileStore ?? getMongoPlayerProfileStore();
+}
+
+function parseSocketPlayerIdentity(value) {
+  try {
+    return parsePlayerIdentity(value);
+  } catch {
+    return null;
+  }
+}
+
+function validateProfileBattleLoadout(profile) {
+  const deckIds = getProfileCardIds(profile.deckIds);
+  const collectionIds = getProfileCardIds(profile.ownedCardIds);
+  const duplicateDeckIds = duplicateValues(deckIds);
+
+  if (duplicateDeckIds.length > 0) {
+    return { error: `Saved deck contains duplicate card ids: ${duplicateDeckIds.join(", ")}` };
+  }
+
+  const deckError = validateKnownCardIds(deckIds, "saved deck");
+  if (deckError) {
+    return { error: deckError };
+  }
+
+  const collectionError = validateKnownCardIds(collectionIds, "owned collection");
+  if (collectionError) {
+    return { error: collectionError };
+  }
+
+  if (deckIds.length < MIN_DECK_SIZE) {
+    return { error: `Saved deck must contain at least ${MIN_DECK_SIZE} cards.` };
+  }
+
+  const missingOwnedIds = getMissingCollectionDeckIds(deckIds, collectionIds);
+  if (missingOwnedIds.length > 0) {
+    return { error: `Saved deck contains non-owned card ids: ${missingOwnedIds.join(", ")}` };
+  }
+
+  return { deckIds, collectionIds };
+}
+
 function isOpen(ws) {
   return ws && ws.readyState === 1;
+}
+
+function getProfileCardIds(value) {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item) => typeof item === "string" && item.length > 0);
 }
 
 function sanitizeStringArray(value) {
@@ -498,6 +579,18 @@ function validateKnownCardIds(cardIds, source) {
 function getMissingCollectionDeckIds(deckIds, collectionIds) {
   const collection = new Set(collectionIds);
   return deckIds.filter((cardId) => !collection.has(cardId));
+}
+
+function duplicateValues(values) {
+  const seen = new Set();
+  const duplicates = new Set();
+
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+
+  return [...duplicates];
 }
 
 function sanitizeMove(value) {
@@ -595,6 +688,101 @@ function shuffle(items) {
 
 function createId(prefix) {
   return `${prefix}_${crypto.randomUUID().replaceAll("-", "").slice(0, 18)}`;
+}
+
+function handleTestProfileRequest(request, response) {
+  const url = new URL(request.url || "/", `http://${request.headers.host || "localhost"}`);
+  if (url.pathname !== "/__test/player-profile") return false;
+
+  if (!testPlayerProfileStore) {
+    response.statusCode = 404;
+    response.end("Not found.");
+    return true;
+  }
+
+  if (request.method !== "POST") {
+    response.statusCode = 405;
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify({ error: "method_not_allowed" }));
+    return true;
+  }
+
+  readJsonRequest(request)
+    .then((body) => {
+      const identity = parsePlayerIdentity(body.identity);
+      const seededProfile = testPlayerProfileStore.seedProfile({
+        id: sanitizeShortString(body.id, 128) || createId("test_player"),
+        identity,
+        ownedCardIds: getProfileCardIds(body.ownedCardIds),
+        deckIds: getProfileCardIds(body.deckIds),
+        starterFreeBoostersRemaining: Number.isInteger(body.starterFreeBoostersRemaining)
+          ? Math.max(0, body.starterFreeBoostersRemaining)
+          : 0,
+        openedBoosterIds: getProfileCardIds(body.openedBoosterIds),
+      });
+
+      response.statusCode = 200;
+      response.setHeader("cache-control", "no-store");
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ player: seededProfile }));
+    })
+    .catch((error) => {
+      response.statusCode = 400;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ error: "invalid_test_profile", message: error.message }));
+    });
+
+  return true;
+}
+
+function readJsonRequest(request) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      raw += chunk;
+      if (raw.length > 64_000) {
+        reject(new Error("request body is too large."));
+        request.destroy();
+      }
+    });
+    request.on("end", () => {
+      try {
+        resolve(raw ? JSON.parse(raw) : {});
+      } catch {
+        reject(new Error("request body must be valid JSON."));
+      }
+    });
+    request.on("error", reject);
+  });
+}
+
+function createMemoryPlayerProfileStore() {
+  const profiles = [];
+
+  return {
+    async findOrCreateByIdentity(identity) {
+      const existing = profiles.find((profile) => isSamePlayerIdentity(profile.identity, identity));
+      if (existing) return existing;
+
+      const profile = createNewStoredPlayerProfile(createId("test_player"), identity);
+      profiles.push(profile);
+      return profile;
+    },
+    seedProfile(profile) {
+      const nextProfile = {
+        ...createNewStoredPlayerProfile(profile.id, profile.identity),
+        ...profile,
+      };
+      const existingIndex = profiles.findIndex((item) => isSamePlayerIdentity(item.identity, nextProfile.identity));
+
+      if (existingIndex >= 0) profiles[existingIndex] = nextProfile;
+      else profiles.push(nextProfile);
+
+      return nextProfile;
+    },
+  };
 }
 
 function getCliValue(name) {

--- a/src/features/battle/ui/BattleGame.tsx
+++ b/src/features/battle/ui/BattleGame.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { PlayerIdentity } from "@/features/player/profile/types";
 import { cn } from "@/shared/lib/cn";
 import type { TelegramPlayer } from "@/shared/lib/telegram";
 import { cards } from "../model/cards";
@@ -28,6 +29,7 @@ import { SelectionOverlay } from "./components/SelectionOverlay";
 type BattleGameProps = {
   playerCollectionIds?: string[];
   playerDeckIds?: string[];
+  playerIdentity?: PlayerIdentity;
   playerName?: string;
   telegramPlayer?: TelegramPlayer;
   mode?: "ai" | "human";
@@ -103,7 +105,7 @@ type HumanForfeitMessage = HumanSocketMessage & {
   reason?: string;
 };
 
-export function BattleGame({ playerCollectionIds, playerDeckIds, playerName, telegramPlayer, mode = "ai", onOpenCollection }: BattleGameProps = {}) {
+export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity, playerName, telegramPlayer, mode = "ai", onOpenCollection }: BattleGameProps = {}) {
   const isHumanMatch = mode === "human";
   const initialGame = useMemo(
     () => createInitialGame({ playerCollectionIds, playerDeckIds, playerName }),
@@ -165,6 +167,7 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerName, tel
         type: "join_human",
         deckIds: playerDeckIds,
         collectionIds: playerCollectionIds,
+        identity: playerIdentity,
         user: telegramPlayer,
       });
     });
@@ -202,7 +205,7 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerName, tel
       socket.close();
       if (socketRef.current === socket) socketRef.current = null;
     };
-  }, [isHumanMatch, playerCollectionIds, playerDeckIds, telegramPlayer]);
+  }, [isHumanMatch, playerCollectionIds, playerDeckIds, playerIdentity, telegramPlayer]);
 
   const selected = getSelectedCard(game.player, selectedId) ?? game.player.hand[0];
   const boostCost = damageBoost ? DAMAGE_BOOST_COST : 0;
@@ -632,6 +635,7 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerName, tel
       type: "join_human",
       deckIds: playerDeckIds,
       collectionIds: playerCollectionIds,
+      identity: playerIdentity,
       user: telegramPlayer,
     });
   }

--- a/src/features/battle/ui/RealtimeBattleGame.tsx
+++ b/src/features/battle/ui/RealtimeBattleGame.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import type { TelegramPlayer } from "@/shared/lib/telegram";
+import type { PlayerIdentity } from "@/features/player/profile/types";
 import { BattleGame } from "./BattleGame";
 
 type RealtimeBattleGameProps = {
   playerCollectionIds: string[];
   playerDeckIds: string[];
+  playerIdentity?: PlayerIdentity;
   playerName?: string;
   telegramPlayer?: TelegramPlayer;
   onOpenCollection: () => void;
@@ -14,6 +16,7 @@ type RealtimeBattleGameProps = {
 export function RealtimeBattleGame({
   playerCollectionIds,
   playerDeckIds,
+  playerIdentity,
   playerName,
   telegramPlayer,
   onOpenCollection,
@@ -22,6 +25,7 @@ export function RealtimeBattleGame({
     <BattleGame
       playerCollectionIds={playerCollectionIds}
       playerDeckIds={playerDeckIds}
+      playerIdentity={playerIdentity}
       playerName={playerName}
       telegramPlayer={telegramPlayer}
       mode="human"

--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -242,6 +242,7 @@ export function GameRoot() {
           <RealtimeBattleGame
             playerCollectionIds={ownedCardIds}
             playerDeckIds={deckIds}
+            playerIdentity={playerIdentity ?? undefined}
             playerName={playerName}
             telegramPlayer={telegramPlayer}
             onOpenCollection={() => setScreen("collection")}

--- a/tests/fixtures/playerProfile.ts
+++ b/tests/fixtures/playerProfile.ts
@@ -2,6 +2,7 @@ import type { Page, Route } from "@playwright/test";
 import { getBoosterCatalogForPlayer } from "../../src/features/boosters/catalog";
 import type { PlayerIdentity } from "../../src/features/player/profile/types";
 
+const GUEST_ID_STORAGE_KEY = "nexus:player-guest-id:v1";
 export const PROFILE_DECK_IDS = [
   "dahack-1645",
   "dahack-110",
@@ -29,11 +30,23 @@ type MockDeckReadyProfileOptions = Partial<TestPlayerProfileInput> & {
 };
 
 export async function mockDeckReadyProfile(page: Page, options: MockDeckReadyProfileOptions = {}) {
+  const defaultIdentity: PlayerIdentity = options.identity ?? { mode: "guest", guestId: "guest-deck-ready-e2e" };
+  const initialProfile = createTestProfileInput(options, defaultIdentity);
   let profile: TestPlayerProfileInput | undefined;
+
+  if (defaultIdentity.mode === "guest") {
+    await page.addInitScript(
+      ({ key, value }) => {
+        window.localStorage.setItem(key, value);
+      },
+      { key: GUEST_ID_STORAGE_KEY, value: defaultIdentity.guestId },
+    );
+  }
+  await seedServerPlayerProfile(page, initialProfile);
 
   await page.route("**/api/player/deck", async (route) => {
     const requestBody = route.request().postDataJSON() as { identity?: PlayerIdentity; deckIds?: string[] };
-    const identity = options.identity ?? requestBody.identity ?? profile?.identity ?? { mode: "guest", guestId: "guest-deck-ready-e2e" };
+    const identity = options.identity ?? requestBody.identity ?? profile?.identity ?? defaultIdentity;
     profile = {
       id: options.id ?? profile?.id ?? "player-deck-ready-e2e",
       identity,
@@ -45,12 +58,13 @@ export async function mockDeckReadyProfile(page: Page, options: MockDeckReadyPro
     const handled = await options.onDeckSave?.(route, profile);
     if (handled === false) return;
 
+    await seedServerPlayerProfile(page, profile);
     await fulfillPlayerProfile(route, profile);
   });
 
   await page.route("**/api/player", async (route) => {
     const requestBody = route.request().postDataJSON() as { identity?: PlayerIdentity };
-    const identity = options.identity ?? requestBody.identity ?? { mode: "guest", guestId: "guest-deck-ready-e2e" };
+    const identity = options.identity ?? requestBody.identity ?? defaultIdentity;
 
     profile = {
       id: options.id ?? profile?.id ?? "player-deck-ready-e2e",
@@ -60,6 +74,7 @@ export async function mockDeckReadyProfile(page: Page, options: MockDeckReadyPro
       starterFreeBoostersRemaining: options.starterFreeBoostersRemaining ?? profile?.starterFreeBoostersRemaining ?? 0,
       openedBoosterIds: options.openedBoosterIds ?? profile?.openedBoosterIds ?? ["neon-breach", "factory-shift"],
     };
+    await seedServerPlayerProfile(page, profile);
     await fulfillPlayerProfile(route, profile);
   });
 }
@@ -102,4 +117,25 @@ function createPlayerProfileBody(profile: TestPlayerProfileInput) {
       completed: collectionReady && deckReady && profile.starterFreeBoostersRemaining === 0,
     },
   };
+}
+
+function createTestProfileInput(options: MockDeckReadyProfileOptions, identity: PlayerIdentity): TestPlayerProfileInput {
+  return {
+    id: options.id ?? "player-deck-ready-e2e",
+    identity,
+    ownedCardIds: options.ownedCardIds ?? PROFILE_OWNED_CARD_IDS,
+    deckIds: options.deckIds ?? PROFILE_DECK_IDS,
+    starterFreeBoostersRemaining: options.starterFreeBoostersRemaining ?? 0,
+    openedBoosterIds: options.openedBoosterIds ?? ["neon-breach", "factory-shift"],
+  };
+}
+
+export async function seedServerPlayerProfile(page: Page, profile: TestPlayerProfileInput) {
+  const response = await page.request.post("/__test/player-profile", {
+    data: profile,
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Failed to seed server player profile: ${response.status()} ${await response.text()}`);
+  }
 }

--- a/tests/realtime.spec.ts
+++ b/tests/realtime.spec.ts
@@ -1,53 +1,83 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
 import { cards } from "../src/features/battle/model/cards";
+import type { PlayerIdentity } from "../src/features/player/profile/types";
 import { mockDeckReadyProfile, PROFILE_DECK_IDS } from "./fixtures/playerProfile";
 
 const PROTOCOL_OWNED_COLLECTION_IDS = cards.slice(0, 10).map((card) => card.id);
 const PROTOCOL_OWNED_DECK_IDS = PROTOCOL_OWNED_COLLECTION_IDS.slice(0, 9);
 
-test("pairs two tabs and resolves the first human round", async ({ context, page }) => {
-  const first = page;
-  const second = await context.newPage();
-  await mockDeckReadyProfile(first);
-  await mockDeckReadyProfile(second);
+test("pairs two tabs and resolves the first human round", async ({ baseURL, browser }) => {
+  const firstContext = await browser.newContext();
+  const secondContext = await browser.newContext();
+  const first = await firstContext.newPage();
+  const second = await secondContext.newPage();
 
-  await first.goto("/");
-  await second.goto("/");
+  try {
+    await mockDeckReadyProfile(first, { identity: testIdentity("ui-a") });
+    await mockDeckReadyProfile(second, { identity: testIdentity("ui-b") });
 
-  await expect(first.getByTestId("player-profile-shell")).toHaveAttribute("data-deck-source", "profile", { timeout: 15_000 });
-  await expect(second.getByTestId("player-profile-shell")).toHaveAttribute("data-deck-source", "profile", { timeout: 15_000 });
-  await expect(first.getByTestId("play-human-match")).toBeEnabled({ timeout: 15_000 });
-  await expect(second.getByTestId("play-human-match")).toBeEnabled({ timeout: 15_000 });
+    await first.goto(baseURL ?? "/");
+    await second.goto(baseURL ?? "/");
 
-  await first.getByTestId("play-human-match").click();
-  await second.getByTestId("play-human-match").click();
+    await expect(first.getByTestId("player-profile-shell")).toHaveAttribute("data-deck-source", "profile", { timeout: 15_000 });
+    await expect(second.getByTestId("player-profile-shell")).toHaveAttribute("data-deck-source", "profile", { timeout: 15_000 });
+    await expect(first.getByTestId("play-human-match")).toBeEnabled({ timeout: 15_000 });
+    await expect(second.getByTestId("play-human-match")).toBeEnabled({ timeout: 15_000 });
 
-  await expect(first.getByTestId("round-status")).toBeVisible({ timeout: 12_000 });
-  await expect(second.getByTestId("round-status")).toBeVisible({ timeout: 12_000 });
-  await expectPlayerHandToUseDeck(first, PROFILE_DECK_IDS);
-  await expectPlayerHandToUseDeck(second, PROFILE_DECK_IDS);
+    await Promise.all([
+      first.getByTestId("play-human-match").click(),
+      second.getByTestId("play-human-match").click(),
+    ]);
 
-  const firstMover = await resolveFirstMover(first, second);
-  const secondMover = firstMover === first ? second : first;
+    await expect(first.getByTestId("round-status")).toBeVisible({ timeout: 20_000 });
+    await expect(second.getByTestId("round-status")).toBeVisible({ timeout: 20_000 });
+    await expectPlayerHandToUseDeck(first, PROFILE_DECK_IDS);
+    await expectPlayerHandToUseDeck(second, PROFILE_DECK_IDS);
 
-  const firstMoverCardId = await pickFirstCard(firstMover);
-  await expect(secondMover.getByTestId("round-status")).toBeVisible({ timeout: 8_000 });
+    const firstMover = await resolveFirstMover(first, second);
+    const secondMover = firstMover === first ? second : first;
 
-  await pickFirstCard(secondMover, { knownEnemyCard: true, hiddenEnemyEnergy: true });
+    const firstMoverCardId = await pickFirstCard(firstMover);
+    await expect(secondMover.getByTestId("round-status")).toBeVisible({ timeout: 8_000 });
 
-  await expect(first.getByTestId("battle-overlay")).toHaveAttribute("data-phase", "battle_intro", { timeout: 8_000 });
-  await expect(second.getByTestId("battle-overlay")).toHaveAttribute("data-phase", "battle_intro", { timeout: 8_000 });
-  await expect(firstMover.getByTestId("battle-overlay")).toBeHidden({ timeout: 24_000 });
-  await expect(firstMover.getByTestId(`player-card-${firstMoverCardId}`)).toHaveClass(/opacity-35/, { timeout: 12_000 });
+    await pickFirstCard(secondMover, { knownEnemyCard: true, hiddenEnemyEnergy: true });
 
-  await second.close();
+    await expect(first.getByTestId("battle-overlay")).toHaveAttribute("data-phase", "battle_intro", { timeout: 8_000 });
+    await expect(second.getByTestId("battle-overlay")).toHaveAttribute("data-phase", "battle_intro", { timeout: 8_000 });
+    await expect(firstMover.getByTestId("battle-overlay")).toBeHidden({ timeout: 24_000 });
+    await expect(firstMover.getByTestId(`player-card-${firstMoverCardId}`)).toHaveClass(/opacity-35/, { timeout: 12_000 });
+  } finally {
+    await firstContext.close();
+    await secondContext.close();
+  }
 });
 
-test("forfeits the active PvP player when their turn times out", async ({ baseURL }) => {
+test("matches direct PvP clients with saved profile decks", async ({ baseURL, request }) => {
   const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
-  const deckIds = PROTOCOL_OWNED_DECK_IDS;
-  const first = await connectRealtimeClient(wsUrl, "Timer A", deckIds);
-  const second = await connectRealtimeClient(wsUrl, "Timer B", deckIds);
+  const firstIdentity = testIdentity("protocol-valid-a");
+  const secondIdentity = testIdentity("protocol-valid-b");
+  const firstProfile = await seedRealtimeProfile(request, firstIdentity);
+  const secondProfile = await seedRealtimeProfile(request, secondIdentity);
+  const first = await connectRealtimeClient(wsUrl, "Profile A", firstProfile.deckIds, { identity: firstIdentity });
+  const second = await connectRealtimeClient(wsUrl, "Profile B", secondProfile.deckIds, { identity: secondIdentity });
+
+  const firstReady = await first.waitFor("match_ready");
+  const secondReady = await second.waitFor("match_ready");
+  expectMatchReadyPlayerLoadout(firstReady, firstProfile.deckIds, firstProfile.ownedCardIds);
+  expectMatchReadyPlayerLoadout(secondReady, secondProfile.deckIds, secondProfile.ownedCardIds);
+
+  first.close();
+  second.close();
+});
+
+test("forfeits the active PvP player when their turn times out", async ({ baseURL, request }) => {
+  const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
+  const firstIdentity = testIdentity("timer-a");
+  const secondIdentity = testIdentity("timer-b");
+  await seedRealtimeProfile(request, firstIdentity);
+  await seedRealtimeProfile(request, secondIdentity);
+  const first = await connectRealtimeClient(wsUrl, "Timer A", PROTOCOL_OWNED_DECK_IDS, { identity: firstIdentity });
+  const second = await connectRealtimeClient(wsUrl, "Timer B", PROTOCOL_OWNED_DECK_IDS, { identity: secondIdentity });
 
   const firstReady = await first.waitFor("match_ready");
   const secondReady = await second.waitFor("match_ready");
@@ -73,11 +103,15 @@ test("forfeits the active PvP player when their turn times out", async ({ baseUR
   second.close();
 });
 
-test("does not leak the first PvP mover energy before reveal", async ({ baseURL }) => {
+test("does not leak the first PvP mover energy before reveal", async ({ baseURL, request }) => {
   const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
+  const firstIdentity = testIdentity("secret-a");
+  const secondIdentity = testIdentity("secret-b");
+  await seedRealtimeProfile(request, firstIdentity);
+  await seedRealtimeProfile(request, secondIdentity);
   const deckIds = PROTOCOL_OWNED_DECK_IDS;
-  const first = await connectRealtimeClient(wsUrl, "Secret A", deckIds);
-  const second = await connectRealtimeClient(wsUrl, "Secret B", deckIds);
+  const first = await connectRealtimeClient(wsUrl, "Secret A", deckIds, { identity: firstIdentity });
+  const second = await connectRealtimeClient(wsUrl, "Secret B", deckIds, { identity: secondIdentity });
 
   const firstReady = await first.waitFor("match_ready");
   const secondReady = await second.waitFor("match_ready");
@@ -109,18 +143,23 @@ test("does not leak the first PvP mover energy before reveal", async ({ baseURL 
   second.close();
 });
 
-test("rejects removed PvP card ids before matchmaking", async ({ baseURL }) => {
+test("rejects removed PvP card ids before matchmaking", async ({ baseURL, request }) => {
   const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
   const deckIds = PROTOCOL_OWNED_DECK_IDS;
   const staleDeckIds = ["corr-1285", ...deckIds.slice(0, 8)];
-  const staleDeckClient = await connectRealtimeClient(wsUrl, "Stale Deck", staleDeckIds);
+  const staleDeckIdentity = testIdentity("stale-deck");
+  await seedRealtimeProfile(request, staleDeckIdentity);
+  const staleDeckClient = await connectRealtimeClient(wsUrl, "Stale Deck", staleDeckIds, { identity: staleDeckIdentity });
 
   const staleDeckError = await staleDeckClient.waitFor("error", { timeoutMs: 2_000 });
   expect(staleDeckError.message).toBe("Unknown deck card ids: corr-1285");
   await expectNoRealtimeMessage(staleDeckClient, "queued");
   await expectNoRealtimeMessage(staleDeckClient, "match_ready");
 
+  const staleCollectionIdentity = testIdentity("stale-collection");
+  await seedRealtimeProfile(request, staleCollectionIdentity);
   const staleCollectionClient = await connectRealtimeClient(wsUrl, "Stale Collection", deckIds, {
+    identity: staleCollectionIdentity,
     collectionIds: [...deckIds, "corr-1285"],
   });
 
@@ -129,7 +168,9 @@ test("rejects removed PvP card ids before matchmaking", async ({ baseURL }) => {
   await expectNoRealtimeMessage(staleCollectionClient, "queued");
   await expectNoRealtimeMessage(staleCollectionClient, "match_ready");
 
-  const validClient = await connectRealtimeClient(wsUrl, "Valid", deckIds);
+  const validIdentity = testIdentity("valid-after-stale");
+  await seedRealtimeProfile(request, validIdentity);
+  const validClient = await connectRealtimeClient(wsUrl, "Valid", deckIds, { identity: validIdentity });
   await expect(validClient.waitFor("queued", { timeoutMs: 2_000 })).resolves.toMatchObject({ type: "queued" });
   await expectNoRealtimeMessage(validClient, "match_ready");
 
@@ -138,10 +179,12 @@ test("rejects removed PvP card ids before matchmaking", async ({ baseURL }) => {
   validClient.close();
 });
 
-test("rejects PvP decks below the nine-card minimum", async ({ baseURL }) => {
+test("rejects PvP decks below the nine-card minimum", async ({ baseURL, request }) => {
   const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
   const shortDeckIds = PROTOCOL_OWNED_DECK_IDS.slice(0, 8);
-  const client = await connectRealtimeClient(wsUrl, "Short Deck", shortDeckIds);
+  const identity = testIdentity("short-client-deck");
+  await seedRealtimeProfile(request, identity);
+  const client = await connectRealtimeClient(wsUrl, "Short Deck", shortDeckIds, { identity });
 
   const error = await client.waitFor("error", { timeoutMs: 2_000 });
   expect(error.message).toBe("Deck must contain at least 9 cards.");
@@ -151,11 +194,14 @@ test("rejects PvP decks below the nine-card minimum", async ({ baseURL }) => {
   client.close();
 });
 
-test("rejects PvP deck cards outside the provided collection", async ({ baseURL }) => {
+test("rejects PvP deck cards outside the provided collection", async ({ baseURL, request }) => {
   const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
   const deckIds = PROTOCOL_OWNED_DECK_IDS;
   const missingCollectionCardId = deckIds[8];
+  const identity = testIdentity("client-collection-miss");
+  await seedRealtimeProfile(request, identity);
   const client = await connectRealtimeClient(wsUrl, "Non Owned Deck", deckIds, {
+    identity,
     collectionIds: deckIds.slice(0, 8),
   });
 
@@ -165,6 +211,72 @@ test("rejects PvP deck cards outside the provided collection", async ({ baseURL 
   await expectNoRealtimeMessage(client, "match_ready");
 
   client.close();
+});
+
+test("rejects direct PvP clients that try to bypass the saved profile deck", async ({ baseURL, request }) => {
+  const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
+  const identity = testIdentity("bypass");
+  const bypassDeckIds = cards
+    .filter((card) => card.clan === "Toyz")
+    .slice(0, 9)
+    .map((card) => card.id);
+  await seedRealtimeProfile(request, identity);
+
+  const client = await connectRealtimeClient(wsUrl, "Bypass", bypassDeckIds, {
+    identity,
+    collectionIds: bypassDeckIds,
+  });
+
+  const error = await client.waitFor("error", { timeoutMs: 2_000 });
+  expect(error.message).toBe("PvP deck must match the saved profile deck.");
+  await expectNoRealtimeMessage(client, "queued");
+  await expectNoRealtimeMessage(client, "match_ready");
+
+  client.close();
+});
+
+test("rejects invalid saved profile decks before PvP matchmaking", async ({ baseURL, request }) => {
+  const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
+  const nonOwnedCardId = PROTOCOL_OWNED_COLLECTION_IDS[9];
+  const cases = [
+    {
+      name: "empty",
+      profile: { ownedCardIds: PROTOCOL_OWNED_COLLECTION_IDS, deckIds: [] },
+      message: "Saved deck must contain at least 9 cards.",
+    },
+    {
+      name: "short",
+      profile: { ownedCardIds: PROTOCOL_OWNED_COLLECTION_IDS, deckIds: PROTOCOL_OWNED_DECK_IDS.slice(0, 8) },
+      message: "Saved deck must contain at least 9 cards.",
+    },
+    {
+      name: "duplicate",
+      profile: { ownedCardIds: PROTOCOL_OWNED_COLLECTION_IDS, deckIds: [...PROTOCOL_OWNED_DECK_IDS.slice(0, 8), PROTOCOL_OWNED_DECK_IDS[0]] },
+      message: `Saved deck contains duplicate card ids: ${PROTOCOL_OWNED_DECK_IDS[0]}`,
+    },
+    {
+      name: "unknown",
+      profile: { ownedCardIds: PROTOCOL_OWNED_COLLECTION_IDS, deckIds: [...PROTOCOL_OWNED_DECK_IDS.slice(0, 8), "corr-1285"] },
+      message: "Unknown saved deck card ids: corr-1285",
+    },
+    {
+      name: "non-owned",
+      profile: { ownedCardIds: PROTOCOL_OWNED_DECK_IDS, deckIds: [...PROTOCOL_OWNED_DECK_IDS.slice(0, 8), nonOwnedCardId] },
+      message: `Saved deck contains non-owned card ids: ${nonOwnedCardId}`,
+    },
+  ];
+
+  for (const testCase of cases) {
+    const identity = testIdentity(`saved-${testCase.name}`);
+    await seedRealtimeProfile(request, identity, testCase.profile);
+    const client = await connectRealtimeClient(wsUrl, `Saved ${testCase.name}`, undefined, { identity });
+
+    const error = await client.waitFor("error", { timeoutMs: 2_000 });
+    expect(error.message).toBe(testCase.message);
+    await expectNoRealtimeMessage(client, "queued");
+    await expectNoRealtimeMessage(client, "match_ready");
+    client.close();
+  }
 });
 
 async function resolveFirstMover(first: Page, second: Page) {
@@ -236,7 +348,12 @@ type RealtimeMessage = {
 
 type RealtimeClient = Awaited<ReturnType<typeof connectRealtimeClient>>;
 
-async function connectRealtimeClient(url: string, name: string, deckIds: string[], options: { collectionIds?: string[] } = {}) {
+async function connectRealtimeClient(
+  url: string,
+  name: string,
+  deckIds: string[] | undefined,
+  options: { collectionIds?: string[]; identity?: PlayerIdentity } = {},
+) {
   const socket = new WebSocket(url);
   const messages: RealtimeMessage[] = [];
   const waiters = new Map<string, ((message: RealtimeMessage) => void)[]>();
@@ -257,8 +374,9 @@ async function connectRealtimeClient(url: string, name: string, deckIds: string[
   socket.send(
     JSON.stringify({
       type: "join_human",
-      deckIds,
-      collectionIds: options.collectionIds ?? deckIds,
+      ...(deckIds ? { deckIds } : {}),
+      ...(options.collectionIds ? { collectionIds: options.collectionIds } : deckIds ? { collectionIds: deckIds } : {}),
+      identity: options.identity,
       user: { name },
     }),
   );
@@ -299,6 +417,47 @@ async function connectRealtimeClient(url: string, name: string, deckIds: string[
       });
     },
   };
+}
+
+function testIdentity(slug: string): PlayerIdentity {
+  return {
+    mode: "guest",
+    guestId: `guest-ws-${slug}`,
+  };
+}
+
+async function seedRealtimeProfile(
+  request: APIRequestContext,
+  identity: PlayerIdentity,
+  overrides: Partial<{
+    ownedCardIds: string[];
+    deckIds: string[];
+    starterFreeBoostersRemaining: number;
+    openedBoosterIds: string[];
+  }> = {},
+) {
+  const profile = {
+    id: `player-${identity.mode === "guest" ? identity.guestId : identity.telegramId}`,
+    identity,
+    ownedCardIds: overrides.ownedCardIds ?? PROTOCOL_OWNED_COLLECTION_IDS,
+    deckIds: overrides.deckIds ?? PROTOCOL_OWNED_DECK_IDS,
+    starterFreeBoostersRemaining: overrides.starterFreeBoostersRemaining ?? 0,
+    openedBoosterIds: overrides.openedBoosterIds ?? ["neon-breach", "factory-shift"],
+  };
+  const response = await request.post("/__test/player-profile", {
+    data: profile,
+  });
+
+  expect(response.ok()).toBe(true);
+  return profile;
+}
+
+function expectMatchReadyPlayerLoadout(message: RealtimeMessage, deckIds: string[], collectionIds: string[]) {
+  const payload = message as unknown as { playerId: string; players: Record<string, { deckIds?: string[]; collectionIds?: string[] }> };
+  const player = payload.players[payload.playerId];
+
+  expect(player.deckIds).toEqual(deckIds);
+  expect(player.collectionIds).toEqual(collectionIds);
 }
 
 async function expectNoRealtimeMessage(client: RealtimeClient, type: string) {

--- a/tests/realtime.spec.ts
+++ b/tests/realtime.spec.ts
@@ -70,6 +70,27 @@ test("matches direct PvP clients with saved profile decks", async ({ baseURL, re
   second.close();
 });
 
+test("matches valid saved decks while filtering stale owned cards out of PvP collection", async ({ baseURL, request }) => {
+  const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
+  const staleOwnedIdentity = testIdentity("stale-owned-valid-deck");
+  const opponentIdentity = testIdentity("stale-owned-opponent");
+  const staleOwnedProfile = await seedRealtimeProfile(request, staleOwnedIdentity, {
+    ownedCardIds: [...PROTOCOL_OWNED_COLLECTION_IDS, "corr-1285"],
+    deckIds: PROTOCOL_OWNED_DECK_IDS,
+  });
+  const opponentProfile = await seedRealtimeProfile(request, opponentIdentity);
+  const staleOwnedClient = await connectRealtimeClient(wsUrl, "Stale Owned", staleOwnedProfile.deckIds, { identity: staleOwnedIdentity });
+  const opponentClient = await connectRealtimeClient(wsUrl, "Opponent", opponentProfile.deckIds, { identity: opponentIdentity });
+
+  const staleOwnedReady = await staleOwnedClient.waitFor("match_ready");
+  const opponentReady = await opponentClient.waitFor("match_ready");
+  expectMatchReadyPlayerLoadout(staleOwnedReady, staleOwnedProfile.deckIds, PROTOCOL_OWNED_COLLECTION_IDS);
+  expectMatchReadyPlayerLoadout(opponentReady, opponentProfile.deckIds, opponentProfile.ownedCardIds);
+
+  staleOwnedClient.close();
+  opponentClient.close();
+});
+
 test("forfeits the active PvP player when their turn times out", async ({ baseURL, request }) => {
   const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
   const firstIdentity = testIdentity("timer-a");


### PR DESCRIPTION
## Summary
- Send player identity with PvP socket joins from the saved-profile battle flow.
- Validate `/ws` `join_human` against the server-loaded player profile instead of trusting client-supplied ownership data.
- Derive queued PvP deck/collection from the saved profile deck and owned cards; reject missing, short, duplicate, unknown, non-owned, and mismatched direct socket joins.
- Add a test-only server profile fixture for Playwright so production/default remains Mongo-backed while e2e can seed deterministic WS identities.

## Verification
- `bunx playwright test tests/realtime.spec.ts`
- `bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts`
- `bun run test:e2e`
- `bun run lint`
- `bun run build`
- `git diff --check`

## Notes
- Follow-up to merged #18 for the review blocker on server-side WS ownership validation.
- Parent: #1
- Issue: #8
