### PR TITLE
test: finalize booster onboarding QA docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See [docs/deploy.md](docs/deploy.md) for the Nginx WebSocket proxy block.
 
 ## Known Limitations
 
-Deck edits are saved through the player profile API and must use known, unique, owned cards with at least 9 cards. Legacy CloudStorage and `sessionStorage` deck keys are ignored without being deleted.
+MongoDB-backed player profiles are the source of truth for owned cards, starter booster history, and saved decks. Deck edits are saved through the player profile API and must use known, unique, owned cards with at least 9 cards. Legacy CloudStorage and `sessionStorage` deck keys may still exist in old clients, but they are ignored without being imported, merged, or deleted.
 
 Telegram profiles currently use the client-provided `Telegram.WebApp.initDataUnsafe.user.id` for MVP bootstrap. Server-side Telegram `initData` HMAC verification is intentionally deferred and should be added before treating Telegram identity as trusted.
 
@@ -55,7 +55,12 @@ Telegram profiles currently use the client-provided `Telegram.WebApp.initDataUns
 
 ```bash
 bun run lint
-bun run test:profile
+bun run test
+docker compose config --quiet
+MONGODB_URI=mongodb://external.example:27017/custom docker compose config --quiet
+bun run test:e2e -- tests/onboarding-reveal.spec.ts tests/data-regression.spec.ts
 bun run build
 bun run test:e2e
 ```
+
+See [docs/release-qa.md](docs/release-qa.md) for the booster onboarding release QA checklist.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -11,16 +11,36 @@ The app is prepared for two deployment paths:
 docker compose up -d --build
 ```
 
+Compose starts two services:
+
+- `mongo`: MongoDB 7 with the persistent `nexus_mongodb_data` volume.
+- `nexus-card-battle`: the production Node/Next.js/WebSocket server.
+
 Defaults:
 
 - Container port: `3000`
 - Host bind: `127.0.0.1:3010`
 - Override with `APP_HOST` and `APP_PORT`
+- App MongoDB URI: `mongodb://mongo:27017/nexus-card-battle`
+- Override the app database by setting `MONGODB_URI` before `docker compose up`
 
-Example:
+The app waits for the Compose MongoDB healthcheck before starting. When `MONGODB_URI` is not set in the shell, the app uses the in-Compose `mongo` hostname. To use an external MongoDB instance instead:
+
+```bash
+MONGODB_URI=mongodb://mongo.example.internal:27017/nexus-card-battle docker compose up -d --build
+```
+
+Port override example:
 
 ```bash
 APP_PORT=3025 docker compose up -d --build
+```
+
+Validate the Compose file without starting services:
+
+```bash
+docker compose config --quiet
+MONGODB_URI=mongodb://external.example:27017/custom docker compose config --quiet
 ```
 
 ## Nginx

--- a/docs/release-qa.md
+++ b/docs/release-qa.md
@@ -1,0 +1,36 @@
+# Booster Onboarding Release QA
+
+This checklist covers the owned-card booster onboarding release.
+
+## Acceptance Coverage
+
+- Fresh guest onboarding E2E: `tests/onboarding-reveal.spec.ts` covers first booster opening, reload with one opened booster, second booster opening, the ten-card deck-ready screen, collection edit entry, and AI battle entry from the saved starter deck.
+- Removed data/mechanics regression: `tests/data-regression.spec.ts` and `tests/boosterOpening.test.ts` assert that active data, default gameplay, starter boosters, and rendered starter onboarding UI do not expose `C.O.R.R.` or `copy-clan-bonus`.
+- Durable profile state: player profile and booster tests cover MongoDB-style profile ownership, starter booster history, duplicate/unknown deck rejection, and ignoring legacy deck payloads.
+- Docker Compose startup: `docker-compose.yml` starts the app plus MongoDB, persists MongoDB in `nexus_mongodb_data`, and supports `MONGODB_URI` override for external databases.
+
+## Verification Commands
+
+Run the narrow release checks:
+
+```bash
+bun run lint
+bun run test
+docker compose config --quiet
+MONGODB_URI=mongodb://external.example:27017/custom docker compose config --quiet
+bun run test:e2e -- tests/onboarding-reveal.spec.ts tests/data-regression.spec.ts
+```
+
+Run the broader release checks before shipping:
+
+```bash
+bun run build
+bun run test:e2e
+```
+
+## Residual Technical Debt
+
+- Telegram MVP identity is not server-validated yet. The client sends `Telegram.WebApp.initDataUnsafe.user.id`, and the server treats that Telegram id as profile identity input after shape validation. Add Telegram `initData` HMAC verification before this identity can be trusted for production-grade account ownership.
+- PvP WebSocket joins validate the submitted deck against the submitted collection ids. Loading profile ownership server-side for socket joins is a future hardening step.
+- Guest identity is browser-local and stored under `nexus:player-guest-id:v1`; clearing browser storage creates a new guest profile.
+- Legacy CloudStorage and `sessionStorage` deck values are intentionally ignored. MongoDB player profiles are the durable source of truth for owned cards, opened starter boosters, and saved decks.

--- a/tests/data-regression.spec.ts
+++ b/tests/data-regression.spec.ts
@@ -2,6 +2,9 @@ import { expect, test } from "@playwright/test";
 import { cards, sourceCards } from "../src/features/battle/model/cards";
 import { clanList, clans } from "../src/features/battle/model/clans";
 import { createCardCollection, createInitialGame, score } from "../src/features/battle/model/game";
+import { fulfillBoosterCatalog, fulfillPlayerProfile, type TestPlayerProfileInput } from "./fixtures/playerProfile";
+
+const GUEST_ID_STORAGE_KEY = "nexus:player-guest-id:v1";
 
 test("exports no C.O.R.R. clan, cards, or copy-clan-bonus effects", () => {
   const activeData = JSON.stringify({ cards, clanList, sourceCards });
@@ -34,4 +37,37 @@ test("all active cards can be scored without copy-clan-bonus support", () => {
   for (const card of cards) {
     expect(() => score(card, 0, true)).not.toThrow();
   }
+});
+
+test("starter onboarding UI does not render removed C.O.R.R. or copy-clan-bonus content", async ({ page }) => {
+  const guestId = "removed-data-ui-e2e";
+  const profile: TestPlayerProfileInput = {
+    id: "player-removed-data-ui-e2e",
+    identity: { mode: "guest", guestId },
+    ownedCardIds: [],
+    deckIds: [],
+    starterFreeBoostersRemaining: 2,
+    openedBoosterIds: [],
+  };
+
+  await page.addInitScript(
+    ({ key, value }) => {
+      window.localStorage.setItem(key, value);
+    },
+    { key: GUEST_ID_STORAGE_KEY, value: guestId },
+  );
+  await page.route("**/api/player", async (route) => {
+    await fulfillPlayerProfile(route, profile);
+  });
+  await page.route("**/api/boosters", async (route) => {
+    await fulfillBoosterCatalog(route, profile);
+  });
+
+  await page.goto("/");
+  await expect(page.getByTestId("starter-booster-catalog")).toBeVisible();
+  await expect(page.locator('[data-testid^="starter-booster-card-"]')).toHaveCount(12);
+
+  await expect(page.locator("body")).not.toContainText(/C\.O\.R\.R\.|copy-clan-bonus/i);
+  const bodyHtml = await page.locator("body").evaluate((element) => element.innerHTML);
+  expect(bodyHtml).not.toMatch(/C\.O\.R\.R\.|copy-clan-bonus|copyClan/);
 });

--- a/tests/onboarding-reveal.spec.ts
+++ b/tests/onboarding-reveal.spec.ts
@@ -21,7 +21,7 @@ type RevealProfileState = Pick<
   "ownedCardIds" | "deckIds" | "starterFreeBoostersRemaining" | "openedBoosterIds"
 >;
 
-test("opens two different starter boosters, reveals saved cards, and edits the ten-card deck-ready state", async ({ page }) => {
+test("opens two different starter boosters, survives reload, reaches deck ready, and enters battle", async ({ page }) => {
   expect(firstOpenedCards).toHaveLength(5);
   expect(secondOpenedCards).toHaveLength(5);
 
@@ -76,6 +76,11 @@ test("opens two different starter boosters, reveals saved cards, and edits the t
   await expect(page.locator('[data-testid^="deck-card-"]')).toHaveCount(10);
   await expect(page.getByTestId("play-selected-deck")).toBeEnabled();
   await expect(page.getByTestId("play-human-match")).toBeEnabled();
+
+  await page.getByTestId("play-selected-deck").click();
+  await expect(page.getByTestId("round-status")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator('[data-testid^="player-card-"]')).toHaveCount(4);
+  await expectPlayerHandToUseDeck(page, fullStarterDeckIds);
 });
 
 test("starts an AI battle from the ten-card starter deck-ready state", async ({ page }) => {


### PR DESCRIPTION
## Summary
- extend starter onboarding E2E to cover reload through battle entry
- add rendered UI regression coverage for removed C.O.R.R./copy-clan-bonus content
- document Docker Compose app+MongoDB startup, MONGODB_URI override, release QA commands, and residual identity debt

## Verification
- bun run lint
- bun run test
- docker compose config --quiet
- MONGODB_URI=mongodb://external.example:27017/custom docker compose config --quiet
- bun run test:e2e -- tests/onboarding-reveal.spec.ts tests/data-regression.spec.ts
- bun run build
- bun run test:e2e

Closes #9