### PR TITLE
fix(docker): include runtime sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN bun install --frozen-lockfile --production
 
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/src/features/battle/model ./src/features/battle/model
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/next.config.mjs ./next.config.mjs
 COPY --from=builder /app/server.js ./server.js
 

--- a/docs/release-qa.md
+++ b/docs/release-qa.md
@@ -10,6 +10,7 @@ This checklist covers the owned-card booster onboarding release.
 - PvP ownership enforcement: `tests/realtime.spec.ts` covers server-side saved-profile WebSocket joins, direct deck bypass rejection, invalid saved deck rejection, stale owned-card filtering, and matched players' deck/collection payloads sourced from the saved profile.
 - Collection deck ownership: `tests/collection-deck.spec.ts` covers owned-only deck editing, read-only base-card browsing for non-owned cards, and rollback after failed deck saves.
 - Docker Compose startup: `docker-compose.yml` starts the app plus MongoDB, persists MongoDB in `nexus_mongodb_data`, and supports `MONGODB_URI` override for external databases.
+- Docker runtime image smoke: the production image must include runtime `src` modules and `tsconfig.json` because `server.js` imports TypeScript model/profile modules directly.
 
 ## Verification Commands
 

--- a/docs/release-qa.md
+++ b/docs/release-qa.md
@@ -7,7 +7,8 @@ This checklist covers the owned-card booster onboarding release.
 - Fresh guest onboarding E2E: `tests/onboarding-reveal.spec.ts` covers first booster opening, reload with one opened booster, second booster opening, the ten-card deck-ready screen, collection edit entry, and AI battle entry from the saved starter deck.
 - Removed data/mechanics regression: `tests/data-regression.spec.ts` and `tests/boosterOpening.test.ts` assert that active data, default gameplay, starter boosters, and rendered starter onboarding UI do not expose `C.O.R.R.` or `copy-clan-bonus`.
 - Durable profile state: player profile and booster tests cover MongoDB-style profile ownership, starter booster history, duplicate/unknown deck rejection, and ignoring legacy deck payloads.
-- PvP ownership enforcement: `tests/realtime.spec.ts` covers saved-profile WebSocket joins, direct deck bypass rejection, invalid saved deck rejection, and filtering stale removed cards out of PvP collections.
+- PvP ownership enforcement: `tests/realtime.spec.ts` covers server-side saved-profile WebSocket joins, direct deck bypass rejection, invalid saved deck rejection, stale owned-card filtering, and matched players' deck/collection payloads sourced from the saved profile.
+- Collection deck ownership: `tests/collection-deck.spec.ts` covers owned-only deck editing, read-only base-card browsing for non-owned cards, and rollback after failed deck saves.
 - Docker Compose startup: `docker-compose.yml` starts the app plus MongoDB, persists MongoDB in `nexus_mongodb_data`, and supports `MONGODB_URI` override for external databases.
 
 ## Verification Commands
@@ -31,6 +32,6 @@ bun run test:e2e
 
 ## Residual Technical Debt
 
-- Telegram MVP identity is not server-validated yet. The client sends `Telegram.WebApp.initDataUnsafe.user.id`, and the server treats that Telegram id as profile identity input after shape validation. Add Telegram `initData` HMAC verification before this identity can be trusted for production-grade account ownership.
+- Telegram MVP identity is not server-validated yet. The client sends `Telegram.WebApp.initDataUnsafe.user.id`, and the server treats that Telegram id as profile identity input after shape validation. PvP socket joins load the saved profile server-side, but still rely on that unverified Telegram MVP identity until `initData` HMAC validation lands.
 - Guest identity is browser-local and stored under `nexus:player-guest-id:v1`; clearing browser storage creates a new guest profile.
 - Legacy CloudStorage and `sessionStorage` deck values are intentionally ignored. MongoDB player profiles are the durable source of truth for owned cards, opened starter boosters, and saved decks.


### PR DESCRIPTION
Parent #1

Post-merge final-audit hotfix for #8/#9. This is not a new product scope.

## Summary
- Copy the full `src` tree and `tsconfig.json` into the Docker runner image so custom `server.js` can resolve its runtime TypeScript imports and `@/*` aliases.
- Update release QA notes to reflect current server-side saved-profile PvP validation and collection/realtime coverage.

## Verification
- `docker compose config --quiet`
- `bun run lint`
- `bun run test`
- `bun run build`
- `docker build -t nexus-card-battle:hotfix-docker-qa .`
- Docker runtime smoke with `NEXUS_TEST_PROFILE_STORE=1`: container started, logged `Нексус server listening`, `GET /` returned 200, and `POST /__test/player-profile` returned a seeded profile JSON response.
