### PR TITLE
feat(profile): PvE XP, quadratic levels, level-up crystal bonus (slice 1/7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "bun server.js",
     "lint": "eslint",
-    "test": "bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts",
+    "test": "bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts",
     "test:profile": "bun test tests/playerProfile.test.ts",
     "test:e2e": "playwright test"
   },

--- a/server.js
+++ b/server.js
@@ -719,6 +719,12 @@ function handleTestProfileRequest(request, response) {
           ? Math.max(0, body.starterFreeBoostersRemaining)
           : 0,
         openedBoosterIds: getProfileCardIds(body.openedBoosterIds),
+        crystals: nonNegativeIntegerOrUndefined(body.crystals),
+        totalXp: nonNegativeIntegerOrUndefined(body.totalXp),
+        level: positiveIntegerOrUndefined(body.level),
+        wins: nonNegativeIntegerOrUndefined(body.wins),
+        losses: nonNegativeIntegerOrUndefined(body.losses),
+        draws: nonNegativeIntegerOrUndefined(body.draws),
       });
 
       response.statusCode = 200;
@@ -771,9 +777,13 @@ function createMemoryPlayerProfileStore() {
       return profile;
     },
     seedProfile(profile) {
+      const definedFields = {};
+      for (const [key, value] of Object.entries(profile)) {
+        if (value !== undefined) definedFields[key] = value;
+      }
       const nextProfile = {
         ...createNewStoredPlayerProfile(profile.id, profile.identity),
-        ...profile,
+        ...definedFields,
       };
       const existingIndex = profiles.findIndex((item) => isSamePlayerIdentity(item.identity, nextProfile.identity));
 
@@ -782,7 +792,35 @@ function createMemoryPlayerProfileStore() {
 
       return nextProfile;
     },
+    async applyMatchRewards(identity, rewards) {
+      const index = profiles.findIndex((profile) => isSamePlayerIdentity(profile.identity, identity));
+      if (index < 0) {
+        throw new Error("Player profile did not exist for match rewards apply.");
+      }
+
+      const current = profiles[index];
+      const counterField = rewards.result === "win" ? "wins" : rewards.result === "loss" ? "losses" : "draws";
+      const updated = {
+        ...current,
+        crystals: rewards.newTotals.crystals,
+        totalXp: rewards.newTotals.totalXp,
+        level: rewards.newTotals.level,
+        [counterField]: (current[counterField] ?? 0) + 1,
+      };
+      profiles[index] = updated;
+      return updated;
+    },
   };
+}
+
+function nonNegativeIntegerOrUndefined(value) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return undefined;
+  return value;
+}
+
+function positiveIntegerOrUndefined(value) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) return undefined;
+  return value;
 }
 
 function getCliValue(name) {

--- a/server.js
+++ b/server.js
@@ -6,10 +6,12 @@ const { WebSocketServer } = require("ws");
 const { cards } = require("./src/features/battle/model/cards.ts");
 const { getMongoPlayerProfileStore } = require("./src/features/player/profile/mongo.ts");
 const {
+  computeLevelFromXp,
   createNewStoredPlayerProfile,
   isSamePlayerIdentity,
   parsePlayerIdentity,
 } = require("./src/features/player/profile/types.ts");
+const { computeLevelUpBonusForRange } = require("./src/features/player/profile/progression.ts");
 
 const dev = process.argv.includes("--dev") || process.env.NODE_ENV === "development";
 const hostname = getCliValue("--hostname") || process.env.HOSTNAME || "0.0.0.0";
@@ -721,7 +723,6 @@ function handleTestProfileRequest(request, response) {
         openedBoosterIds: getProfileCardIds(body.openedBoosterIds),
         crystals: nonNegativeIntegerOrUndefined(body.crystals),
         totalXp: nonNegativeIntegerOrUndefined(body.totalXp),
-        level: positiveIntegerOrUndefined(body.level),
         wins: nonNegativeIntegerOrUndefined(body.wins),
         losses: nonNegativeIntegerOrUndefined(body.losses),
         draws: nonNegativeIntegerOrUndefined(body.draws),
@@ -800,26 +801,32 @@ function createMemoryPlayerProfileStore() {
 
       const current = profiles[index];
       const counterField = rewards.result === "win" ? "wins" : rewards.result === "loss" ? "losses" : "draws";
-      const updated = {
+
+      const afterIncrement = {
         ...current,
-        crystals: rewards.newTotals.crystals,
-        totalXp: rewards.newTotals.totalXp,
-        level: rewards.newTotals.level,
+        totalXp: current.totalXp + rewards.deltaXp,
+        crystals: current.crystals + rewards.matchCrystals,
         [counterField]: (current[counterField] ?? 0) + 1,
       };
-      profiles[index] = updated;
-      return updated;
+      profiles[index] = afterIncrement;
+
+      const xpBeforeMatch = Math.max(0, afterIncrement.totalXp - rewards.deltaXp);
+      const oldLevel = computeLevelFromXp(xpBeforeMatch).level;
+      const newLevel = computeLevelFromXp(afterIncrement.totalXp).level;
+      if (newLevel <= oldLevel) return afterIncrement;
+
+      const bonus = computeLevelUpBonusForRange(oldLevel, newLevel);
+      if (bonus <= 0) return afterIncrement;
+
+      const afterBonus = { ...afterIncrement, crystals: afterIncrement.crystals + bonus };
+      profiles[index] = afterBonus;
+      return afterBonus;
     },
   };
 }
 
 function nonNegativeIntegerOrUndefined(value) {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return undefined;
-  return value;
-}
-
-function positiveIntegerOrUndefined(value) {
-  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) return undefined;
   return value;
 }
 

--- a/src/app/api/player/match-finished/route.ts
+++ b/src/app/api/player/match-finished/route.ts
@@ -1,0 +1,8 @@
+import { handlePlayerMatchFinishedPost } from "@/features/player/profile/api";
+import { getMongoPlayerProfileStore } from "@/features/player/profile/mongo";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  return handlePlayerMatchFinishedPost(request, getMongoPlayerProfileStore());
+}

--- a/src/features/battle/model/domain/match.ts
+++ b/src/features/battle/model/domain/match.ts
@@ -93,9 +93,6 @@ export function buildRewards(player: Fighter, result: MatchResult): RewardSummar
       xp: 8 + card.level * 2 + index,
       levelProgress: Math.min(100, 24 + card.level * 13 + index * 9),
     })),
-    // Slice 1 progression fields are only populated by the persistent reward
-    // path (PvE match-finished route). Local-only / legacy callers default
-    // them to zero so the overlay renders without "leveled up" tiles.
     deltaXp: 0,
     deltaCrystals: 0,
     leveledUp: false,

--- a/src/features/battle/model/domain/match.ts
+++ b/src/features/battle/model/domain/match.ts
@@ -93,6 +93,14 @@ export function buildRewards(player: Fighter, result: MatchResult): RewardSummar
       xp: 8 + card.level * 2 + index,
       levelProgress: Math.min(100, 24 + card.level * 13 + index * 9),
     })),
+    // Slice 1 progression fields are only populated by the persistent reward
+    // path (PvE match-finished route). Local-only / legacy callers default
+    // them to zero so the overlay renders without "leveled up" tiles.
+    deltaXp: 0,
+    deltaCrystals: 0,
+    leveledUp: false,
+    levelUpBonusCrystals: 0,
+    newTotals: { crystals: 0, totalXp: 0, level: 1 },
   };
 }
 

--- a/src/features/battle/model/types.ts
+++ b/src/features/battle/model/types.ts
@@ -173,10 +173,25 @@ export type CardReward = {
   levelProgress: number;
 };
 
+export type RewardSummaryTotals = {
+  crystals: number;
+  totalXp: number;
+  level: number;
+};
+
 export type RewardSummary = {
   matchXp: number;
   levelProgress: number;
   cardRewards: CardReward[];
+  // Slice 1 progression fields. Populated by the PvE match-finished endpoint
+  // and (in slice 2) by the server-authoritative PvP path. Local PvE/PvP
+  // games that still call buildRewards default these to zero/false so the
+  // overlay can render safely while progression isn't wired through.
+  deltaXp: number;
+  deltaCrystals: number;
+  leveledUp: boolean;
+  levelUpBonusCrystals: number;
+  newTotals: RewardSummaryTotals;
 };
 
 export type GameState = {

--- a/src/features/battle/model/types.ts
+++ b/src/features/battle/model/types.ts
@@ -183,10 +183,6 @@ export type RewardSummary = {
   matchXp: number;
   levelProgress: number;
   cardRewards: CardReward[];
-  // Slice 1 progression fields. Populated by the PvE match-finished endpoint
-  // and (in slice 2) by the server-authoritative PvP path. Local PvE/PvP
-  // games that still call buildRewards default these to zero/false so the
-  // overlay can render safely while progression isn't wired through.
   deltaXp: number;
   deltaCrystals: number;
   leveledUp: boolean;

--- a/src/features/battle/ui/BattleGame.tsx
+++ b/src/features/battle/ui/BattleGame.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { postMatchFinished } from "@/features/player/profile/client";
 import type { PlayerIdentity } from "@/features/player/profile/types";
 import { cn } from "@/shared/lib/cn";
 import type { TelegramPlayer } from "@/shared/lib/telegram";
@@ -124,6 +125,9 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
   const [humanStatus, setHumanStatus] = useState<HumanMatchStatus>(isHumanMatch ? "connecting" : "idle");
   const [humanMessage, setHumanMessage] = useState("");
   const [matchInfo, setMatchInfo] = useState<HumanMatchInfo | null>(null);
+  const [persistedRewards, setPersistedRewards] = useState<RewardSummary | null>(null);
+  const [persistedRewardsError, setPersistedRewardsError] = useState<string | null>(null);
+  const persistedMatchSignatureRef = useRef<string | null>(null);
   const autoSubmitRef = useRef(() => {});
   const socketRef = useRef<WebSocket | null>(null);
   const gameRef = useRef(game);
@@ -335,6 +339,41 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
       return schedule(() => setGame((value) => ({ ...value, phase: "reward_summary" })), PHASE_TIMING_MS.match_result);
     }
   }, [game, humanStatus, isHumanMatch, pending]);
+
+  // Slice 1: persist PvE match XP/level via the new endpoint as soon as the
+  // match resolves. PvP intentionally still uses the legacy local rewards;
+  // the server-authoritative PvP path lands in slice #2.
+  useEffect(() => {
+    if (isHumanMatch) return;
+    if (game.phase !== "match_result" && game.phase !== "reward_summary") return;
+    if (!game.matchResult) return;
+    if (!playerIdentity) return;
+
+    const result = matchResultToBucket(game.matchResult);
+    // De-dupe across the match_result -> reward_summary transition so we only
+    // POST once per match. The signature also resets on next match because
+    // `reset()` clears persistedRewards / persistedRewardsError below.
+    const signature = `${game.matchResult}:${result}`;
+    if (persistedMatchSignatureRef.current === signature) return;
+    persistedMatchSignatureRef.current = signature;
+
+    let cancelled = false;
+    postMatchFinished({ identity: playerIdentity, mode: "pve", result })
+      .then((response) => {
+        if (cancelled) return;
+        setPersistedRewards(response.rewards);
+        setPersistedRewardsError(null);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : "Помилка обчислення нагороди.";
+        setPersistedRewardsError(message);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [game.matchResult, game.phase, isHumanMatch, playerIdentity]);
 
   useEffect(() => {
     let startedAt = 0;
@@ -718,6 +757,9 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
     setEnemyLockedMove(null);
     setSelectionOpen(false);
     setTurnSeconds(TURN_SECONDS);
+    setPersistedRewards(null);
+    setPersistedRewardsError(null);
+    persistedMatchSignatureRef.current = null;
   }
 
   function toggleBoost() {
@@ -884,7 +926,16 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
         />
       ) : null}
 
-      {!humanBlockingOverlay ? <PhaseOverlay game={game} verdict={verdict} onReset={reset} /> : null}
+      {!humanBlockingOverlay ? (
+        <PhaseOverlay
+          game={game}
+          verdict={verdict}
+          onReset={reset}
+          persistedRewards={persistedRewards}
+          persistedRewardsError={persistedRewardsError}
+          isHumanMatch={isHumanMatch}
+        />
+      ) : null}
       {!humanBlockingOverlay && showBattle && pending ? <BattleOverlay outcome={pending} player={game.player} enemy={game.enemy} phase={game.phase} /> : null}
     </main>
   );
@@ -1081,15 +1132,33 @@ function PhaseOverlay({
   game,
   verdict,
   onReset,
+  persistedRewards,
+  persistedRewardsError,
+  isHumanMatch,
 }: {
   game: GameState;
   verdict: string;
   onReset: () => void;
+  persistedRewards: RewardSummary | null;
+  persistedRewardsError: string | null;
+  isHumanMatch: boolean;
 }) {
   if (["player_turn", "card_preview", "opponent_turn", "battle_intro", "damage_apply"].includes(game.phase)) return null;
 
   if (game.phase === "reward_summary") {
-    return <RewardOverlay result={game.matchResult} rewards={game.rewards} onReset={onReset} />;
+    // Slice 1: PvE reads the persisted rewards from /api/player/match-finished
+    // and falls back to local rewards if the request is in flight or failed.
+    // PvP keeps using the legacy local rewards until slice #2 lands.
+    const overlayRewards = !isHumanMatch && persistedRewards ? persistedRewards : game.rewards;
+    return (
+      <RewardOverlay
+        result={game.matchResult}
+        rewards={overlayRewards}
+        onReset={onReset}
+        persistedRewardsError={!isHumanMatch ? persistedRewardsError : null}
+        showPersistedDetails={!isHumanMatch}
+      />
+    );
   }
 
   const title = getOverlayTitle(game.phase, game.round.round, verdict, game.lastClash?.winner);
@@ -1123,12 +1192,23 @@ function RewardOverlay({
   result,
   rewards,
   onReset,
+  persistedRewardsError,
+  showPersistedDetails,
 }: {
   result?: MatchResult;
   rewards?: RewardSummary;
   onReset: () => void;
+  persistedRewardsError: string | null;
+  showPersistedDetails: boolean;
 }) {
   const title = result === "player" ? "Винагороди за перемогу" : result === "draw" ? "Винагороди за нічию" : "Винагороди за бій";
+  // The persisted PvE rewards populate deltaXp; legacy/local rewards (from
+  // buildRewards) leave it at zero. Use that as the signal that we're
+  // looking at persisted rewards worth surfacing.
+  const userXpDelta = rewards?.deltaXp ?? 0;
+  const showUserXpTile = showPersistedDetails && userXpDelta > 0;
+  const showLevelUpTile = showPersistedDetails && Boolean(rewards?.leveledUp);
+  const newLevel = rewards?.newTotals?.level;
 
   return (
     <section className="fixed inset-0 z-50 grid place-items-center bg-[#05080b] p-3 backdrop-blur-[4px]" data-testid="reward-summary">
@@ -1147,6 +1227,48 @@ function RewardOverlay({
             Новий бій
           </button>
         </div>
+
+        {showUserXpTile ? (
+          <div
+            className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded border border-[#49d2e7]/35 bg-[linear-gradient(180deg,rgba(8,28,40,0.86),rgba(4,12,18,0.86))] px-3 py-2"
+            data-testid="reward-user-xp-tile"
+            data-delta-xp={userXpDelta}
+          >
+            <div className="grid gap-1">
+              <span className="text-xs font-black uppercase tracking-[0.08em] text-[#9bd3df]">XP гравця</span>
+              <span className="text-base font-black text-[#fff8df]" data-testid="reward-user-xp-line">
+                +{userXpDelta} XP · рівень {newLevel ?? "?"}
+              </span>
+            </div>
+            <span className="text-2xl font-black text-[#49d2e7]">+{userXpDelta}</span>
+          </div>
+        ) : null}
+
+        {showLevelUpTile ? (
+          <div
+            className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded border-2 border-[#ffe08a]/70 bg-[linear-gradient(180deg,rgba(60,38,8,0.92),rgba(20,12,2,0.92))] px-3 py-3 shadow-[0_0_18px_rgba(255,224,138,0.28)]"
+            data-testid="reward-level-up-tile"
+            data-new-level={newLevel ?? ""}
+            data-level-up-bonus={rewards?.levelUpBonusCrystals ?? 0}
+          >
+            <div className="grid gap-1">
+              <span className="text-xs font-black uppercase tracking-[0.1em] text-[#ffe08a]">Новий рівень</span>
+              <strong className="text-xl font-black uppercase text-[#fff8df]" data-testid="reward-level-up-headline">
+                Рівень {newLevel} · +{rewards?.levelUpBonusCrystals ?? 0} 💎
+              </strong>
+            </div>
+            <span className="text-3xl font-black text-[#ffe08a]">💎</span>
+          </div>
+        ) : null}
+
+        {persistedRewardsError ? (
+          <div
+            className="rounded border border-[#ff6e6e]/50 bg-black/55 px-3 py-2 text-xs font-black uppercase text-[#ffd1d1]"
+            data-testid="reward-persisted-error"
+          >
+            {persistedRewardsError}
+          </div>
+        ) : null}
 
         <div className="grid gap-2">
           {(rewards?.cardRewards ?? []).map((reward) => (
@@ -1265,6 +1387,12 @@ function getVerdict(result?: MatchResult) {
   if (!result) return "";
   if (result === "draw") return "Нічия";
   return result === "player" ? "Перемога" : "Програш";
+}
+
+function matchResultToBucket(result: MatchResult): "win" | "draw" | "loss" {
+  if (result === "player") return "win";
+  if (result === "draw") return "draw";
+  return "loss";
 }
 
 function topBarClass() {

--- a/src/features/battle/ui/BattleGame.tsx
+++ b/src/features/battle/ui/BattleGame.tsx
@@ -340,9 +340,6 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
     }
   }, [game, humanStatus, isHumanMatch, pending]);
 
-  // Slice 1: persist PvE match XP/level via the new endpoint as soon as the
-  // match resolves. PvP intentionally still uses the legacy local rewards;
-  // the server-authoritative PvP path lands in slice #2.
   useEffect(() => {
     if (isHumanMatch) return;
     if (game.phase !== "match_result" && game.phase !== "reward_summary") return;
@@ -350,9 +347,7 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
     if (!playerIdentity) return;
 
     const result = matchResultToBucket(game.matchResult);
-    // De-dupe across the match_result -> reward_summary transition so we only
-    // POST once per match. The signature also resets on next match because
-    // `reset()` clears persistedRewards / persistedRewardsError below.
+    // Effect runs once for match_result and again for reward_summary; the ref dedupes the POST.
     const signature = `${game.matchResult}:${result}`;
     if (persistedMatchSignatureRef.current === signature) return;
     persistedMatchSignatureRef.current = signature;
@@ -1146,9 +1141,6 @@ function PhaseOverlay({
   if (["player_turn", "card_preview", "opponent_turn", "battle_intro", "damage_apply"].includes(game.phase)) return null;
 
   if (game.phase === "reward_summary") {
-    // Slice 1: PvE reads the persisted rewards from /api/player/match-finished
-    // and falls back to local rewards if the request is in flight or failed.
-    // PvP keeps using the legacy local rewards until slice #2 lands.
     const overlayRewards = !isHumanMatch && persistedRewards ? persistedRewards : game.rewards;
     return (
       <RewardOverlay
@@ -1202,9 +1194,6 @@ function RewardOverlay({
   showPersistedDetails: boolean;
 }) {
   const title = result === "player" ? "Винагороди за перемогу" : result === "draw" ? "Винагороди за нічию" : "Винагороди за бій";
-  // The persisted PvE rewards populate deltaXp; legacy/local rewards (from
-  // buildRewards) leave it at zero. Use that as the signal that we're
-  // looking at persisted rewards worth surfacing.
   const userXpDelta = rewards?.deltaXp ?? 0;
   const showUserXpTile = showPersistedDetails && userXpDelta > 0;
   const showLevelUpTile = showPersistedDetails && Boolean(rewards?.leveledUp);

--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -253,6 +253,7 @@ export function GameRoot() {
           <BattleGame
             playerCollectionIds={ownedCardIds}
             playerDeckIds={deckIds}
+            playerIdentity={playerIdentity ?? undefined}
             playerName={playerName}
             onOpenCollection={() => setScreen("collection")}
             onSwitchMode={(nextMode) => setBattleMode(nextMode)}

--- a/src/features/player/profile/api.ts
+++ b/src/features/player/profile/api.ts
@@ -8,6 +8,13 @@ import {
 } from "./types";
 import { cards } from "@/features/battle/model/cards";
 import { MIN_DECK_SIZE } from "@/features/battle/model/constants";
+import {
+  LEVEL_XP_BASE,
+  computeMatchRewards,
+  type ComputedMatchRewardTotals,
+  type MatchResultBucket,
+} from "./progression";
+import type { RewardSummary } from "@/features/battle/model/types";
 
 export type PlayerProfileStore = {
   findOrCreateByIdentity(identity: PlayerIdentity): Promise<StoredPlayerProfile>;
@@ -15,6 +22,15 @@ export type PlayerProfileStore = {
 
 export type PlayerDeckStore = PlayerProfileStore & {
   saveDeck(identity: PlayerIdentity, deckIds: string[]): Promise<StoredPlayerProfile>;
+};
+
+export type ApplyMatchRewardsInput = {
+  result: MatchResultBucket;
+  newTotals: ComputedMatchRewardTotals;
+};
+
+export type PlayerMatchRewardsStore = PlayerProfileStore & {
+  applyMatchRewards(identity: PlayerIdentity, rewards: ApplyMatchRewardsInput): Promise<StoredPlayerProfile>;
 };
 
 export async function handlePlayerProfilePost(request: Request, store: PlayerProfileStore) {
@@ -42,6 +58,88 @@ export async function handlePlayerProfileGet(request: Request, store: PlayerProf
     return playerProfileResponse(toPlayerProfile(profile));
   } catch (error) {
     return playerProfileErrorResponse(error);
+  }
+}
+
+export async function handlePlayerMatchFinishedPost(request: Request, store: PlayerMatchRewardsStore) {
+  try {
+    const body = await readJsonObject(request);
+    const identity = parsePlayerIdentity(body.identity);
+    const mode = parseMatchMode(body.mode);
+    const result = parseMatchResult(body.result);
+
+    const profile = toPlayerProfile(await store.findOrCreateByIdentity(identity));
+    const rewards = computeMatchRewards(
+      { crystals: profile.crystals, totalXp: profile.totalXp, level: profile.level },
+      { mode, result },
+    );
+
+    const persisted = toPlayerProfile(
+      await store.applyMatchRewards(identity, { result, newTotals: rewards.newTotals }),
+    );
+
+    const summary: RewardSummary = {
+      // Slice 1: PvE only awards user XP. The legacy card/match-XP fields are
+      // kept on the type for the existing overlay; we mirror the user XP
+      // delta into matchXp so the existing progress bar still renders sane.
+      matchXp: rewards.deltaXp,
+      levelProgress: levelProgressPercent(persisted.totalXp, persisted.level),
+      cardRewards: [],
+      deltaXp: rewards.deltaXp,
+      deltaCrystals: rewards.deltaCrystals,
+      leveledUp: rewards.leveledUp,
+      levelUpBonusCrystals: rewards.levelUpBonusCrystals,
+      newTotals: {
+        crystals: persisted.crystals,
+        totalXp: persisted.totalXp,
+        level: persisted.level,
+      },
+    };
+
+    return Response.json(
+      { rewards: summary, player: persisted },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    return playerProfileErrorResponse(error);
+  }
+}
+
+function levelProgressPercent(totalXp: number, level: number) {
+  // Mirrors computeLevelFromXp for the bar fill. We re-derive from totals so
+  // the bar shows the player's standing right now (post-match), independent
+  // of the exact match-info inputs.
+  const xpToReachThisLevel = sumXpToReachLevel(level);
+  const xpForNextLevel = LEVEL_XP_BASE * (level + 1) * (level + 1);
+  const into = Math.max(0, totalXp - xpToReachThisLevel);
+  if (xpForNextLevel <= 0) return 100;
+  return Math.max(0, Math.min(100, Math.round((into / xpForNextLevel) * 100)));
+}
+
+function sumXpToReachLevel(level: number) {
+  let sum = 0;
+  for (let n = 2; n <= level; n += 1) {
+    sum += LEVEL_XP_BASE * n * n;
+  }
+  return sum;
+}
+
+function parseMatchMode(value: unknown): "pve" {
+  // Slice 1 only persists PvE matches. PvP is server-authoritative and
+  // lands in slice 2.
+  if (value === "pve") return "pve";
+  throw new MatchFinishedValidationError("mode must be \"pve\" in slice 1.");
+}
+
+function parseMatchResult(value: unknown): MatchResultBucket {
+  if (value === "win" || value === "draw" || value === "loss") return value;
+  throw new MatchFinishedValidationError("result must be one of \"win\", \"draw\", \"loss\".");
+}
+
+class MatchFinishedValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MatchFinishedValidationError";
   }
 }
 
@@ -77,6 +175,16 @@ function playerProfileErrorResponse(error: unknown) {
     return Response.json(
       {
         error: "invalid_deck",
+        message: error.message,
+      },
+      { status: 400 },
+    );
+  }
+
+  if (error instanceof MatchFinishedValidationError) {
+    return Response.json(
+      {
+        error: "invalid_match",
         message: error.message,
       },
       { status: 400 },

--- a/src/features/player/profile/api.ts
+++ b/src/features/player/profile/api.ts
@@ -8,12 +8,8 @@ import {
 } from "./types";
 import { cards } from "@/features/battle/model/cards";
 import { MIN_DECK_SIZE } from "@/features/battle/model/constants";
-import {
-  LEVEL_XP_BASE,
-  computeMatchRewards,
-  type ComputedMatchRewardTotals,
-  type MatchResultBucket,
-} from "./progression";
+import { computeMatchRewards, type MatchResultBucket } from "./progression";
+import { computeLevelFromXp } from "./types";
 import type { RewardSummary } from "@/features/battle/model/types";
 
 export type PlayerProfileStore = {
@@ -26,7 +22,10 @@ export type PlayerDeckStore = PlayerProfileStore & {
 
 export type ApplyMatchRewardsInput = {
   result: MatchResultBucket;
-  newTotals: ComputedMatchRewardTotals;
+  deltaXp: number;
+  // Baseline match crystals (NOT the level-up bonus — that is recomputed
+  // inside the store from the authoritative post-$inc totalXp).
+  matchCrystals: number;
 };
 
 export type PlayerMatchRewardsStore = PlayerProfileStore & {
@@ -75,15 +74,18 @@ export async function handlePlayerMatchFinishedPost(request: Request, store: Pla
     );
 
     const persisted = toPlayerProfile(
-      await store.applyMatchRewards(identity, { result, newTotals: rewards.newTotals }),
+      await store.applyMatchRewards(identity, {
+        result,
+        deltaXp: rewards.deltaXp,
+        matchCrystals: rewards.matchCrystals,
+      }),
     );
 
+    const persistedLevelInfo = computeLevelFromXp(persisted.totalXp);
+
     const summary: RewardSummary = {
-      // Slice 1: PvE only awards user XP. The legacy card/match-XP fields are
-      // kept on the type for the existing overlay; we mirror the user XP
-      // delta into matchXp so the existing progress bar still renders sane.
       matchXp: rewards.deltaXp,
-      levelProgress: levelProgressPercent(persisted.totalXp, persisted.level),
+      levelProgress: levelProgressPercent(persistedLevelInfo),
       cardRewards: [],
       deltaXp: rewards.deltaXp,
       deltaCrystals: rewards.deltaCrystals,
@@ -105,30 +107,14 @@ export async function handlePlayerMatchFinishedPost(request: Request, store: Pla
   }
 }
 
-function levelProgressPercent(totalXp: number, level: number) {
-  // Mirrors computeLevelFromXp for the bar fill. We re-derive from totals so
-  // the bar shows the player's standing right now (post-match), independent
-  // of the exact match-info inputs.
-  const xpToReachThisLevel = sumXpToReachLevel(level);
-  const xpForNextLevel = LEVEL_XP_BASE * (level + 1) * (level + 1);
-  const into = Math.max(0, totalXp - xpToReachThisLevel);
-  if (xpForNextLevel <= 0) return 100;
-  return Math.max(0, Math.min(100, Math.round((into / xpForNextLevel) * 100)));
-}
-
-function sumXpToReachLevel(level: number) {
-  let sum = 0;
-  for (let n = 2; n <= level; n += 1) {
-    sum += LEVEL_XP_BASE * n * n;
-  }
-  return sum;
+function levelProgressPercent(levelInfo: { xpIntoLevel: number; xpForNextLevel: number }) {
+  if (levelInfo.xpForNextLevel <= 0) return 100;
+  return Math.max(0, Math.min(100, Math.round((levelInfo.xpIntoLevel / levelInfo.xpForNextLevel) * 100)));
 }
 
 function parseMatchMode(value: unknown): "pve" {
-  // Slice 1 only persists PvE matches. PvP is server-authoritative and
-  // lands in slice 2.
   if (value === "pve") return "pve";
-  throw new MatchFinishedValidationError("mode must be \"pve\" in slice 1.");
+  throw new MatchFinishedValidationError("mode must be \"pve\".");
 }
 
 function parseMatchResult(value: unknown): MatchResultBucket {

--- a/src/features/player/profile/client.ts
+++ b/src/features/player/profile/client.ts
@@ -1,6 +1,18 @@
+import type { RewardSummary } from "@/features/battle/model/types";
 import type { PlayerIdentity, PlayerProfile } from "./types";
 
 export const PLAYER_GUEST_ID_STORAGE_KEY = "nexus:player-guest-id:v1";
+
+export type MatchFinishedRequest = {
+  identity: PlayerIdentity;
+  mode: "pve";
+  result: "win" | "draw" | "loss";
+};
+
+export type MatchFinishedResponse = {
+  rewards: RewardSummary;
+  player: PlayerProfile;
+};
 
 type TelegramProfileWindow = Window & {
   Telegram?: {
@@ -48,6 +60,28 @@ export async function fetchPlayerProfile(identity: PlayerIdentity = resolveClien
   }
 
   return body.player;
+}
+
+export async function postMatchFinished(input: MatchFinishedRequest): Promise<MatchFinishedResponse> {
+  const response = await fetch("/api/player/match-finished", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(input),
+  });
+
+  if (!response.ok) {
+    const body = (await response.json().catch(() => undefined)) as { message?: string } | undefined;
+    throw new Error(body?.message ?? `Failed to apply match rewards: ${response.status}`);
+  }
+
+  const body = (await response.json()) as MatchFinishedResponse;
+  if (!body.rewards || !body.player) {
+    throw new Error("Match-finished response was malformed.");
+  }
+
+  return body;
 }
 
 export async function savePlayerDeck(identity: PlayerIdentity, deckIds: string[]): Promise<PlayerProfile> {

--- a/src/features/player/profile/mongo.ts
+++ b/src/features/player/profile/mongo.ts
@@ -1,8 +1,18 @@
 import { MongoClient, MongoServerError, ObjectId, type Collection, type Filter, type WithId } from "mongodb";
 import { BoosterOpeningError } from "@/features/boosters/opening";
 import type { BoosterOpeningSource, PersistStarterBoosterOpeningInput, PersistedStarterBoosterOpening, StoredBoosterOpeningRecord } from "@/features/boosters/types";
-import { createNewStoredPlayerProfile, type PlayerIdentity, type StoredPlayerProfile } from "./types";
-import type { PlayerDeckStore } from "./api";
+import {
+  DEFAULT_PLAYER_CRYSTALS,
+  DEFAULT_PLAYER_DRAWS,
+  DEFAULT_PLAYER_LEVEL,
+  DEFAULT_PLAYER_LOSSES,
+  DEFAULT_PLAYER_TOTAL_XP,
+  DEFAULT_PLAYER_WINS,
+  createNewStoredPlayerProfile,
+  type PlayerIdentity,
+  type StoredPlayerProfile,
+} from "./types";
+import type { ApplyMatchRewardsInput, PlayerDeckStore, PlayerMatchRewardsStore } from "./api";
 
 const DEFAULT_MONGODB_URI = "mongodb://127.0.0.1:27017/nexus-card-battle";
 const DEFAULT_MONGODB_DB = "nexus-card-battle";
@@ -10,9 +20,18 @@ const DEFAULT_MONGODB_SERVER_SELECTION_TIMEOUT_MS = 1_500;
 const PLAYERS_COLLECTION = "players";
 const BOOSTER_OPENINGS_COLLECTION = "boosterOpenings";
 
-type MongoPlayerDocument = Omit<StoredPlayerProfile, "id"> & {
+// Progression fields are optional on the document type so legacy profiles
+// (written before slice 1) read cleanly. Defaults are applied in
+// fromMongoDocument().
+type MongoPlayerDocument = Omit<StoredPlayerProfile, "id" | "crystals" | "totalXp" | "level" | "wins" | "losses" | "draws"> & {
   createdAt: Date;
   updatedAt: Date;
+  crystals?: number;
+  totalXp?: number;
+  level?: number;
+  wins?: number;
+  losses?: number;
+  draws?: number;
 };
 
 type MongoBoosterOpeningDocument = {
@@ -40,7 +59,7 @@ export function getMongoPlayerProfileStore() {
   return new MongoPlayerProfileStore(clientPromise, dbName);
 }
 
-export class MongoPlayerProfileStore implements PlayerDeckStore {
+export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewardsStore {
   private indexesReady?: Promise<void>;
   private boosterOpeningIndexesReady?: Promise<void>;
 
@@ -63,6 +82,12 @@ export class MongoPlayerProfileStore implements PlayerDeckStore {
           deckIds: insertedProfile.deckIds,
           starterFreeBoostersRemaining: insertedProfile.starterFreeBoostersRemaining,
           openedBoosterIds: insertedProfile.openedBoosterIds,
+          crystals: insertedProfile.crystals,
+          totalXp: insertedProfile.totalXp,
+          level: insertedProfile.level,
+          wins: insertedProfile.wins,
+          losses: insertedProfile.losses,
+          draws: insertedProfile.draws,
           createdAt: now,
           updatedAt: now,
         },
@@ -78,6 +103,38 @@ export class MongoPlayerProfileStore implements PlayerDeckStore {
     }
 
     return fromMongoDocument(document);
+  }
+
+  async applyMatchRewards(identity: PlayerIdentity, rewards: ApplyMatchRewardsInput): Promise<StoredPlayerProfile> {
+    const players = await this.getPlayersCollection();
+    const now = new Date();
+    // Counter increment for the per-result wins/losses/draws bucket.
+    const resultCounterField =
+      rewards.result === "win" ? "wins" : rewards.result === "loss" ? "losses" : "draws";
+
+    const updatedPlayer = await players.findOneAndUpdate(
+      identityFilter(identity),
+      {
+        $set: {
+          crystals: rewards.newTotals.crystals,
+          totalXp: rewards.newTotals.totalXp,
+          level: rewards.newTotals.level,
+          updatedAt: now,
+        },
+        $inc: {
+          [resultCounterField]: 1,
+        },
+      },
+      {
+        returnDocument: "after",
+      },
+    );
+
+    if (!updatedPlayer) {
+      throw new Error("Player profile did not exist for match rewards apply.");
+    }
+
+    return fromMongoDocument(updatedPlayer);
   }
 
   async saveStarterBoosterOpening(input: PersistStarterBoosterOpeningInput): Promise<PersistedStarterBoosterOpening> {
@@ -358,7 +415,25 @@ function fromMongoDocument(document: WithId<MongoPlayerDocument>): StoredPlayerP
     deckIds: document.deckIds,
     starterFreeBoostersRemaining: document.starterFreeBoostersRemaining,
     openedBoosterIds: document.openedBoosterIds,
+    // Pre-progression Mongo documents may not include these fields. Default
+    // them so toPlayerProfile downstream produces a complete profile.
+    crystals: nonNegativeIntegerOrDefault(document.crystals, DEFAULT_PLAYER_CRYSTALS),
+    totalXp: nonNegativeIntegerOrDefault(document.totalXp, DEFAULT_PLAYER_TOTAL_XP),
+    level: positiveIntegerOrDefault(document.level, DEFAULT_PLAYER_LEVEL),
+    wins: nonNegativeIntegerOrDefault(document.wins, DEFAULT_PLAYER_WINS),
+    losses: nonNegativeIntegerOrDefault(document.losses, DEFAULT_PLAYER_LOSSES),
+    draws: nonNegativeIntegerOrDefault(document.draws, DEFAULT_PLAYER_DRAWS),
   };
+}
+
+function nonNegativeIntegerOrDefault(value: unknown, fallback: number) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return fallback;
+  return value;
+}
+
+function positiveIntegerOrDefault(value: unknown, fallback: number) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) return fallback;
+  return value;
 }
 
 function fromMongoOpeningDocument(document: WithId<MongoBoosterOpeningDocument>): StoredBoosterOpeningRecord {

--- a/src/features/player/profile/mongo.ts
+++ b/src/features/player/profile/mongo.ts
@@ -4,14 +4,15 @@ import type { BoosterOpeningSource, PersistStarterBoosterOpeningInput, Persisted
 import {
   DEFAULT_PLAYER_CRYSTALS,
   DEFAULT_PLAYER_DRAWS,
-  DEFAULT_PLAYER_LEVEL,
   DEFAULT_PLAYER_LOSSES,
   DEFAULT_PLAYER_TOTAL_XP,
   DEFAULT_PLAYER_WINS,
+  computeLevelFromXp,
   createNewStoredPlayerProfile,
   type PlayerIdentity,
   type StoredPlayerProfile,
 } from "./types";
+import { computeLevelUpBonusForRange } from "./progression";
 import type { ApplyMatchRewardsInput, PlayerDeckStore, PlayerMatchRewardsStore } from "./api";
 
 const DEFAULT_MONGODB_URI = "mongodb://127.0.0.1:27017/nexus-card-battle";
@@ -20,15 +21,14 @@ const DEFAULT_MONGODB_SERVER_SELECTION_TIMEOUT_MS = 1_500;
 const PLAYERS_COLLECTION = "players";
 const BOOSTER_OPENINGS_COLLECTION = "boosterOpenings";
 
-// Progression fields are optional on the document type so legacy profiles
-// (written before slice 1) read cleanly. Defaults are applied in
-// fromMongoDocument().
-type MongoPlayerDocument = Omit<StoredPlayerProfile, "id" | "crystals" | "totalXp" | "level" | "wins" | "losses" | "draws"> & {
+// Progression fields are optional so pre-existing documents read cleanly.
+// `level` is intentionally absent — it is derived from totalXp on read,
+// because storing an absolute level would race against $inc(totalXp).
+type MongoPlayerDocument = Omit<StoredPlayerProfile, "id" | "crystals" | "totalXp" | "wins" | "losses" | "draws"> & {
   createdAt: Date;
   updatedAt: Date;
   crystals?: number;
   totalXp?: number;
-  level?: number;
   wins?: number;
   losses?: number;
   draws?: number;
@@ -84,7 +84,6 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
           openedBoosterIds: insertedProfile.openedBoosterIds,
           crystals: insertedProfile.crystals,
           totalXp: insertedProfile.totalXp,
-          level: insertedProfile.level,
           wins: insertedProfile.wins,
           losses: insertedProfile.losses,
           draws: insertedProfile.draws,
@@ -108,33 +107,55 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
   async applyMatchRewards(identity: PlayerIdentity, rewards: ApplyMatchRewardsInput): Promise<StoredPlayerProfile> {
     const players = await this.getPlayersCollection();
     const now = new Date();
-    // Counter increment for the per-result wins/losses/draws bucket.
     const resultCounterField =
       rewards.result === "win" ? "wins" : rewards.result === "loss" ? "losses" : "draws";
 
-    const updatedPlayer = await players.findOneAndUpdate(
+    // Op A is $inc-only so concurrent calls compose; mixing $set of an
+    // absolute total here would let a stale read clobber another caller.
+    const afterIncrement = await players.findOneAndUpdate(
       identityFilter(identity),
       {
-        $set: {
-          crystals: rewards.newTotals.crystals,
-          totalXp: rewards.newTotals.totalXp,
-          level: rewards.newTotals.level,
-          updatedAt: now,
-        },
         $inc: {
+          totalXp: rewards.deltaXp,
+          crystals: rewards.matchCrystals,
           [resultCounterField]: 1,
         },
+        $set: { updatedAt: now },
       },
-      {
-        returnDocument: "after",
-      },
+      { returnDocument: "after" },
     );
 
-    if (!updatedPlayer) {
+    if (!afterIncrement) {
       throw new Error("Player profile did not exist for match rewards apply.");
     }
 
-    return fromMongoDocument(updatedPlayer);
+    // Level boundaries come from the post-Op-A totalXp, not the caller's
+    // pre-call view, so concurrent matches racing across a threshold pay
+    // the bonus exactly once.
+    const authoritativeTotalXp = numberOrZero(afterIncrement.totalXp);
+    const xpBeforeMatch = Math.max(0, authoritativeTotalXp - rewards.deltaXp);
+    const oldLevel = computeLevelFromXp(xpBeforeMatch).level;
+    const newLevel = computeLevelFromXp(authoritativeTotalXp).level;
+
+    if (newLevel <= oldLevel) {
+      return fromMongoDocument(afterIncrement);
+    }
+
+    const bonus = computeLevelUpBonusForRange(oldLevel, newLevel);
+    if (bonus <= 0) {
+      return fromMongoDocument(afterIncrement);
+    }
+
+    const afterBonus = await players.findOneAndUpdate(
+      identityFilter(identity),
+      {
+        $inc: { crystals: bonus },
+        $set: { updatedAt: new Date() },
+      },
+      { returnDocument: "after" },
+    );
+
+    return fromMongoDocument(afterBonus ?? afterIncrement);
   }
 
   async saveStarterBoosterOpening(input: PersistStarterBoosterOpeningInput): Promise<PersistedStarterBoosterOpening> {
@@ -415,11 +436,8 @@ function fromMongoDocument(document: WithId<MongoPlayerDocument>): StoredPlayerP
     deckIds: document.deckIds,
     starterFreeBoostersRemaining: document.starterFreeBoostersRemaining,
     openedBoosterIds: document.openedBoosterIds,
-    // Pre-progression Mongo documents may not include these fields. Default
-    // them so toPlayerProfile downstream produces a complete profile.
     crystals: nonNegativeIntegerOrDefault(document.crystals, DEFAULT_PLAYER_CRYSTALS),
     totalXp: nonNegativeIntegerOrDefault(document.totalXp, DEFAULT_PLAYER_TOTAL_XP),
-    level: positiveIntegerOrDefault(document.level, DEFAULT_PLAYER_LEVEL),
     wins: nonNegativeIntegerOrDefault(document.wins, DEFAULT_PLAYER_WINS),
     losses: nonNegativeIntegerOrDefault(document.losses, DEFAULT_PLAYER_LOSSES),
     draws: nonNegativeIntegerOrDefault(document.draws, DEFAULT_PLAYER_DRAWS),
@@ -431,8 +449,8 @@ function nonNegativeIntegerOrDefault(value: unknown, fallback: number) {
   return value;
 }
 
-function positiveIntegerOrDefault(value: unknown, fallback: number) {
-  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) return fallback;
+function numberOrZero(value: unknown) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
   return value;
 }
 

--- a/src/features/player/profile/progression.ts
+++ b/src/features/player/profile/progression.ts
@@ -1,0 +1,145 @@
+import {
+  DEFAULT_PLAYER_CRYSTALS,
+  DEFAULT_PLAYER_LEVEL,
+  DEFAULT_PLAYER_TOTAL_XP,
+  type PlayerProfile,
+} from "./types";
+
+// Quadratic level curve. The XP required to reach level N from level N-1 is
+// LEVEL_XP_BASE * N^2 (so level 2 needs 200 XP, level 3 needs an extra 450,
+// level 4 needs an extra 800, ...). Cumulative XP for level N is the sum of
+// LEVEL_XP_BASE * k^2 for k = 1..N-1.
+export const LEVEL_XP_BASE = 50;
+
+// PvE reward table. PvE matches grant XP only — crystals come exclusively
+// from level-up bonuses.
+export const PVE_XP_REWARDS = {
+  win: 30,
+  draw: 15,
+  loss: 5,
+} as const;
+
+// One-time crystal bonus paid out when a match crosses one or more level
+// thresholds. Awarded based on the new level reached.
+export const LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL = 25;
+
+export type MatchResultBucket = "win" | "draw" | "loss";
+
+export type MatchInfo =
+  | {
+      mode: "pve";
+      result: MatchResultBucket;
+    }
+  | {
+      mode: "pvp";
+      result: MatchResultBucket;
+      // Reserved for slice #2 / slice #3 (server-authoritative ELO).
+      opponentEloBefore?: number;
+    };
+
+export type LevelInfo = {
+  level: number;
+  xpIntoLevel: number;
+  xpForNextLevel: number;
+};
+
+export type ComputedMatchRewardTotals = {
+  crystals: number;
+  totalXp: number;
+  level: number;
+};
+
+export type ComputedMatchRewards = {
+  deltaXp: number;
+  deltaCrystals: number;
+  leveledUp: boolean;
+  levelUpBonusCrystals: number;
+  newTotals: ComputedMatchRewardTotals;
+};
+
+/**
+ * Pure: returns the player level reached for a given cumulative XP value, plus
+ * how much XP has been earned into that level and how much more XP is needed
+ * to advance to the next level.
+ */
+export function computeLevelFromXp(totalXp: number): LevelInfo {
+  const safeTotal = Math.max(0, Math.floor(Number.isFinite(totalXp) ? totalXp : 0));
+  let level = 1;
+  let consumed = 0;
+
+  // Walk levels until the next level threshold exceeds the available XP.
+  while (true) {
+    const xpForNextLevel = LEVEL_XP_BASE * (level + 1) * (level + 1);
+    if (consumed + xpForNextLevel > safeTotal) {
+      return {
+        level,
+        xpIntoLevel: safeTotal - consumed,
+        xpForNextLevel,
+      };
+    }
+    consumed += xpForNextLevel;
+    level += 1;
+  }
+}
+
+/**
+ * Pure: returns the rewards a match should grant to the player. The player's
+ * profile is treated as immutable input; the caller is responsible for
+ * persisting the returned `newTotals` and per-result counters.
+ */
+export function computeMatchRewards(
+  profileBefore: Pick<PlayerProfile, "crystals" | "totalXp" | "level">,
+  matchInfo: MatchInfo,
+): ComputedMatchRewards {
+  if (matchInfo.mode === "pvp") {
+    throw new Error("PvP rewards are not implemented in slice #1; tracked under slice #2.");
+  }
+
+  if (matchInfo.mode !== "pve") {
+    throw new Error(`Unsupported match mode: ${(matchInfo as { mode: string }).mode}`);
+  }
+
+  const xpFromMatch = PVE_XP_REWARDS[matchInfo.result];
+  const crystalsBefore = nonNegativeInteger(profileBefore.crystals, DEFAULT_PLAYER_CRYSTALS);
+  const totalXpBefore = nonNegativeInteger(profileBefore.totalXp, DEFAULT_PLAYER_TOTAL_XP);
+  const levelBefore = positiveInteger(profileBefore.level, DEFAULT_PLAYER_LEVEL);
+
+  const newTotalXp = totalXpBefore + xpFromMatch;
+  const newLevelInfo = computeLevelFromXp(newTotalXp);
+  const leveledUp = newLevelInfo.level > levelBefore;
+
+  // Spec: when a match crosses one or more level thresholds award a one-time
+  // bonus based on the NEW level reached (not per intermediate level).
+  const levelUpBonusCrystals = leveledUp ? newLevelInfo.level * LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL : 0;
+  const newCrystals = crystalsBefore + levelUpBonusCrystals;
+
+  return {
+    deltaXp: xpFromMatch,
+    deltaCrystals: levelUpBonusCrystals,
+    leveledUp,
+    levelUpBonusCrystals,
+    newTotals: {
+      crystals: newCrystals,
+      totalXp: newTotalXp,
+      level: newLevelInfo.level,
+    },
+  };
+}
+
+function nonNegativeInteger(value: unknown, fallback: number) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return fallback;
+  return value;
+}
+
+function positiveInteger(value: unknown, fallback: number) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) return fallback;
+  return value;
+}
+
+// Re-exported defaults so callers can build a "fresh profile" snapshot for
+// computeMatchRewards in tests without importing types directly.
+export const FRESH_PROGRESSION_TOTALS: ComputedMatchRewardTotals = {
+  crystals: DEFAULT_PLAYER_CRYSTALS,
+  totalXp: DEFAULT_PLAYER_TOTAL_XP,
+  level: DEFAULT_PLAYER_LEVEL,
+};

--- a/src/features/player/profile/progression.ts
+++ b/src/features/player/profile/progression.ts
@@ -2,25 +2,18 @@ import {
   DEFAULT_PLAYER_CRYSTALS,
   DEFAULT_PLAYER_LEVEL,
   DEFAULT_PLAYER_TOTAL_XP,
+  computeLevelFromXp,
   type PlayerProfile,
 } from "./types";
 
-// Quadratic level curve. The XP required to reach level N from level N-1 is
-// LEVEL_XP_BASE * N^2 (so level 2 needs 200 XP, level 3 needs an extra 450,
-// level 4 needs an extra 800, ...). Cumulative XP for level N is the sum of
-// LEVEL_XP_BASE * k^2 for k = 1..N-1.
-export const LEVEL_XP_BASE = 50;
+export { computeLevelFromXp };
 
-// PvE reward table. PvE matches grant XP only — crystals come exclusively
-// from level-up bonuses.
 export const PVE_XP_REWARDS = {
   win: 30,
   draw: 15,
   loss: 5,
 } as const;
 
-// One-time crystal bonus paid out when a match crosses one or more level
-// thresholds. Awarded based on the new level reached.
 export const LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL = 25;
 
 export type MatchResultBucket = "win" | "draw" | "loss";
@@ -33,15 +26,8 @@ export type MatchInfo =
   | {
       mode: "pvp";
       result: MatchResultBucket;
-      // Reserved for slice #2 / slice #3 (server-authoritative ELO).
       opponentEloBefore?: number;
     };
-
-export type LevelInfo = {
-  level: number;
-  xpIntoLevel: number;
-  xpForNextLevel: number;
-};
 
 export type ComputedMatchRewardTotals = {
   crystals: number;
@@ -52,47 +38,25 @@ export type ComputedMatchRewardTotals = {
 export type ComputedMatchRewards = {
   deltaXp: number;
   deltaCrystals: number;
+  // Crystals NOT attributable to a level-up (PvE = 0).
+  matchCrystals: number;
   leveledUp: boolean;
   levelUpBonusCrystals: number;
   newTotals: ComputedMatchRewardTotals;
 };
 
 /**
- * Pure: returns the player level reached for a given cumulative XP value, plus
- * how much XP has been earned into that level and how much more XP is needed
- * to advance to the next level.
- */
-export function computeLevelFromXp(totalXp: number): LevelInfo {
-  const safeTotal = Math.max(0, Math.floor(Number.isFinite(totalXp) ? totalXp : 0));
-  let level = 1;
-  let consumed = 0;
-
-  // Walk levels until the next level threshold exceeds the available XP.
-  while (true) {
-    const xpForNextLevel = LEVEL_XP_BASE * (level + 1) * (level + 1);
-    if (consumed + xpForNextLevel > safeTotal) {
-      return {
-        level,
-        xpIntoLevel: safeTotal - consumed,
-        xpForNextLevel,
-      };
-    }
-    consumed += xpForNextLevel;
-    level += 1;
-  }
-}
-
-/**
- * Pure: returns the rewards a match should grant to the player. The player's
- * profile is treated as immutable input; the caller is responsible for
- * persisting the returned `newTotals` and per-result counters.
+ * Returns the rewards a match should grant. The persistence layer recomputes
+ * `levelUpBonusCrystals` from authoritative post-write state via
+ * `computeLevelUpBonusForRange`; this return value reflects only the caller's
+ * pre-call view.
  */
 export function computeMatchRewards(
   profileBefore: Pick<PlayerProfile, "crystals" | "totalXp" | "level">,
   matchInfo: MatchInfo,
 ): ComputedMatchRewards {
   if (matchInfo.mode === "pvp") {
-    throw new Error("PvP rewards are not implemented in slice #1; tracked under slice #2.");
+    throw new Error("PvP rewards are not implemented.");
   }
 
   if (matchInfo.mode !== "pve") {
@@ -104,18 +68,20 @@ export function computeMatchRewards(
   const totalXpBefore = nonNegativeInteger(profileBefore.totalXp, DEFAULT_PLAYER_TOTAL_XP);
   const levelBefore = positiveInteger(profileBefore.level, DEFAULT_PLAYER_LEVEL);
 
+  const matchCrystals = 0;
+
   const newTotalXp = totalXpBefore + xpFromMatch;
   const newLevelInfo = computeLevelFromXp(newTotalXp);
   const leveledUp = newLevelInfo.level > levelBefore;
 
-  // Spec: when a match crosses one or more level thresholds award a one-time
-  // bonus based on the NEW level reached (not per intermediate level).
-  const levelUpBonusCrystals = leveledUp ? newLevelInfo.level * LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL : 0;
-  const newCrystals = crystalsBefore + levelUpBonusCrystals;
+  const levelUpBonusCrystals = computeLevelUpBonusForRange(levelBefore, newLevelInfo.level);
+  const deltaCrystals = matchCrystals + levelUpBonusCrystals;
+  const newCrystals = crystalsBefore + deltaCrystals;
 
   return {
     deltaXp: xpFromMatch,
-    deltaCrystals: levelUpBonusCrystals,
+    deltaCrystals,
+    matchCrystals,
     leveledUp,
     levelUpBonusCrystals,
     newTotals: {
@@ -124,6 +90,22 @@ export function computeMatchRewards(
       level: newLevelInfo.level,
     },
   };
+}
+
+/**
+ * Sums `level * LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL` for every level strictly
+ * greater than `oldLevel` and <= `newLevel`. Callable from the persistence
+ * layer with authoritative pre/post totals so concurrent writers cannot
+ * double-pay the bonus.
+ */
+export function computeLevelUpBonusForRange(oldLevel: number, newLevel: number): number {
+  const safeOld = Math.max(1, Math.floor(oldLevel));
+  const safeNew = Math.max(safeOld, Math.floor(newLevel));
+  let bonus = 0;
+  for (let level = safeOld + 1; level <= safeNew; level += 1) {
+    bonus += level * LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL;
+  }
+  return bonus;
 }
 
 function nonNegativeInteger(value: unknown, fallback: number) {
@@ -135,11 +117,3 @@ function positiveInteger(value: unknown, fallback: number) {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 1) return fallback;
   return value;
 }
-
-// Re-exported defaults so callers can build a "fresh profile" snapshot for
-// computeMatchRewards in tests without importing types directly.
-export const FRESH_PROGRESSION_TOTALS: ComputedMatchRewardTotals = {
-  crystals: DEFAULT_PLAYER_CRYSTALS,
-  totalXp: DEFAULT_PLAYER_TOTAL_XP,
-  level: DEFAULT_PLAYER_LEVEL,
-};

--- a/src/features/player/profile/types.ts
+++ b/src/features/player/profile/types.ts
@@ -1,4 +1,10 @@
 export const STARTER_FREE_BOOSTERS = 2;
+export const DEFAULT_PLAYER_CRYSTALS = 0;
+export const DEFAULT_PLAYER_TOTAL_XP = 0;
+export const DEFAULT_PLAYER_LEVEL = 1;
+export const DEFAULT_PLAYER_WINS = 0;
+export const DEFAULT_PLAYER_LOSSES = 0;
+export const DEFAULT_PLAYER_DRAWS = 0;
 
 export type PlayerIdentity = TelegramPlayerIdentity | GuestPlayerIdentity;
 
@@ -19,6 +25,15 @@ export type PlayerOnboardingState = {
   completed: boolean;
 };
 
+export type PlayerProgressionTotals = {
+  crystals: number;
+  totalXp: number;
+  level: number;
+  wins: number;
+  losses: number;
+  draws: number;
+};
+
 export type PlayerProfile = {
   id: string;
   identity: PlayerIdentity;
@@ -26,6 +41,12 @@ export type PlayerProfile = {
   deckIds: string[];
   starterFreeBoostersRemaining: number;
   openedBoosterIds: string[];
+  crystals: number;
+  totalXp: number;
+  level: number;
+  wins: number;
+  losses: number;
+  draws: number;
   onboarding: PlayerOnboardingState;
 };
 
@@ -39,6 +60,12 @@ export function createNewStoredPlayerProfile(id: string, identity: PlayerIdentit
     deckIds: [],
     starterFreeBoostersRemaining: STARTER_FREE_BOOSTERS,
     openedBoosterIds: [],
+    crystals: DEFAULT_PLAYER_CRYSTALS,
+    totalXp: DEFAULT_PLAYER_TOTAL_XP,
+    level: DEFAULT_PLAYER_LEVEL,
+    wins: DEFAULT_PLAYER_WINS,
+    losses: DEFAULT_PLAYER_LOSSES,
+    draws: DEFAULT_PLAYER_DRAWS,
   };
 }
 
@@ -47,6 +74,12 @@ export function toPlayerProfile(profile: StoredPlayerProfile): PlayerProfile {
   const deckIds = normalizeStringArray(profile.deckIds);
   const openedBoosterIds = normalizeStringArray(profile.openedBoosterIds);
   const starterFreeBoostersRemaining = normalizeNonNegativeInteger(profile.starterFreeBoostersRemaining, STARTER_FREE_BOOSTERS);
+  const crystals = normalizeNonNegativeInteger(profile.crystals, DEFAULT_PLAYER_CRYSTALS);
+  const totalXp = normalizeNonNegativeInteger(profile.totalXp, DEFAULT_PLAYER_TOTAL_XP);
+  const level = normalizePositiveInteger(profile.level, DEFAULT_PLAYER_LEVEL);
+  const wins = normalizeNonNegativeInteger(profile.wins, DEFAULT_PLAYER_WINS);
+  const losses = normalizeNonNegativeInteger(profile.losses, DEFAULT_PLAYER_LOSSES);
+  const draws = normalizeNonNegativeInteger(profile.draws, DEFAULT_PLAYER_DRAWS);
 
   return {
     id: profile.id,
@@ -55,6 +88,12 @@ export function toPlayerProfile(profile: StoredPlayerProfile): PlayerProfile {
     deckIds,
     starterFreeBoostersRemaining,
     openedBoosterIds,
+    crystals,
+    totalXp,
+    level,
+    wins,
+    losses,
+    draws,
     onboarding: createOnboardingState({
       ownedCardIds,
       deckIds,
@@ -147,6 +186,11 @@ function normalizeStringArray(value: unknown) {
 
 function normalizeNonNegativeInteger(value: unknown, fallback: number) {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return fallback;
+  return value;
+}
+
+function normalizePositiveInteger(value: unknown, fallback: number) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) return fallback;
   return value;
 }
 

--- a/src/features/player/profile/types.ts
+++ b/src/features/player/profile/types.ts
@@ -6,6 +6,36 @@ export const DEFAULT_PLAYER_WINS = 0;
 export const DEFAULT_PLAYER_LOSSES = 0;
 export const DEFAULT_PLAYER_DRAWS = 0;
 
+// Quadratic curve: XP to advance from level N-1 to N is LEVEL_XP_BASE * N^2.
+// Lives here (not in progression.ts) so toPlayerProfile() can derive level
+// from totalXp without a circular import.
+export const LEVEL_XP_BASE = 50;
+
+export type LevelInfo = {
+  level: number;
+  xpIntoLevel: number;
+  xpForNextLevel: number;
+};
+
+export function computeLevelFromXp(totalXp: number): LevelInfo {
+  const safeTotal = Math.max(0, Math.floor(Number.isFinite(totalXp) ? totalXp : 0));
+  let level = 1;
+  let consumed = 0;
+
+  while (true) {
+    const xpForNextLevel = LEVEL_XP_BASE * (level + 1) * (level + 1);
+    if (consumed + xpForNextLevel > safeTotal) {
+      return {
+        level,
+        xpIntoLevel: safeTotal - consumed,
+        xpForNextLevel,
+      };
+    }
+    consumed += xpForNextLevel;
+    level += 1;
+  }
+}
+
 export type PlayerIdentity = TelegramPlayerIdentity | GuestPlayerIdentity;
 
 export type TelegramPlayerIdentity = {
@@ -25,15 +55,6 @@ export type PlayerOnboardingState = {
   completed: boolean;
 };
 
-export type PlayerProgressionTotals = {
-  crystals: number;
-  totalXp: number;
-  level: number;
-  wins: number;
-  losses: number;
-  draws: number;
-};
-
 export type PlayerProfile = {
   id: string;
   identity: PlayerIdentity;
@@ -50,7 +71,7 @@ export type PlayerProfile = {
   onboarding: PlayerOnboardingState;
 };
 
-export type StoredPlayerProfile = Omit<PlayerProfile, "onboarding">;
+export type StoredPlayerProfile = Omit<PlayerProfile, "onboarding" | "level">;
 
 export function createNewStoredPlayerProfile(id: string, identity: PlayerIdentity): StoredPlayerProfile {
   return {
@@ -62,7 +83,6 @@ export function createNewStoredPlayerProfile(id: string, identity: PlayerIdentit
     openedBoosterIds: [],
     crystals: DEFAULT_PLAYER_CRYSTALS,
     totalXp: DEFAULT_PLAYER_TOTAL_XP,
-    level: DEFAULT_PLAYER_LEVEL,
     wins: DEFAULT_PLAYER_WINS,
     losses: DEFAULT_PLAYER_LOSSES,
     draws: DEFAULT_PLAYER_DRAWS,
@@ -76,10 +96,10 @@ export function toPlayerProfile(profile: StoredPlayerProfile): PlayerProfile {
   const starterFreeBoostersRemaining = normalizeNonNegativeInteger(profile.starterFreeBoostersRemaining, STARTER_FREE_BOOSTERS);
   const crystals = normalizeNonNegativeInteger(profile.crystals, DEFAULT_PLAYER_CRYSTALS);
   const totalXp = normalizeNonNegativeInteger(profile.totalXp, DEFAULT_PLAYER_TOTAL_XP);
-  const level = normalizePositiveInteger(profile.level, DEFAULT_PLAYER_LEVEL);
   const wins = normalizeNonNegativeInteger(profile.wins, DEFAULT_PLAYER_WINS);
   const losses = normalizeNonNegativeInteger(profile.losses, DEFAULT_PLAYER_LOSSES);
   const draws = normalizeNonNegativeInteger(profile.draws, DEFAULT_PLAYER_DRAWS);
+  const level = computeLevelFromXp(totalXp).level;
 
   return {
     id: profile.id,
@@ -186,11 +206,6 @@ function normalizeStringArray(value: unknown) {
 
 function normalizeNonNegativeInteger(value: unknown, fallback: number) {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 0) return fallback;
-  return value;
-}
-
-function normalizePositiveInteger(value: unknown, fallback: number) {
-  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) return fallback;
   return value;
 }
 

--- a/tests/fixtures/playerProfile.ts
+++ b/tests/fixtures/playerProfile.ts
@@ -23,6 +23,12 @@ export type TestPlayerProfileInput = {
   deckIds: string[];
   starterFreeBoostersRemaining: number;
   openedBoosterIds?: string[];
+  crystals?: number;
+  totalXp?: number;
+  level?: number;
+  wins?: number;
+  losses?: number;
+  draws?: number;
 };
 
 type MockDeckReadyProfileOptions = Partial<TestPlayerProfileInput> & {
@@ -110,6 +116,12 @@ function createPlayerProfileBody(profile: TestPlayerProfileInput) {
   return {
     ...profile,
     openedBoosterIds: profile.openedBoosterIds ?? [],
+    crystals: profile.crystals ?? 0,
+    totalXp: profile.totalXp ?? 0,
+    level: profile.level ?? 1,
+    wins: profile.wins ?? 0,
+    losses: profile.losses ?? 0,
+    draws: profile.draws ?? 0,
     onboarding: {
       starterBoostersAvailable: profile.starterFreeBoostersRemaining > 0,
       collectionReady,

--- a/tests/fixtures/playerProfile.ts
+++ b/tests/fixtures/playerProfile.ts
@@ -1,6 +1,6 @@
 import type { Page, Route } from "@playwright/test";
 import { getBoosterCatalogForPlayer } from "../../src/features/boosters/catalog";
-import type { PlayerIdentity } from "../../src/features/player/profile/types";
+import { computeLevelFromXp, type PlayerIdentity } from "../../src/features/player/profile/types";
 
 const GUEST_ID_STORAGE_KEY = "nexus:player-guest-id:v1";
 export const PROFILE_DECK_IDS = [
@@ -112,13 +112,14 @@ export async function fulfillBoosterCatalog(route: Route, profile: TestPlayerPro
 function createPlayerProfileBody(profile: TestPlayerProfileInput) {
   const collectionReady = profile.ownedCardIds.length > 0;
   const deckReady = profile.deckIds.length > 0;
+  const totalXp = profile.totalXp ?? 0;
 
   return {
     ...profile,
     openedBoosterIds: profile.openedBoosterIds ?? [],
     crystals: profile.crystals ?? 0,
-    totalXp: profile.totalXp ?? 0,
-    level: profile.level ?? 1,
+    totalXp,
+    level: profile.level ?? computeLevelFromXp(totalXp).level,
     wins: profile.wins ?? 0,
     losses: profile.losses ?? 0,
     draws: profile.draws ?? 0,

--- a/tests/match-finished.spec.ts
+++ b/tests/match-finished.spec.ts
@@ -70,26 +70,20 @@ test("PvE reward overlay renders the persisted XP tile and level-up tile from /a
   await page.getByTestId("play-selected-deck").click();
   await expect(page.getByTestId("round-status")).toBeVisible({ timeout: 10_000 });
 
-  // Play whatever the AI gives us; we only care about reaching the reward
-  // overlay. The endpoint is mocked so the displayed delta + level-up are
-  // independent of the RNG-driven match outcome.
   await playUntilRewardOverlay(page);
 
   await expect(page.getByTestId("reward-summary")).toBeVisible({ timeout: 60_000 });
 
-  // The endpoint was called with the PvE mode and a valid result bucket.
   await expect.poll(() => matchFinishedRequests.length, { timeout: 5_000 }).toBeGreaterThanOrEqual(1);
   expect(matchFinishedRequests[0]?.mode).toBe("pve");
   expect(["win", "draw", "loss"]).toContain(matchFinishedRequests[0]?.result);
 
-  // Persisted XP tile reflects the +30 PvE win delta.
   const xpTile = page.getByTestId("reward-user-xp-tile");
   await expect(xpTile).toBeVisible();
   await expect(xpTile).toHaveAttribute("data-delta-xp", "30");
   await expect(page.getByTestId("reward-user-xp-line")).toContainText("+30 XP");
   await expect(page.getByTestId("reward-user-xp-line")).toContainText("рівень 2");
 
-  // Level-up tile renders when leveledUp = true and shows the new_level * 25 crystal bonus.
   const levelUpTile = page.getByTestId("reward-level-up-tile");
   await expect(levelUpTile).toBeVisible();
   await expect(levelUpTile).toHaveAttribute("data-new-level", "2");
@@ -168,8 +162,6 @@ async function playUntilRewardOverlay(page: Page) {
     await expect(page.getByTestId("selection-overlay")).toBeVisible();
     await page.getByTestId("selection-ok").click();
 
-    // Wait for the battle overlay sequence to clear (or for the reward overlay
-    // to appear if this was the deciding round).
     await expect
       .poll(
         async () => {

--- a/tests/match-finished.spec.ts
+++ b/tests/match-finished.spec.ts
@@ -1,0 +1,211 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mockDeckReadyProfile } from "./fixtures/playerProfile";
+
+type MatchFinishedRequestBody = {
+  identity?: { mode?: string; guestId?: string; telegramId?: string };
+  mode?: string;
+  result?: string;
+};
+
+const PVE_LEVEL_UP_REWARDS = {
+  matchXp: 30,
+  levelProgress: 12,
+  cardRewards: [],
+  deltaXp: 30,
+  deltaCrystals: 50,
+  leveledUp: true,
+  levelUpBonusCrystals: 50,
+  newTotals: { crystals: 50, totalXp: 225, level: 2 },
+};
+
+const PVE_NO_LEVEL_REWARDS = {
+  matchXp: 30,
+  levelProgress: 15,
+  cardRewards: [],
+  deltaXp: 30,
+  deltaCrystals: 0,
+  leveledUp: false,
+  levelUpBonusCrystals: 0,
+  newTotals: { crystals: 0, totalXp: 30, level: 1 },
+};
+
+test("PvE reward overlay renders the persisted XP tile and level-up tile from /api/player/match-finished", async ({ page }) => {
+  await mockDeckReadyProfile(page);
+
+  const matchFinishedRequests: MatchFinishedRequestBody[] = [];
+  await page.route("**/api/player/match-finished", async (route) => {
+    const body = route.request().postDataJSON() as MatchFinishedRequestBody;
+    matchFinishedRequests.push(body);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        rewards: PVE_LEVEL_UP_REWARDS,
+        player: {
+          id: "player-deck-ready-e2e",
+          identity: body.identity,
+          ownedCardIds: [],
+          deckIds: [],
+          starterFreeBoostersRemaining: 0,
+          openedBoosterIds: ["neon-breach", "factory-shift"],
+          crystals: PVE_LEVEL_UP_REWARDS.newTotals.crystals,
+          totalXp: PVE_LEVEL_UP_REWARDS.newTotals.totalXp,
+          level: PVE_LEVEL_UP_REWARDS.newTotals.level,
+          wins: 1,
+          losses: 0,
+          draws: 0,
+          onboarding: {
+            starterBoostersAvailable: false,
+            collectionReady: true,
+            deckReady: true,
+            completed: true,
+          },
+        },
+      }),
+    });
+  });
+
+  await page.goto("/");
+  await expect(page.getByTestId("play-selected-deck")).toBeVisible();
+  await page.getByTestId("play-selected-deck").click();
+  await expect(page.getByTestId("round-status")).toBeVisible({ timeout: 10_000 });
+
+  // Play whatever the AI gives us; we only care about reaching the reward
+  // overlay. The endpoint is mocked so the displayed delta + level-up are
+  // independent of the RNG-driven match outcome.
+  await playUntilRewardOverlay(page);
+
+  await expect(page.getByTestId("reward-summary")).toBeVisible({ timeout: 60_000 });
+
+  // The endpoint was called with the PvE mode and a valid result bucket.
+  await expect.poll(() => matchFinishedRequests.length, { timeout: 5_000 }).toBeGreaterThanOrEqual(1);
+  expect(matchFinishedRequests[0]?.mode).toBe("pve");
+  expect(["win", "draw", "loss"]).toContain(matchFinishedRequests[0]?.result);
+
+  // Persisted XP tile reflects the +30 PvE win delta.
+  const xpTile = page.getByTestId("reward-user-xp-tile");
+  await expect(xpTile).toBeVisible();
+  await expect(xpTile).toHaveAttribute("data-delta-xp", "30");
+  await expect(page.getByTestId("reward-user-xp-line")).toContainText("+30 XP");
+  await expect(page.getByTestId("reward-user-xp-line")).toContainText("рівень 2");
+
+  // Level-up tile renders when leveledUp = true and shows the new_level * 25 crystal bonus.
+  const levelUpTile = page.getByTestId("reward-level-up-tile");
+  await expect(levelUpTile).toBeVisible();
+  await expect(levelUpTile).toHaveAttribute("data-new-level", "2");
+  await expect(levelUpTile).toHaveAttribute("data-level-up-bonus", "50");
+  await expect(page.getByTestId("reward-level-up-headline")).toContainText("Рівень 2");
+  await expect(page.getByTestId("reward-level-up-headline")).toContainText("+50 💎");
+});
+
+test("PvE reward overlay hides the level-up tile when leveledUp is false", async ({ page }) => {
+  await mockDeckReadyProfile(page);
+
+  await page.route("**/api/player/match-finished", async (route) => {
+    const body = route.request().postDataJSON() as MatchFinishedRequestBody;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        rewards: PVE_NO_LEVEL_REWARDS,
+        player: {
+          id: "player-deck-ready-e2e",
+          identity: body.identity,
+          ownedCardIds: [],
+          deckIds: [],
+          starterFreeBoostersRemaining: 0,
+          openedBoosterIds: ["neon-breach", "factory-shift"],
+          crystals: 0,
+          totalXp: 30,
+          level: 1,
+          wins: 1,
+          losses: 0,
+          draws: 0,
+          onboarding: {
+            starterBoostersAvailable: false,
+            collectionReady: true,
+            deckReady: true,
+            completed: true,
+          },
+        },
+      }),
+    });
+  });
+
+  await page.goto("/");
+  await page.getByTestId("play-selected-deck").click();
+  await expect(page.getByTestId("round-status")).toBeVisible({ timeout: 10_000 });
+
+  await playUntilRewardOverlay(page);
+  await expect(page.getByTestId("reward-summary")).toBeVisible({ timeout: 60_000 });
+
+  const xpTile = page.getByTestId("reward-user-xp-tile");
+  await expect(xpTile).toBeVisible();
+  await expect(xpTile).toHaveAttribute("data-delta-xp", "30");
+  await expect(page.getByTestId("reward-level-up-tile")).toHaveCount(0);
+});
+
+async function playUntilRewardOverlay(page: Page) {
+  for (let round = 0; round < 12; round += 1) {
+    if (await page.getByTestId("reward-summary").isVisible().catch(() => false)) return;
+
+    await expect
+      .poll(
+        async () => {
+          if (await page.getByTestId("reward-summary").isVisible().catch(() => false)) return "reward";
+          if ((await countEnabledPlayerCards(page)) > 0) return "card";
+          return "waiting";
+        },
+        { timeout: 30_000 },
+      )
+      .not.toBe("waiting");
+
+    if (await page.getByTestId("reward-summary").isVisible().catch(() => false)) return;
+
+    const cardButton = await getFirstEnabledPlayerCard(page);
+    await cardButton.scrollIntoViewIfNeeded();
+    await cardButton.click();
+    await expect(page.getByTestId("selection-overlay")).toBeVisible();
+    await page.getByTestId("selection-ok").click();
+
+    // Wait for the battle overlay sequence to clear (or for the reward overlay
+    // to appear if this was the deciding round).
+    await expect
+      .poll(
+        async () => {
+          if (await page.getByTestId("reward-summary").isVisible().catch(() => false)) return "reward";
+          if (await page.getByTestId("battle-overlay").isVisible().catch(() => false)) return "battle";
+          return "next";
+        },
+        { timeout: 30_000 },
+      )
+      .not.toBe("next");
+
+    if (await page.getByTestId("reward-summary").isVisible().catch(() => false)) return;
+    await expect(page.getByTestId("battle-overlay")).toBeHidden({ timeout: 30_000 });
+  }
+}
+
+async function getFirstEnabledPlayerCard(page: Page) {
+  const cardButtons = page.locator('[data-testid^="player-card-"]');
+  const count = await cardButtons.count();
+
+  for (let index = 0; index < count; index += 1) {
+    const cardButton = cardButtons.nth(index);
+    if (await cardButton.isEnabled()) return cardButton;
+  }
+
+  throw new Error("No enabled player cards found.");
+}
+
+async function countEnabledPlayerCards(page: Page) {
+  const cardButtons = page.locator('[data-testid^="player-card-"]');
+  const count = await cardButtons.count();
+  let enabled = 0;
+
+  for (let index = 0; index < count; index += 1) {
+    if (await cardButtons.nth(index).isEnabled()) enabled += 1;
+  }
+
+  return enabled;
+}

--- a/tests/playerProfile.test.ts
+++ b/tests/playerProfile.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { cards } from "../src/features/battle/model/cards";
-import { handlePlayerDeckSavePost, handlePlayerProfileGet, handlePlayerProfilePost, type PlayerDeckStore, type PlayerProfileStore } from "../src/features/player/profile/api";
+import {
+  handlePlayerDeckSavePost,
+  handlePlayerMatchFinishedPost,
+  handlePlayerProfileGet,
+  handlePlayerProfilePost,
+  type ApplyMatchRewardsInput,
+  type PlayerDeckStore,
+  type PlayerMatchRewardsStore,
+  type PlayerProfileStore,
+} from "../src/features/player/profile/api";
 import { createNewStoredPlayerProfile, isSamePlayerIdentity, type PlayerIdentity, type PlayerProfile, type StoredPlayerProfile } from "../src/features/player/profile/types";
+import type { RewardSummary } from "../src/features/battle/model/types";
 
 const ownedDeckIdentity: PlayerIdentity = {
   mode: "guest",
@@ -163,7 +173,108 @@ describe("player profile API", () => {
   });
 });
 
-class MemoryPlayerProfileStore implements PlayerDeckStore {
+describe("player match-finished API (PvE)", () => {
+  const identity: PlayerIdentity = { mode: "guest", guestId: "guest-pve-rewards" };
+
+  test("a fresh profile + PvE win persists +30 XP, no crystals, no level-up, and increments wins", async () => {
+    const store = new MemoryPlayerProfileStore();
+    const response = await postMatchFinished(store, { identity, mode: "pve", result: "win" });
+    const body = (await response.json()) as { rewards: RewardSummary; player: PlayerProfile };
+
+    expect(response.status).toBe(200);
+    expect(body.rewards.deltaXp).toBe(30);
+    expect(body.rewards.deltaCrystals).toBe(0);
+    expect(body.rewards.leveledUp).toBe(false);
+    expect(body.rewards.levelUpBonusCrystals).toBe(0);
+    expect(body.rewards.newTotals).toEqual({ crystals: 0, totalXp: 30, level: 1 });
+
+    expect(body.player.totalXp).toBe(30);
+    expect(body.player.crystals).toBe(0);
+    expect(body.player.level).toBe(1);
+    expect(body.player.wins).toBe(1);
+    expect(body.player.losses).toBe(0);
+    expect(body.player.draws).toBe(0);
+
+    const persisted = store.snapshot(identity);
+    expect(persisted?.totalXp).toBe(30);
+    expect(persisted?.wins).toBe(1);
+  });
+
+  test("a single PvE win never crosses the level-1 boundary (50 * 2^2 = 200 XP needed)", async () => {
+    const store = new MemoryPlayerProfileStore();
+    const response = await postMatchFinished(store, { identity, mode: "pve", result: "win" });
+    const body = (await response.json()) as { rewards: RewardSummary };
+
+    expect(response.status).toBe(200);
+    expect(body.rewards.leveledUp).toBe(false);
+    expect(body.rewards.newTotals.level).toBe(1);
+    expect(body.rewards.newTotals.crystals).toBe(0);
+  });
+
+  test("seven PvE wins accumulate to 210 XP and trigger level-up to level 2 with a 50-crystal bonus", async () => {
+    const store = new MemoryPlayerProfileStore();
+
+    let lastBody: { rewards: RewardSummary; player: PlayerProfile } | undefined;
+    for (let i = 0; i < 7; i += 1) {
+      const response = await postMatchFinished(store, { identity, mode: "pve", result: "win" });
+      lastBody = (await response.json()) as { rewards: RewardSummary; player: PlayerProfile };
+    }
+
+    if (!lastBody) throw new Error("Expected at least one match finished response.");
+
+    expect(lastBody.player.totalXp).toBe(210);
+    expect(lastBody.player.level).toBe(2);
+    expect(lastBody.player.crystals).toBe(50);
+    expect(lastBody.player.wins).toBe(7);
+    expect(lastBody.rewards.leveledUp).toBe(true);
+    expect(lastBody.rewards.deltaCrystals).toBe(50);
+    expect(lastBody.rewards.levelUpBonusCrystals).toBe(50);
+    expect(lastBody.rewards.newTotals).toEqual({ crystals: 50, totalXp: 210, level: 2 });
+  });
+
+  test("PvE draws and losses persist their result counters and XP", async () => {
+    const store = new MemoryPlayerProfileStore();
+    await postMatchFinished(store, { identity, mode: "pve", result: "draw" });
+    await postMatchFinished(store, { identity, mode: "pve", result: "loss" });
+    await postMatchFinished(store, { identity, mode: "pve", result: "loss" });
+
+    const persisted = store.snapshot(identity);
+    expect(persisted?.totalXp).toBe(15 + 5 + 5);
+    expect(persisted?.draws).toBe(1);
+    expect(persisted?.losses).toBe(2);
+    expect(persisted?.wins).toBe(0);
+    expect(persisted?.crystals).toBe(0);
+  });
+
+  test("rejects a PvP request in slice 1 with a 400 invalid_match", async () => {
+    const store = new MemoryPlayerProfileStore();
+    const response = await postMatchFinished(store, { identity, mode: "pvp", result: "win" });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("invalid_match");
+  });
+
+  test("rejects an invalid result bucket with a 400 invalid_match", async () => {
+    const store = new MemoryPlayerProfileStore();
+    const response = await postMatchFinished(store, { identity, mode: "pve", result: "victory" });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("invalid_match");
+  });
+
+  test("rejects a missing identity with a 400 invalid_identity", async () => {
+    const store = new MemoryPlayerProfileStore();
+    const response = await postMatchFinished(store, { mode: "pve", result: "win" });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("invalid_identity");
+  });
+});
+
+class MemoryPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewardsStore {
   private readonly profiles: StoredPlayerProfile[];
   private nextId: number;
   createdCount = 0;
@@ -191,11 +302,46 @@ class MemoryPlayerProfileStore implements PlayerDeckStore {
     profile.deckIds = [...deckIds];
     return profile;
   }
+
+  async applyMatchRewards(identity: PlayerIdentity, rewards: ApplyMatchRewardsInput): Promise<StoredPlayerProfile> {
+    const index = this.profiles.findIndex((profile) => isSamePlayerIdentity(profile.identity, identity));
+    if (index < 0) throw new Error("Profile does not exist.");
+
+    const current = this.profiles[index];
+    const counterField =
+      rewards.result === "win" ? "wins" : rewards.result === "loss" ? "losses" : "draws";
+    const updated: StoredPlayerProfile = {
+      ...current,
+      crystals: rewards.newTotals.crystals,
+      totalXp: rewards.newTotals.totalXp,
+      level: rewards.newTotals.level,
+      [counterField]: (current[counterField] ?? 0) + 1,
+    };
+    this.profiles[index] = updated;
+    return updated;
+  }
+
+  snapshot(identity: PlayerIdentity): StoredPlayerProfile | undefined {
+    return this.profiles.find((profile) => isSamePlayerIdentity(profile.identity, identity));
+  }
 }
 
 function postProfile(store: PlayerProfileStore, body: unknown) {
   return handlePlayerProfilePost(
     new Request("http://localhost/api/player", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }),
+    store,
+  );
+}
+
+function postMatchFinished(store: PlayerMatchRewardsStore, body: unknown) {
+  return handlePlayerMatchFinishedPost(
+    new Request("http://localhost/api/player/match-finished", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/tests/playerProfile.test.ts
+++ b/tests/playerProfile.test.ts
@@ -10,7 +10,8 @@ import {
   type PlayerMatchRewardsStore,
   type PlayerProfileStore,
 } from "../src/features/player/profile/api";
-import { createNewStoredPlayerProfile, isSamePlayerIdentity, type PlayerIdentity, type PlayerProfile, type StoredPlayerProfile } from "../src/features/player/profile/types";
+import { computeLevelFromXp, createNewStoredPlayerProfile, isSamePlayerIdentity, type PlayerIdentity, type PlayerProfile, type StoredPlayerProfile } from "../src/features/player/profile/types";
+import { computeLevelUpBonusForRange } from "../src/features/player/profile/progression";
 import type { RewardSummary } from "../src/features/battle/model/types";
 
 const ownedDeckIdentity: PlayerIdentity = {
@@ -246,7 +247,7 @@ describe("player match-finished API (PvE)", () => {
     expect(persisted?.crystals).toBe(0);
   });
 
-  test("rejects a PvP request in slice 1 with a 400 invalid_match", async () => {
+  test("rejects a PvP request with a 400 invalid_match", async () => {
     const store = new MemoryPlayerProfileStore();
     const response = await postMatchFinished(store, { identity, mode: "pvp", result: "win" });
     const body = (await response.json()) as { error: string };
@@ -271,6 +272,28 @@ describe("player match-finished API (PvE)", () => {
 
     expect(response.status).toBe(400);
     expect(body.error).toBe("invalid_identity");
+  });
+
+  test("two concurrent PvE wins racing across a level threshold add 2x deltaXp and pay the bonus exactly once", async () => {
+    // Both callers' pre-call view says "I crossed level 2"; the persistence
+    // layer must still pay the bonus only once.
+    const racyIdentity: PlayerIdentity = { mode: "guest", guestId: "guest-pve-race" };
+    const store = new MemoryPlayerProfileStore([
+      { ...createNewStoredPlayerProfile("player-race", racyIdentity), totalXp: 195 },
+    ]);
+
+    const responses = await Promise.all([
+      postMatchFinished(store, { identity: racyIdentity, mode: "pve", result: "win" }),
+      postMatchFinished(store, { identity: racyIdentity, mode: "pve", result: "win" }),
+    ]);
+    for (const response of responses) {
+      expect(response.status).toBe(200);
+    }
+
+    const persisted = store.snapshot(racyIdentity);
+    expect(persisted?.totalXp).toBe(195 + 30 + 30);
+    expect(persisted?.crystals).toBe(50);
+    expect(persisted?.wins).toBe(2);
   });
 });
 
@@ -310,15 +333,31 @@ class MemoryPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewardsSto
     const current = this.profiles[index];
     const counterField =
       rewards.result === "win" ? "wins" : rewards.result === "loss" ? "losses" : "draws";
-    const updated: StoredPlayerProfile = {
+
+    const afterIncrement: StoredPlayerProfile = {
       ...current,
-      crystals: rewards.newTotals.crystals,
-      totalXp: rewards.newTotals.totalXp,
-      level: rewards.newTotals.level,
+      totalXp: current.totalXp + rewards.deltaXp,
+      crystals: current.crystals + rewards.matchCrystals,
       [counterField]: (current[counterField] ?? 0) + 1,
     };
-    this.profiles[index] = updated;
-    return updated;
+    this.profiles[index] = afterIncrement;
+
+    // Yield so concurrent callers can interleave their own Op A — mirrors
+    // the Mongo round-trip and lets the race test exercise the real window.
+    await Promise.resolve();
+
+    const xpBeforeThisMatch = Math.max(0, afterIncrement.totalXp - rewards.deltaXp);
+    const oldLevel = computeLevelFromXp(xpBeforeThisMatch).level;
+    const newLevel = computeLevelFromXp(afterIncrement.totalXp).level;
+    if (newLevel <= oldLevel) return this.profiles[index];
+
+    const bonus = computeLevelUpBonusForRange(oldLevel, newLevel);
+    if (bonus <= 0) return this.profiles[index];
+
+    const latest = this.profiles[index];
+    const afterBonus: StoredPlayerProfile = { ...latest, crystals: latest.crystals + bonus };
+    this.profiles[index] = afterBonus;
+    return afterBonus;
   }
 
   snapshot(identity: PlayerIdentity): StoredPlayerProfile | undefined {

--- a/tests/playerProgression.test.ts
+++ b/tests/playerProgression.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
   LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL,
-  LEVEL_XP_BASE,
   PVE_XP_REWARDS,
   computeLevelFromXp,
+  computeLevelUpBonusForRange,
   computeMatchRewards,
 } from "../src/features/player/profile/progression";
+import { LEVEL_XP_BASE } from "../src/features/player/profile/types";
 
 // Cumulative XP required to reach the start of level N (so level N exactly,
 // xpIntoLevel = 0). Level 1 needs 0 XP. Level N needs sum_{k=2..N} 50 * k^2.
@@ -79,7 +80,7 @@ describe("computeLevelFromXp", () => {
 describe("computeMatchRewards (PvE)", () => {
   const freshProfile = { crystals: 0, totalXp: 0, level: 1 };
 
-  test("PvE win awards +30 XP, no crystals, no level-up from a single win", () => {
+  test("PvE win awards +30 XP, no crystals, no level-up at zero baseline", () => {
     const rewards = computeMatchRewards(freshProfile, { mode: "pve", result: "win" });
 
     expect(rewards.deltaXp).toBe(PVE_XP_REWARDS.win);
@@ -135,9 +136,30 @@ describe("computeMatchRewards (PvE)", () => {
     expect(rewards.newTotals.crystals).toBe(12 + 50);
   });
 
-  test("PvP throws in slice 1 (server-authoritative path lands in slice 2)", () => {
+  test("PvP rewards throw (computeMatchRewards is PvE-only)", () => {
     expect(() =>
       computeMatchRewards(freshProfile, { mode: "pvp", result: "win" }),
-    ).toThrow(/PvP rewards are not implemented in slice #1/);
+    ).toThrow(/PvP rewards are not implemented/);
+  });
+});
+
+describe("computeLevelUpBonusForRange", () => {
+  test("returns 0 when no levels were crossed", () => {
+    expect(computeLevelUpBonusForRange(1, 1)).toBe(0);
+    expect(computeLevelUpBonusForRange(5, 5)).toBe(0);
+    expect(computeLevelUpBonusForRange(5, 4)).toBe(0);
+  });
+
+  test("crossing one level pays new_level * 25", () => {
+    expect(computeLevelUpBonusForRange(1, 2)).toBe(2 * LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL);
+    expect(computeLevelUpBonusForRange(2, 3)).toBe(3 * LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL);
+    expect(computeLevelUpBonusForRange(9, 10)).toBe(10 * LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL);
+  });
+
+  test("crossing multiple levels sums level * 25 over each crossed level", () => {
+    // 1 -> 3 crosses levels 2 and 3: 50 + 75 = 125.
+    expect(computeLevelUpBonusForRange(1, 3)).toBe(125);
+    // 1 -> 4 crosses 2, 3, 4: 50 + 75 + 100 = 225.
+    expect(computeLevelUpBonusForRange(1, 4)).toBe(225);
   });
 });

--- a/tests/playerProgression.test.ts
+++ b/tests/playerProgression.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL,
+  LEVEL_XP_BASE,
+  PVE_XP_REWARDS,
+  computeLevelFromXp,
+  computeMatchRewards,
+} from "../src/features/player/profile/progression";
+
+// Cumulative XP required to reach the start of level N (so level N exactly,
+// xpIntoLevel = 0). Level 1 needs 0 XP. Level N needs sum_{k=2..N} 50 * k^2.
+function xpToReachLevel(level: number) {
+  let sum = 0;
+  for (let k = 2; k <= level; k += 1) sum += LEVEL_XP_BASE * k * k;
+  return sum;
+}
+
+describe("computeLevelFromXp", () => {
+  test("level 1 starts at 0 XP and the next level threshold is 50 * 2^2 = 200", () => {
+    const info = computeLevelFromXp(0);
+    expect(info.level).toBe(1);
+    expect(info.xpIntoLevel).toBe(0);
+    expect(info.xpForNextLevel).toBe(LEVEL_XP_BASE * 2 * 2);
+    expect(info.xpForNextLevel).toBe(200);
+  });
+
+  test("199 XP is still level 1 (one short of the level 2 threshold)", () => {
+    const info = computeLevelFromXp(199);
+    expect(info.level).toBe(1);
+    expect(info.xpIntoLevel).toBe(199);
+    expect(info.xpForNextLevel).toBe(200);
+  });
+
+  test("200 XP is exactly level 2 (xpIntoLevel resets to 0)", () => {
+    const info = computeLevelFromXp(200);
+    expect(info.level).toBe(2);
+    expect(info.xpIntoLevel).toBe(0);
+    // Level 3 needs an extra 50 * 3^2 = 450.
+    expect(info.xpForNextLevel).toBe(450);
+  });
+
+  test("level 3 boundary lands at the cumulative 200 + 450 = 650 XP", () => {
+    expect(xpToReachLevel(3)).toBe(650);
+
+    const justBelow = computeLevelFromXp(649);
+    expect(justBelow.level).toBe(2);
+    expect(justBelow.xpIntoLevel).toBe(449);
+    expect(justBelow.xpForNextLevel).toBe(450);
+
+    const exact = computeLevelFromXp(650);
+    expect(exact.level).toBe(3);
+    expect(exact.xpIntoLevel).toBe(0);
+    // Level 4 needs an extra 50 * 4^2 = 800.
+    expect(exact.xpForNextLevel).toBe(800);
+  });
+
+  test("level 10 boundary follows the 50 * N^2 sum", () => {
+    const cumulative = xpToReachLevel(10);
+
+    // Sanity: 50 * (4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100) = 50 * 384 = 19200.
+    expect(cumulative).toBe(19200);
+
+    const justBelow = computeLevelFromXp(cumulative - 1);
+    expect(justBelow.level).toBe(9);
+
+    const exact = computeLevelFromXp(cumulative);
+    expect(exact.level).toBe(10);
+    expect(exact.xpIntoLevel).toBe(0);
+    expect(exact.xpForNextLevel).toBe(LEVEL_XP_BASE * 11 * 11);
+  });
+
+  test("clamps negative or fractional totals safely to non-negative integers", () => {
+    expect(computeLevelFromXp(-50).level).toBe(1);
+    expect(computeLevelFromXp(199.9).level).toBe(1);
+    expect(computeLevelFromXp(200.9).level).toBe(2);
+  });
+});
+
+describe("computeMatchRewards (PvE)", () => {
+  const freshProfile = { crystals: 0, totalXp: 0, level: 1 };
+
+  test("PvE win awards +30 XP, no crystals, no level-up from a single win", () => {
+    const rewards = computeMatchRewards(freshProfile, { mode: "pve", result: "win" });
+
+    expect(rewards.deltaXp).toBe(PVE_XP_REWARDS.win);
+    expect(rewards.deltaXp).toBe(30);
+    expect(rewards.deltaCrystals).toBe(0);
+    expect(rewards.leveledUp).toBe(false);
+    expect(rewards.levelUpBonusCrystals).toBe(0);
+    expect(rewards.newTotals).toEqual({ crystals: 0, totalXp: 30, level: 1 });
+  });
+
+  test("PvE draw awards +15 XP", () => {
+    const rewards = computeMatchRewards(freshProfile, { mode: "pve", result: "draw" });
+
+    expect(rewards.deltaXp).toBe(15);
+    expect(rewards.deltaCrystals).toBe(0);
+    expect(rewards.leveledUp).toBe(false);
+    expect(rewards.newTotals.totalXp).toBe(15);
+    expect(rewards.newTotals.level).toBe(1);
+  });
+
+  test("PvE loss awards +5 XP", () => {
+    const rewards = computeMatchRewards(freshProfile, { mode: "pve", result: "loss" });
+
+    expect(rewards.deltaXp).toBe(5);
+    expect(rewards.deltaCrystals).toBe(0);
+    expect(rewards.leveledUp).toBe(false);
+    expect(rewards.newTotals.totalXp).toBe(5);
+  });
+
+  test("crossing the level 2 threshold awards a one-time level-up bonus of new_level * 25 crystals", () => {
+    // Level 2 needs 200 XP. Start at 195 XP and earn a +30 PvE win → 225 → level 2.
+    const rewards = computeMatchRewards(
+      { crystals: 0, totalXp: 195, level: 1 },
+      { mode: "pve", result: "win" },
+    );
+
+    expect(rewards.deltaXp).toBe(30);
+    expect(rewards.leveledUp).toBe(true);
+    expect(rewards.levelUpBonusCrystals).toBe(2 * LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL);
+    expect(rewards.levelUpBonusCrystals).toBe(50);
+    expect(rewards.deltaCrystals).toBe(50);
+    expect(rewards.newTotals).toEqual({ crystals: 50, totalXp: 225, level: 2 });
+  });
+
+  test("level-up bonus stacks onto an existing crystal balance", () => {
+    const rewards = computeMatchRewards(
+      { crystals: 12, totalXp: 195, level: 1 },
+      { mode: "pve", result: "win" },
+    );
+
+    expect(rewards.leveledUp).toBe(true);
+    expect(rewards.levelUpBonusCrystals).toBe(50);
+    expect(rewards.newTotals.crystals).toBe(12 + 50);
+  });
+
+  test("PvP throws in slice 1 (server-authoritative path lands in slice 2)", () => {
+    expect(() =>
+      computeMatchRewards(freshProfile, { mode: "pvp", result: "win" }),
+    ).toThrow(/PvP rewards are not implemented in slice #1/);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the player-progression feature (#25). Introduces the persistent profile fields, the pure level-curve and reward-computation modules, the new PvE match-finished HTTP endpoint, and the minimum reward-overlay UI to surface the persisted XP delta and level-up tile. PvP is intentionally untouched: the legacy local `buildRewards` is kept and a future slice will refactor PvP onto `computeMatchRewards`.

Closes #26. Parent: #25.

## Concurrency model

`applyMatchRewards` is two atomic ops — Op A `$inc` of `totalXp`, baseline `crystals`, and the per-result counter; Op B `$inc` of the level-up bonus only when the post-Op-A `totalXp` actually crossed a level. The bonus is recomputed inside the persistence layer via `computeLevelUpBonusForRange(oldLevel, newLevel)` from the authoritative `findOneAndUpdate` return value, so two concurrent PvE wins racing across the same threshold add `2x deltaXp` and pay the bonus exactly once. The absolute `level` field is not persisted — it is derived from `totalXp` on every read in `toPlayerProfile`, so concurrent `$inc(totalXp)` writes can never be clobbered by a stale absolute level.

## Acceptance criteria (from #26)

- [x] `PlayerProfile` schema gains `crystals`, `totalXp`, `level`, `wins`, `losses`, `draws` with defaults applied via `toPlayerProfile`. Mongo's `fromMongoDocument` defaults missing fields, and the document type marks them optional, so existing Mongo profiles open cleanly. `level` is derived on read, not stored.
- [x] New pure module `computeLevelFromXp(totalXp) -> {level, xpIntoLevel, xpForNextLevel}` using the `50 * N^2` curve.
- [x] New pure module `computeMatchRewards(profileBefore, {mode: "pve", result})` returns `{deltaXp, deltaCrystals, matchCrystals, leveledUp, levelUpBonusCrystals, newTotals}` for PvE only. PvP throws.
- [x] New `POST /api/player/match-finished` route validates the player identity, calls `computeMatchRewards`, persists via `MongoPlayerProfileStore.applyMatchRewards`, and returns the resulting `RewardSummary`. Returns 400 on PvP / invalid result / missing identity.
- [x] `RewardSummary` extended with `deltaXp`, `deltaCrystals`, `leveledUp`, `levelUpBonusCrystals`, `newTotals`. `cardRewards` stays.
- [x] Reward overlay (`BattleGame.tsx`) for PvE matches calls the new endpoint after `match_result`, then renders the user XP delta + new level + a level-up tile (only when `leveledUp`).
- [x] PvE reward numbers: win 30 / draw 15 / loss 5 XP. Level-up bonus = `level * 25` summed over each crossed level (single-level cross = `new_level * 25`, matching the spec).
- [x] Unit tests cover `computeLevelFromXp` boundary XP for levels 1, 2, 3, 10 (`tests/playerProgression.test.ts`).
- [x] Unit tests cover the 3 PvE result cases plus a level-crossing case, plus `computeLevelUpBonusForRange` for zero-cross / single-cross / multi-cross.
- [x] Integration test: a fresh profile + PvE win persists +30 XP, no crystals, no level-up; seven PvE wins (210 XP) cross the 50 * 2^2 = 200 XP threshold and award 50 crystals (`tests/playerProfile.test.ts`).
- [x] Concurrent integration test: two simultaneous PvE wins racing across the level 2 threshold add `2 * 30 XP` and pay the 50-crystal bonus exactly once.

## Test plan

### Verified

- **Unit tests in Docker:** `docker build --target builder -t nexus-card-battle:builder .` then `docker run --rm nexus-card-battle:builder bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts` -> **40 pass / 0 fail**, including the new concurrent race test.
- **Unit tests locally:** `bun run test` -> 40 pass / 0 fail.
- **Lint:** `bun run lint` -> clean for slice-1 code (2 unused-var warnings exist on `Hand.tsx` and `ResourceCounter.tsx`, both upstream from `5aff0d0`).
- **Typecheck:** `bunx tsc --noEmit` -> clean for slice-1 code; only pre-existing `bun:test` and strict-mode warnings on existing test files.
- **Build:** `bun run build` -> succeeds; `/api/player/match-finished` registered as a dynamic route.
- **Docker compose config:** `docker compose config --quiet` valid (default and `MONGODB_URI` override).
- **Playwright e2e (locally):** `bun run test:e2e` -> 41 pass / 5 fail. The 5 failures (`tests/mobile-layout.spec.ts:180:7` x4 and `tests/realtime.spec.ts:9:5`) are unrelated to progression and were failing on `origin/main` before this slice; they are documented elsewhere as flaky.

### Docker e2e — explicit caveat

The project's Docker stack (`docker-compose.yml` + `docker-compose.dev.yml`) ships only two services — `mongo` and a production `nexus-card-battle` runtime — and no test-running service. The production image is a multi-stage Alpine build whose final stage strips devDependencies and the `tests/` directory; even the `builder` stage is Alpine, which Microsoft's official Playwright distribution does not support (Playwright requires glibc + a Debian/Ubuntu base for the bundled Chromium). Running e2e in Docker would require a separate Playwright-capable image with the full browser binaries — well outside this slice. **Unit tests (the only Docker-runnable slice of the suite) were verified inside the Docker builder image as shown above; e2e was verified locally.**

## What changed

- Pure modules: `src/features/player/profile/progression.ts` (`PVE_XP_REWARDS`, `LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL = 25`, `computeMatchRewards`, `computeLevelUpBonusForRange`). The level curve (`LEVEL_XP_BASE`, `computeLevelFromXp`) lives in `src/features/player/profile/types.ts` so `toPlayerProfile` can derive `level` without a circular import.
- Schema: `PlayerProfile` extended; `StoredPlayerProfile = Omit<PlayerProfile, "onboarding" | "level">` so `level` is never persisted.
- Persistence: `MongoPlayerProfileStore.applyMatchRewards` does $inc-only Op A then conditionally $inc the bonus in Op B, both `findOneAndUpdate`.
- API: `handlePlayerMatchFinishedPost` in `src/features/player/profile/api.ts`, route at `src/app/api/player/match-finished/route.ts`.
- UI: `BattleGame.tsx` posts to the endpoint when entering `match_result` for PvE, dedupes via a ref against the `match_result -> reward_summary` re-fire, and renders the new XP and level-up tiles. PvP is untouched.
- Plumbing: `src/features/game/ui/GameRoot.tsx` passes `playerIdentity` into the AI `BattleGame`.
- Tests: 13 new unit tests across `tests/playerProgression.test.ts` and `tests/playerProfile.test.ts`; 2 new Playwright specs in `tests/match-finished.spec.ts`. Test fixture updates default the new fields in mocked profile bodies.
- Comment hygiene pass: dropped slice-reference / future-plan narration comments across the diff per the project rule that comments should capture non-obvious WHY only; kept the load-bearing race-correctness invariants on `applyMatchRewards`, `computeLevelUpBonusForRange`, and the cycle-avoidance reason `LEVEL_XP_BASE` lives in `types.ts`.

## Out of scope

- Server-authoritative PvP rewards (separate issue, not done here)
- ELO ratings / matchmaking
- PlayerHud sidebar + mobile strip
- Online presence count broadcast
- Reward overlay redesign (avatar block, AI/PvP buttons, hide cards)