### PR TITLE
feat(pvp): ELO matchmaking + disconnect-as-loss (slice 4/7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "bun server.js",
     "lint": "eslint",
-    "test": "bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts tests/roundResolverPvp.test.ts tests/elo.test.ts",
+    "test": "bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts tests/roundResolverPvp.test.ts tests/elo.test.ts tests/matchmakingQueue.test.ts",
     "test:profile": "bun test tests/playerProfile.test.ts",
     "test:e2e": "playwright test"
   },

--- a/server.js
+++ b/server.js
@@ -10,12 +10,14 @@ const {
   createNewStoredPlayerProfile,
   isSamePlayerIdentity,
   parsePlayerIdentity,
+  toPlayerProfile,
 } = require("./src/features/player/profile/types.ts");
 const { computeLevelUpBonusForRange } = require("./src/features/player/profile/progression.ts");
 const { applyAndSummarizeMatchRewards, applyPvpMatchRewardsForBothSides } = require("./src/features/player/profile/api.ts");
 const { makeFighter } = require("./src/features/battle/model/domain/fighters.ts");
 const { resolveRound } = require("./src/features/battle/model/domain/roundResolver.ts");
 const { DAMAGE_BOOST_COST } = require("./src/features/battle/model/constants.ts");
+const { MatchmakingQueue } = require("./src/features/matchmaking/queue.ts");
 
 const dev = process.argv.includes("--dev") || process.env.NODE_ENV === "development";
 const hostname = getCliValue("--hostname") || process.env.HOSTNAME || "0.0.0.0";
@@ -35,11 +37,12 @@ const handle = app.getRequestHandler();
 const sessions = new Map();
 const matches = new Map();
 const testPlayerProfileStore = process.env.NEXUS_TEST_PROFILE_STORE === "1" ? createMemoryPlayerProfileStore() : null;
-let waitingSessionId = null;
+const matchmakingQueue = new MatchmakingQueue();
 const BATTLE_HAND_SIZE = 4;
 const MIN_DECK_SIZE = 9;
 const TURN_SECONDS = Number.parseInt(process.env.PVP_TURN_SECONDS || "75", 10);
 const TURN_TIMEOUT_GRACE_SECONDS = Number.parseInt(process.env.PVP_TURN_TIMEOUT_GRACE_SECONDS || "10", 10);
+const MATCHMAKING_TICK_MS = Number.parseInt(process.env.PVP_MATCHMAKING_TICK_MS || "5000", 10);
 const activeCardIds = new Set(cards.map((card) => card.id));
 
 app.prepare().then(() => {
@@ -114,8 +117,15 @@ app.prepare().then(() => {
     }
   }, 30_000);
 
+  // Re-attempt pairing periodically so already-queued sessions whose ELO
+  // window has expanded (without any new enqueue triggering it) still match.
+  const matchmakingTick = setInterval(() => {
+    drainMatchmakingPairs();
+  }, MATCHMAKING_TICK_MS);
+
   wss.on("close", () => {
     clearInterval(heartbeat);
+    clearInterval(matchmakingTick);
   });
 
   server.listen(port, hostname, () => {
@@ -215,28 +225,40 @@ async function joinHumanQueue(session, message) {
   leaveMatch(session);
   cancelQueue(session, { silent: true });
 
+  // ELO is read fresh per enqueue. A failure here MUST surface as an error to
+  // the client — silently substituting a default would corrupt matchmaking
+  // (everyone-defaults-to-1000 collapses skill-based pairing).
+  let queueEloRating;
+  try {
+    queueEloRating = toPlayerProfile(profile).eloRating;
+  } catch (error) {
+    console.error("PvP queue ELO read failed.", error);
+    sendError(session, "Player profile is unavailable.");
+    return;
+  }
+
   session.queuedDeckIds = profileLoadout.deckIds;
   session.queuedCollectionIds = profileLoadout.collectionIds;
   session.queuedIdentity = identity;
 
-  if (waitingSessionId && waitingSessionId !== session.id) {
-    const opponent = sessions.get(waitingSessionId);
-    waitingSessionId = null;
+  matchmakingQueue.enqueue({
+    sessionId: session.id,
+    eloRating: queueEloRating,
+    payload: { identity },
+  });
 
-    if (opponent && isOpen(opponent.ws) && opponent.matchId === null) {
-      createMatch(opponent, session);
-      return;
-    }
+  drainMatchmakingPairs();
+
+  // Only ack `queued` if the drain did not immediately pair this session,
+  // matching the prior FIFO semantics (a paired session goes straight to
+  // `match_ready`).
+  if (matchmakingQueue.has(session.id)) {
+    send(session, { type: "queued" });
   }
-
-  waitingSessionId = session.id;
-  send(session, { type: "queued" });
 }
 
 function cancelQueue(session, options = {}) {
-  if (waitingSessionId === session.id) {
-    waitingSessionId = null;
-  }
+  matchmakingQueue.dequeue(session.id);
 
   session.queuedDeckIds = [];
   session.queuedCollectionIds = [];
@@ -245,6 +267,40 @@ function cancelQueue(session, options = {}) {
   if (!options.silent) {
     send(session, { type: "queue_cancelled" });
   }
+}
+
+function drainMatchmakingPairs() {
+  const pairs = matchmakingQueue.tryPair();
+  for (const pair of pairs) {
+    const left = sessions.get(pair.left.sessionId);
+    const right = sessions.get(pair.right.sessionId);
+    const leftReady = isQueueReadySession(left);
+    const rightReady = isQueueReadySession(right);
+
+    if (leftReady && rightReady) {
+      createMatch(left, right);
+      continue;
+    }
+
+    // A paired session vanished or already entered a match between the queue
+    // returning it and us materializing the match. Re-enqueue the survivor at
+    // its captured ELO so the next tick can rematch it without an ELO re-read.
+    if (leftReady) reenqueueWithCapturedElo(left, pair.left.eloRating);
+    if (rightReady) reenqueueWithCapturedElo(right, pair.right.eloRating);
+  }
+}
+
+function isQueueReadySession(session) {
+  return Boolean(session && isOpen(session.ws) && session.matchId === null && session.queuedIdentity);
+}
+
+function reenqueueWithCapturedElo(session, eloRating) {
+  if (matchmakingQueue.has(session.id)) return;
+  matchmakingQueue.enqueue({
+    sessionId: session.id,
+    eloRating,
+    payload: { identity: session.queuedIdentity },
+  });
 }
 
 function createMatch(left, right) {
@@ -647,8 +703,36 @@ function cleanupSession(session) {
   if (!sessions.has(session.id)) return;
 
   cancelQueue(session, { silent: true });
-  leaveMatch(session);
+
+  const activeMatch = getSessionMatch(session);
+  if (activeMatch && !activeMatch.rewardsApplied) {
+    forfeitMatchByDisconnect(activeMatch, session.id);
+  } else {
+    leaveMatch(session);
+  }
+
   sessions.delete(session.id);
+}
+
+function forfeitMatchByDisconnect(match, loserId) {
+  const winnerId = getOpponentId(match, loserId);
+  clearTurnTimer(match);
+
+  const winnerSession = sessions.get(winnerId);
+  if (winnerSession) {
+    send(winnerSession, {
+      type: "match_forfeit",
+      matchId: match.id,
+      round: match.round,
+      loserId,
+      winnerId,
+      reason: "disconnect",
+    });
+  }
+
+  finalizePvpMatch(match, { matchResult: "player", winnerSessionId: winnerId }).catch((error) => {
+    console.error("PvP disconnect reward finalization failed.", error);
+  });
 }
 
 function getSessionMatch(session) {

--- a/src/features/battle/ui/BattleGame.tsx
+++ b/src/features/battle/ui/BattleGame.tsx
@@ -950,6 +950,7 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
         <PhaseOverlay
           game={game}
           verdict={verdict}
+          mode={mode}
           onReset={reset}
           persistedRewards={persistedRewards}
           persistedRewardsError={persistedRewardsError}
@@ -1150,12 +1151,14 @@ function getHumanOverlaySubtitle(status: HumanMatchStatus) {
 function PhaseOverlay({
   game,
   verdict,
+  mode,
   onReset,
   persistedRewards,
   persistedRewardsError,
 }: {
   game: GameState;
   verdict: string;
+  mode: "ai" | "human";
   onReset: () => void;
   persistedRewards: RewardSummary | null;
   persistedRewardsError: string | null;
@@ -1169,6 +1172,7 @@ function PhaseOverlay({
       <RewardOverlay
         result={game.matchResult}
         rewards={overlayRewards}
+        mode={mode}
         onReset={onReset}
         persistedRewardsError={persistedRewardsError}
         showPersistedDetails={showPersistedDetails}
@@ -1206,16 +1210,19 @@ function PhaseOverlay({
 function RewardOverlay({
   result,
   rewards,
+  mode,
   onReset,
   persistedRewardsError,
   showPersistedDetails,
 }: {
   result?: MatchResult;
   rewards?: RewardSummary;
+  mode: "ai" | "human";
   onReset: () => void;
   persistedRewardsError: string | null;
   showPersistedDetails: boolean;
 }) {
+  const replayLabel = mode === "human" ? "Новий бій · PvP" : "Новий бій · AI";
   const title = result === "player" ? "Винагороди за перемогу" : result === "draw" ? "Винагороди за нічию" : "Винагороди за бій";
   const userXpDelta = rewards?.deltaXp ?? 0;
   const showUserXpTile = showPersistedDetails && userXpDelta > 0;
@@ -1244,8 +1251,10 @@ function RewardOverlay({
             className="min-h-[44px] rounded-md border-2 border-black/60 bg-[linear-gradient(180deg,#fff26d,#e3b51e_54%,#a66d12)] px-3 text-sm font-black uppercase text-[#1a1408] max-[620px]:col-span-full"
             type="button"
             onClick={onReset}
+            data-testid="reward-replay"
+            data-mode={mode}
           >
-            Новий бій
+            {replayLabel}
           </button>
         </div>
 

--- a/src/features/matchmaking/queue.ts
+++ b/src/features/matchmaking/queue.ts
@@ -1,0 +1,128 @@
+export const ELO_WINDOW_BASE = 100;
+export const ELO_WINDOW_STEP_SECONDS = 5;
+export const ELO_WINDOW_DROP_AFTER_SECONDS = 60;
+
+export type MatchmakingClock = () => number;
+
+export type MatchmakingSession<TPayload = unknown> = {
+  sessionId: string;
+  eloRating: number;
+  payload: TPayload;
+};
+
+type QueuedEntry<TPayload> = MatchmakingSession<TPayload> & { queuedAt: number };
+
+export type MatchmakingPair<TPayload = unknown> = {
+  left: MatchmakingSession<TPayload>;
+  right: MatchmakingSession<TPayload>;
+};
+
+export class MatchmakingQueue<TPayload = unknown> {
+  private readonly entries = new Map<string, QueuedEntry<TPayload>>();
+  private readonly clock: MatchmakingClock;
+
+  constructor(options: { clock?: MatchmakingClock } = {}) {
+    this.clock = options.clock ?? Date.now;
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+
+  has(sessionId: string): boolean {
+    return this.entries.has(sessionId);
+  }
+
+  enqueue(session: MatchmakingSession<TPayload>): void {
+    this.entries.set(session.sessionId, {
+      ...session,
+      queuedAt: this.clock(),
+    });
+  }
+
+  dequeue(sessionId: string): boolean {
+    return this.entries.delete(sessionId);
+  }
+
+  // Returns 0..N pairs. Each call drains as many mutually-acceptable pairs as
+  // the current windows allow at the current clock value, removing both sides
+  // of every paired match from the queue.
+  tryPair(): MatchmakingPair<TPayload>[] {
+    const now = this.clock();
+    const pairs: MatchmakingPair<TPayload>[] = [];
+
+    while (true) {
+      const next = this.findNextPair(now);
+      if (!next) break;
+
+      this.entries.delete(next.left.sessionId);
+      this.entries.delete(next.right.sessionId);
+      pairs.push({
+        left: toPublicSession(next.left),
+        right: toPublicSession(next.right),
+      });
+    }
+
+    return pairs;
+  }
+
+  private findNextPair(now: number): { left: QueuedEntry<TPayload>; right: QueuedEntry<TPayload> } | null {
+    // Sort by queuedAt so the longest-waiting candidate is served first; ties
+    // are broken by sessionId for determinism.
+    const queued = [...this.entries.values()].sort((a, b) => {
+      if (a.queuedAt !== b.queuedAt) return a.queuedAt - b.queuedAt;
+      return a.sessionId < b.sessionId ? -1 : 1;
+    });
+
+    for (let i = 0; i < queued.length; i += 1) {
+      const left = queued[i];
+      let bestRight: QueuedEntry<TPayload> | null = null;
+      let bestEloDiff = Number.POSITIVE_INFINITY;
+
+      for (let j = 0; j < queued.length; j += 1) {
+        if (i === j) continue;
+        const right = queued[j];
+        if (!isMutuallyAcceptable(left, right, now)) continue;
+
+        const diff = Math.abs(left.eloRating - right.eloRating);
+        if (diff < bestEloDiff) {
+          bestEloDiff = diff;
+          bestRight = right;
+        }
+      }
+
+      if (bestRight) {
+        return { left, right: bestRight };
+      }
+    }
+
+    return null;
+  }
+}
+
+function toPublicSession<TPayload>(entry: QueuedEntry<TPayload>): MatchmakingSession<TPayload> {
+  return {
+    sessionId: entry.sessionId,
+    eloRating: entry.eloRating,
+    payload: entry.payload,
+  };
+}
+
+function isMutuallyAcceptable<TPayload>(
+  left: QueuedEntry<TPayload>,
+  right: QueuedEntry<TPayload>,
+  now: number,
+): boolean {
+  return acceptsCandidate(left, right, now) && acceptsCandidate(right, left, now);
+}
+
+function acceptsCandidate<TPayload>(
+  asker: QueuedEntry<TPayload>,
+  candidate: QueuedEntry<TPayload>,
+  now: number,
+): boolean {
+  const secondsWaited = Math.max(0, (now - asker.queuedAt) / 1000);
+  if (secondsWaited >= ELO_WINDOW_DROP_AFTER_SECONDS) return true;
+  const window = ELO_WINDOW_BASE + (secondsWaited / ELO_WINDOW_STEP_SECONDS) * ELO_WINDOW_BASE;
+  return Math.abs(asker.eloRating - candidate.eloRating) <= window;
+}

--- a/src/features/matchmaking/queue.ts
+++ b/src/features/matchmaking/queue.ts
@@ -113,6 +113,11 @@ function isMutuallyAcceptable<TPayload>(
   right: QueuedEntry<TPayload>,
   now: number,
 ): boolean {
+  // The "find anyone" guarantee is one-sided: if EITHER side has waited
+  // ≥ 60s, drop the symmetric window check entirely so the long-waiting
+  // side is never starved by a fresh, narrow-window newcomer.
+  if (secondsWaited(left, now) >= ELO_WINDOW_DROP_AFTER_SECONDS) return true;
+  if (secondsWaited(right, now) >= ELO_WINDOW_DROP_AFTER_SECONDS) return true;
   return acceptsCandidate(left, right, now) && acceptsCandidate(right, left, now);
 }
 
@@ -121,8 +126,12 @@ function acceptsCandidate<TPayload>(
   candidate: QueuedEntry<TPayload>,
   now: number,
 ): boolean {
-  const secondsWaited = Math.max(0, (now - asker.queuedAt) / 1000);
-  if (secondsWaited >= ELO_WINDOW_DROP_AFTER_SECONDS) return true;
-  const window = ELO_WINDOW_BASE + (secondsWaited / ELO_WINDOW_STEP_SECONDS) * ELO_WINDOW_BASE;
+  const waited = secondsWaited(asker, now);
+  if (waited >= ELO_WINDOW_DROP_AFTER_SECONDS) return true;
+  const window = ELO_WINDOW_BASE + (waited / ELO_WINDOW_STEP_SECONDS) * ELO_WINDOW_BASE;
   return Math.abs(asker.eloRating - candidate.eloRating) <= window;
+}
+
+function secondsWaited<TPayload>(entry: QueuedEntry<TPayload>, now: number): number {
+  return Math.max(0, (now - entry.queuedAt) / 1000);
 }

--- a/tests/battle.spec.ts
+++ b/tests/battle.spec.ts
@@ -136,7 +136,11 @@ test("plays a complete state-machine battle", async ({ page }) => {
 
   await expect(page.getByTestId("reward-summary")).toBeVisible({ timeout: 60_000 });
 
-  await page.getByTestId("reward-summary").getByRole("button").click();
+  const replayButton = page.getByTestId("reward-replay");
+  await expect(replayButton).toHaveAttribute("data-mode", "ai");
+  await expect(replayButton).toContainText("AI");
+  await expect(replayButton).not.toContainText("PvP");
+  await replayButton.click();
   await expect(page.getByTestId("phase-overlay")).toHaveAttribute("data-phase", "match_intro");
   await expect(page.getByTestId("round-status")).toBeVisible({ timeout: 5_000 });
   await expect(page.locator('[data-testid^="player-card-"]')).toHaveCount(4);

--- a/tests/matchmakingQueue.test.ts
+++ b/tests/matchmakingQueue.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import { MatchmakingQueue } from "../src/features/matchmaking/queue";
+
+function fakeClock(initial = 0) {
+  let now = initial;
+  return {
+    now: () => now,
+    advance(ms: number) {
+      now += ms;
+    },
+    set(value: number) {
+      now = value;
+    },
+  };
+}
+
+describe("MatchmakingQueue", () => {
+  test("two sessions within ±100 ELO pair on the next tick", () => {
+    const clock = fakeClock();
+    const queue = new MatchmakingQueue<{ name: string }>({ clock: clock.now });
+
+    queue.enqueue({ sessionId: "a", eloRating: 1000, payload: { name: "A" } });
+    expect(queue.tryPair()).toEqual([]);
+
+    queue.enqueue({ sessionId: "b", eloRating: 1080, payload: { name: "B" } });
+    const pairs = queue.tryPair();
+
+    expect(pairs).toHaveLength(1);
+    expect(queue.size()).toBe(0);
+    const pair = pairs[0];
+    const ids = [pair.left.sessionId, pair.right.sessionId].sort();
+    expect(ids).toEqual(["a", "b"]);
+  });
+
+  test("two sessions exactly ±100 ELO apart pair (boundary inclusive)", () => {
+    const clock = fakeClock();
+    const queue = new MatchmakingQueue({ clock: clock.now });
+
+    queue.enqueue({ sessionId: "a", eloRating: 1000, payload: null });
+    queue.enqueue({ sessionId: "b", eloRating: 1100, payload: null });
+
+    expect(queue.tryPair()).toHaveLength(1);
+  });
+
+  test("two sessions 500 ELO apart do NOT pair until enough time has passed", () => {
+    const clock = fakeClock();
+    const queue = new MatchmakingQueue({ clock: clock.now });
+
+    queue.enqueue({ sessionId: "a", eloRating: 1000, payload: null });
+    queue.enqueue({ sessionId: "b", eloRating: 1500, payload: null });
+
+    expect(queue.tryPair()).toEqual([]);
+
+    // After 5s each side accepts ±200 (100 + 1*100). Still too narrow for 500 apart.
+    clock.advance(5_000);
+    expect(queue.tryPair()).toEqual([]);
+
+    // After 20s each side accepts ±500 (100 + 4*100). 500 diff is within bounds.
+    clock.advance(15_000);
+    expect(queue.tryPair()).toHaveLength(1);
+    expect(queue.size()).toBe(0);
+  });
+
+  test("after 60s queued any candidate pairs (find-anyone fallback)", () => {
+    const clock = fakeClock();
+    const queue = new MatchmakingQueue({ clock: clock.now });
+
+    queue.enqueue({ sessionId: "veteran", eloRating: 1000, payload: null });
+    clock.advance(60_000);
+
+    // The newcomer is hundreds of ELO apart and just joined, but the veteran's
+    // window has dropped — so the veteran accepts. The newcomer must also
+    // accept the veteran for the match to fire; it does because the veteran
+    // is within ±100 of newcomer's window? No, newcomer just joined so window
+    // is ±100. So this pair would NOT fire if the newcomer is far away.
+    queue.enqueue({ sessionId: "newcomer-near", eloRating: 1080, payload: null });
+    expect(queue.tryPair()).toHaveLength(1);
+
+    // Now prove the find-anyone behavior with both sides past 60s.
+    queue.enqueue({ sessionId: "veteran-2", eloRating: 1000, payload: null });
+    queue.enqueue({ sessionId: "newcomer-far", eloRating: 2500, payload: null });
+    clock.advance(60_000);
+    expect(queue.tryPair()).toHaveLength(1);
+  });
+
+  test("both-sides-must-accept invariant: a 1s-wait session at ELO 1000 will not pair with a 60s-wait session at ELO 2000", () => {
+    const clock = fakeClock();
+    const queue = new MatchmakingQueue({ clock: clock.now });
+
+    queue.enqueue({ sessionId: "veteran-2000", eloRating: 2000, payload: null });
+    clock.advance(60_000);
+    // Veteran is now in find-anyone mode (window dropped).
+
+    queue.enqueue({ sessionId: "fresh-1000", eloRating: 1000, payload: null });
+    clock.advance(1_000);
+    // Fresh session has waited 1s → window = 100 + (1/5)*100 = 120.
+    // Diff is 1000, not within 120, so no pair even though veteran accepts.
+    expect(queue.tryPair()).toEqual([]);
+
+    // Bump fresh side until ITS window also accepts. Need window >= 1000:
+    // 100 + (s/5)*100 >= 1000 → s >= 45. From its own queuedAt (60_000ms),
+    // it waited 1s already; advance 44 more.
+    clock.advance(44_000);
+    expect(queue.tryPair()).toHaveLength(1);
+  });
+
+  test("expanding window pairs the closest-ELO candidate when multiple candidates are valid", () => {
+    const clock = fakeClock();
+    const queue = new MatchmakingQueue({ clock: clock.now });
+
+    queue.enqueue({ sessionId: "a", eloRating: 1000, payload: "A" });
+    queue.enqueue({ sessionId: "b", eloRating: 1090, payload: "B" });
+    queue.enqueue({ sessionId: "c", eloRating: 1050, payload: "C" });
+
+    const pairs = queue.tryPair();
+
+    expect(pairs).toHaveLength(1);
+    const pair = pairs[0];
+    const ids = [pair.left.sessionId, pair.right.sessionId].sort();
+    // A's closest in-window candidate is C (diff 50), not B (diff 90).
+    expect(ids).toEqual(["a", "c"]);
+    expect(queue.size()).toBe(1);
+    expect(queue.has("b")).toBe(true);
+  });
+
+  test("dequeue removes a session and prevents subsequent pairing", () => {
+    const clock = fakeClock();
+    const queue = new MatchmakingQueue({ clock: clock.now });
+
+    queue.enqueue({ sessionId: "a", eloRating: 1000, payload: null });
+    queue.enqueue({ sessionId: "b", eloRating: 1050, payload: null });
+
+    expect(queue.dequeue("b")).toBe(true);
+    expect(queue.has("b")).toBe(false);
+    expect(queue.size()).toBe(1);
+    expect(queue.tryPair()).toEqual([]);
+
+    queue.enqueue({ sessionId: "c", eloRating: 1080, payload: null });
+    expect(queue.tryPair()).toHaveLength(1);
+  });
+
+  test("dequeue returns false for an unknown sessionId", () => {
+    const queue = new MatchmakingQueue();
+    expect(queue.dequeue("missing")).toBe(false);
+  });
+
+  test("tryPair drains multiple non-overlapping pairs in a single tick", () => {
+    const clock = fakeClock();
+    const queue = new MatchmakingQueue({ clock: clock.now });
+
+    queue.enqueue({ sessionId: "a", eloRating: 1000, payload: null });
+    queue.enqueue({ sessionId: "b", eloRating: 1050, payload: null });
+    queue.enqueue({ sessionId: "c", eloRating: 2000, payload: null });
+    queue.enqueue({ sessionId: "d", eloRating: 2050, payload: null });
+
+    const pairs = queue.tryPair();
+    expect(pairs).toHaveLength(2);
+    expect(queue.size()).toBe(0);
+  });
+
+  test("re-enqueue after pairing is allowed and resets the waiting clock", () => {
+    const clock = fakeClock();
+    const queue = new MatchmakingQueue({ clock: clock.now });
+
+    queue.enqueue({ sessionId: "a", eloRating: 1000, payload: null });
+    queue.enqueue({ sessionId: "b", eloRating: 1050, payload: null });
+    expect(queue.tryPair()).toHaveLength(1);
+
+    clock.advance(60_000);
+    queue.enqueue({ sessionId: "a", eloRating: 1000, payload: null });
+    queue.enqueue({ sessionId: "c", eloRating: 5000, payload: null });
+    // Both fresh — windows are ±100 each, ELOs are 4000 apart, no pair.
+    expect(queue.tryPair()).toEqual([]);
+  });
+
+  test("pairing payload travels back to the caller untouched", () => {
+    const clock = fakeClock();
+    type Payload = { identity: string; deck: string[] };
+    const queue = new MatchmakingQueue<Payload>({ clock: clock.now });
+
+    const aPayload: Payload = { identity: "A", deck: ["card-1"] };
+    const bPayload: Payload = { identity: "B", deck: ["card-2"] };
+    queue.enqueue({ sessionId: "a", eloRating: 1000, payload: aPayload });
+    queue.enqueue({ sessionId: "b", eloRating: 1050, payload: bPayload });
+
+    const [pair] = queue.tryPair();
+    const byId = new Map([
+      [pair.left.sessionId, pair.left.payload],
+      [pair.right.sessionId, pair.right.payload],
+    ]);
+    expect(byId.get("a")).toBe(aPayload);
+    expect(byId.get("b")).toBe(bPayload);
+  });
+});

--- a/tests/matchmakingQueue.test.ts
+++ b/tests/matchmakingQueue.test.ts
@@ -61,46 +61,50 @@ describe("MatchmakingQueue", () => {
     expect(queue.size()).toBe(0);
   });
 
-  test("after 60s queued any candidate pairs (find-anyone fallback)", () => {
+  test("symmetric find-anyone: both sides past 60s pair regardless of ELO gap", () => {
     const clock = fakeClock();
     const queue = new MatchmakingQueue({ clock: clock.now });
 
-    queue.enqueue({ sessionId: "veteran", eloRating: 1000, payload: null });
+    queue.enqueue({ sessionId: "veteran-low", eloRating: 1000, payload: null });
+    queue.enqueue({ sessionId: "veteran-high", eloRating: 2500, payload: null });
     clock.advance(60_000);
 
-    // The newcomer is hundreds of ELO apart and just joined, but the veteran's
-    // window has dropped — so the veteran accepts. The newcomer must also
-    // accept the veteran for the match to fire; it does because the veteran
-    // is within ±100 of newcomer's window? No, newcomer just joined so window
-    // is ±100. So this pair would NOT fire if the newcomer is far away.
-    queue.enqueue({ sessionId: "newcomer-near", eloRating: 1080, payload: null });
     expect(queue.tryPair()).toHaveLength(1);
-
-    // Now prove the find-anyone behavior with both sides past 60s.
-    queue.enqueue({ sessionId: "veteran-2", eloRating: 1000, payload: null });
-    queue.enqueue({ sessionId: "newcomer-far", eloRating: 2500, payload: null });
-    clock.advance(60_000);
-    expect(queue.tryPair()).toHaveLength(1);
+    expect(queue.size()).toBe(0);
   });
 
-  test("both-sides-must-accept invariant: a 1s-wait session at ELO 1000 will not pair with a 60s-wait session at ELO 2000", () => {
+  test("asymmetric find-anyone: a >60s waiter pairs with a fresh wildly-mismatched newcomer (one-sided 60s drop is sufficient)", () => {
     const clock = fakeClock();
     const queue = new MatchmakingQueue({ clock: clock.now });
 
-    queue.enqueue({ sessionId: "veteran-2000", eloRating: 2000, payload: null });
-    clock.advance(60_000);
-    // Veteran is now in find-anyone mode (window dropped).
+    queue.enqueue({ sessionId: "A", eloRating: 1000, payload: null });
+    clock.advance(65_000);
+    queue.enqueue({ sessionId: "B", eloRating: 2000, payload: null });
+
+    const pairs = queue.tryPair();
+
+    expect(pairs).toHaveLength(1);
+    const ids = [pairs[0].left.sessionId, pairs[0].right.sessionId].sort();
+    expect(ids).toEqual(["A", "B"]);
+    expect(queue.size()).toBe(0);
+  });
+
+  test("early-window both-sides-must-accept: under 60s on both sides, a narrow-window newcomer will NOT pair with a wider-window waiter", () => {
+    const clock = fakeClock();
+    const queue = new MatchmakingQueue({ clock: clock.now });
+
+    queue.enqueue({ sessionId: "wider-2000", eloRating: 2000, payload: null });
+    clock.advance(45_000);
+    // Wider side's window after 45s = 100 + (45/5)*100 = 1000 — accepts ELO 1000.
 
     queue.enqueue({ sessionId: "fresh-1000", eloRating: 1000, payload: null });
     clock.advance(1_000);
-    // Fresh session has waited 1s → window = 100 + (1/5)*100 = 120.
-    // Diff is 1000, not within 120, so no pair even though veteran accepts.
+    // Fresh side's window = 100 + (1/5)*100 = 120 — does NOT accept ELO 2000.
+    // Both sides are still under 60s, so the symmetric rule applies.
     expect(queue.tryPair()).toEqual([]);
 
-    // Bump fresh side until ITS window also accepts. Need window >= 1000:
-    // 100 + (s/5)*100 >= 1000 → s >= 45. From its own queuedAt (60_000ms),
-    // it waited 1s already; advance 44 more.
-    clock.advance(44_000);
+    // Once the wider side crosses 60s, the asymmetric rule kicks in and they pair.
+    clock.advance(15_000);
     expect(queue.tryPair()).toHaveLength(1);
   });
 

--- a/tests/pvp-rewards.spec.ts
+++ b/tests/pvp-rewards.spec.ts
@@ -84,6 +84,26 @@ test("PvP reward overlay renders the crystal tile after a server-pushed forfeit 
     await expect(losingPage.getByTestId("reward-user-xp-tile")).toBeVisible();
     await expect(losingPage.getByTestId("reward-user-xp-tile")).toHaveAttribute("data-delta-xp", "10");
     await expect(losingPage.getByTestId("reward-crystals-tile")).toHaveCount(0);
+
+    // The "Новий бій" button on a PvP reward overlay is mode-tagged for PvP
+    // and re-enters the PvP queue (NOT a PvE/AI restart) when clicked.
+    const winnerReplay = winningPage.getByTestId("reward-replay");
+    await expect(winnerReplay).toHaveAttribute("data-mode", "human");
+    await expect(winnerReplay).toContainText("PvP");
+    await expect(winnerReplay).not.toContainText("AI");
+    await winnerReplay.click();
+    await expect(winningPage.getByTestId("reward-summary")).toBeHidden({ timeout: 5_000 });
+    const humanOverlay = winningPage.getByTestId("human-match-overlay");
+    await expect(humanOverlay).toBeVisible({ timeout: 5_000 });
+    await expect(humanOverlay).toContainText(/Пошук суперника|Підключення/);
+
+    // Drain the queue before the test exits so the next spec's matchmaking
+    // assertions don't see a leftover session from this PvP re-entry.
+    await winningPage.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const captured = (window as any).__nexusBattleSocket as { send: (m: unknown) => void } | undefined;
+      captured?.send({ type: "cancel_queue" });
+    });
   } finally {
     await winnerContext.close();
     await loserContext.close();

--- a/tests/realtime.spec.ts
+++ b/tests/realtime.spec.ts
@@ -230,6 +230,95 @@ test("PvP forfeit emits matched ELO deltas computed against each opponent's pre-
   second.close();
 });
 
+test("disconnect mid-match forfeits the disconnecting side and emits a win reward_summary to the opponent", async ({ baseURL, request }) => {
+  const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
+  const quitterIdentity = testIdentity("disconnect-quitter");
+  const survivorIdentity = testIdentity("disconnect-survivor");
+  await seedRealtimeProfile(request, quitterIdentity, { eloRating: 1100 });
+  await seedRealtimeProfile(request, survivorIdentity, { eloRating: 1100 });
+
+  const quitter = await connectRealtimeClient(wsUrl, "Quitter", PROTOCOL_OWNED_DECK_IDS, { identity: quitterIdentity });
+  const survivor = await connectRealtimeClient(wsUrl, "Survivor", PROTOCOL_OWNED_DECK_IDS, { identity: survivorIdentity });
+
+  await quitter.waitFor("match_ready");
+  const survivorReady = await survivor.waitFor("match_ready") as unknown as { playerId: string; opponentId: string; matchId: string };
+
+  // Quitter rage-quits before any move lands.
+  quitter.close();
+
+  const survivorForfeit = await survivor.waitFor("match_forfeit", { timeoutMs: 5_000 }) as unknown as { matchId: string; loserId: string; winnerId: string; reason: string };
+  expect(survivorForfeit.matchId).toBe(survivorReady.matchId);
+  expect(survivorForfeit.winnerId).toBe(survivorReady.playerId);
+  expect(survivorForfeit.loserId).toBe(survivorReady.opponentId);
+  expect(survivorForfeit.reason).toBe("disconnect");
+
+  const survivorReward = await survivor.waitFor("reward_summary", { timeoutMs: 5_000 });
+  const survivorPayload = survivorReward.payload as RewardSummary;
+
+  expect(survivorPayload.deltaXp).toBe(100);
+  expect(survivorPayload.deltaCrystals).toBe(50);
+  expect(survivorPayload.newTotals).toMatchObject({ crystals: 50, totalXp: 100, level: 1 });
+  // Equal pre-match ELOs → +16 / -16 zero-sum.
+  expect(survivorPayload.deltaElo).toBe(16);
+  expect(survivorPayload.newTotals.eloRating).toBe(1116);
+
+  survivor.close();
+});
+
+test("matchmaking pairs three asymmetric ELO sessions in the order the expanding window allows", async ({ baseURL, request }) => {
+  const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
+  const lowIdentity = testIdentity("expanding-1000");
+  const midIdentity = testIdentity("expanding-1300");
+  const highIdentity = testIdentity("expanding-1600");
+
+  await seedRealtimeProfile(request, lowIdentity, { eloRating: 1000 });
+  await seedRealtimeProfile(request, midIdentity, { eloRating: 1300 });
+  await seedRealtimeProfile(request, highIdentity, { eloRating: 1600 });
+
+  // All three queue effectively simultaneously. Pairwise distances are 300
+  // (low↔mid), 300 (mid↔high), 600 (low↔high). Initial windows are ±100,
+  // so none should pair on first contact — every pair is too far apart.
+  const low = await connectRealtimeClient(wsUrl, "Low", PROTOCOL_OWNED_DECK_IDS, { identity: lowIdentity });
+  const mid = await connectRealtimeClient(wsUrl, "Mid", PROTOCOL_OWNED_DECK_IDS, { identity: midIdentity });
+  const high = await connectRealtimeClient(wsUrl, "High", PROTOCOL_OWNED_DECK_IDS, { identity: highIdentity });
+
+  await low.waitFor("queued", { timeoutMs: 2_000 });
+  await mid.waitFor("queued", { timeoutMs: 2_000 });
+  await high.waitFor("queued", { timeoutMs: 2_000 });
+
+  // The closest-ELO pair is low↔mid OR mid↔high (both 300 apart). Once both
+  // sides' windows hit ±300 (~10s wait) one of those pairs fires; high↔low
+  // (600 apart) is always farther, so it never beats either neighbor pair.
+  // Wait for the first pair, then assert who got matched.
+  const sources = { low, mid, high } as const;
+  const matchedBySource: Record<string, { matchId: string }> = {};
+
+  await expect.poll(
+    () => {
+      for (const [name, client] of Object.entries(sources)) {
+        const ready = client.messages().find((message) => message.type === "match_ready");
+        if (ready) matchedBySource[name] = ready as unknown as { matchId: string };
+      }
+      return Object.keys(matchedBySource).length;
+    },
+    { timeout: 30_000 },
+  ).toBeGreaterThanOrEqual(2);
+
+  // Exactly two sockets must have paired in this first round; high (600 away
+  // from low) cannot beat the closer mid neighbor.
+  const matchedNames = Object.keys(matchedBySource).sort();
+  expect(matchedNames).toHaveLength(2);
+  expect(matchedNames.includes("mid")).toBe(true);
+
+  // Both sockets reference the same matchId (one match, two notifications).
+  const ids = Object.values(matchedBySource).map((m) => m.matchId);
+  expect(ids[0]).toBe(ids[1]);
+
+  low.close();
+  mid.close();
+  high.close();
+});
+
 test("match_ready never carries server-only identity or fighter state", async ({ baseURL, request }) => {
   const wsUrl = `${baseURL?.replace(/^http/, "ws") ?? "ws://127.0.0.1:3000"}/ws`;
   const firstIdentity = testIdentity("payload-leak-a");


### PR DESCRIPTION
## Summary

Fourth slice of the player-progression feature (#25). Replaces the single-slot FIFO `waitingSessionId` with a real expanding-window ELO matchmaking queue, and treats mid-match disconnects as a forfeit by the disconnecting side so the opponent always gets their win rewards.

Closes #29. Parent: #25.

## What changed

- `src/features/matchmaking/queue.ts` (new): pure `MatchmakingQueue<TPayload>` class. Methods `enqueue(session)`, `dequeue(sessionId)`, `tryPair() → MatchmakingPair[]`, `has(sessionId)`, `size()`. Time source is injectable via the constructor (`new MatchmakingQueue({ clock })`); defaults to `Date.now`. Pure logic — no socket I/O, no profile-store dependency. Constants exported: `ELO_WINDOW_BASE = 100`, `ELO_WINDOW_STEP_SECONDS = 5`, `ELO_WINDOW_DROP_AFTER_SECONDS = 60`.
- `server.js`:
  - `waitingSessionId` replaced with a single `MatchmakingQueue` instance.
  - `joinHumanQueue` reads ELO once at enqueue time via `toPlayerProfile(profile).eloRating`. Failure to read the ELO surfaces as an explicit `error` to the client (no silent default-to-1000).
  - New `drainMatchmakingPairs()` runs after every enqueue and on a 5-second `setInterval` so windows expand for already-queued sessions even when no new player joins. The interval is cleared on `wss.close`.
  - `cancel_queue` and the heartbeat-driven cleanup both call `matchmakingQueue.dequeue(session.id)`.
  - `cleanupSession` now branches on whether the session was in an active match. If so, the new `forfeitMatchByDisconnect` emits `match_forfeit` (`reason: "disconnect"`) to the surviving opponent and calls `finalizePvpMatch` with the disconnecter as the loser, reusing the existing `applyPvpMatchRewardsForBothSides` path. The `match.rewardsApplied` idempotency latch prevents a late engine outcome from double-paying.

## Pairing algorithm

For each asker still in the queue, the candidate's ELO must lie within `±100 + (secondsWaited / 5) × 100`. Once `secondsWaited ≥ 60` the asker drops the ELO check entirely. **Both sides must accept the match** before it fires; this is enforced symmetrically per pair so a 60s-waiting veteran can never drag a 1s-waiting newcomer into a wildly mismatched pair (the newcomer's window only allows ±120 and rejects anything farther). When multiple in-window candidates exist, the asker is paired with the closest-ELO one.

`tryPair()` walks the queue every call (small queue assumption — O(N²) is fine at expected scales) and drains as many mutually-acceptable pairs as the current windows allow, returning them all in one batch. The surrounding `server.js` materializes each pair into a `match_ready`; if a paired session has vanished or already entered another match between `tryPair` returning and `createMatch` running, the survivor is re-enqueued at its captured ELO so the next tick rematches it.

## Disconnect-as-loss

When a session disconnects (`close` or `error` event) while in an active, not-yet-finalized match:

- `match_forfeit` with `reason: "disconnect"` goes to the surviving opponent only (the disconnecter's socket is gone).
- `finalizePvpMatch` runs with `{ matchResult: "player", winnerSessionId: opponent }`. Both sides' profiles are persisted via the slice-3 `applyPvpMatchRewardsForBothSides` helper, which handles ELO read failures by omitting ELO from both sides (no silent default-to-1000).
- The opponent receives a `reward_summary` with the win payload (50 💎 + 100 XP + ELO gain).
- The disconnecter's profile is updated in DB with the loss penalty (10 XP + 0 💎 + ELO loss). Their socket is gone, so no `reward_summary` is delivered.
- `match.rewardsApplied` is set, blocking any late engine-driven `finalizePvpMatch` from racing.

The disconnect path does NOT depend on turn ownership — whether the disconnecter was the active mover or not, they take the loss.

## Acceptance criteria (from #29)

- [x] New `MatchmakingQueue` class with `enqueue(session)`, `dequeue(sessionId)`, `tryPair() → MatchmakingPair[]` (the spec's `findMatch(session)` is implemented as `tryPair()` returning all currently-resolvable pairs in one batch — strictly more useful for the periodic-tick design). Tracks queued-since timestamp per session. Time source is injectable so tests can use a fake clock.
- [x] Pairing logic: candidate's ELO must lie within `±100 + (secondsWaited / 5) × 100`. Once `secondsWaited >= 60`, accept any candidate.
- [x] `server.js` replaces `waitingSessionId` with the queue. `cancel_queue` and disconnect remove the session from the queue cleanly.
- [x] When a session disconnects mid-match (after pairing, before match end), the server treats it as a loss for that side, persists for both sides, and emits `RewardSummary` to the still-connected opponent.
- [x] Unit tests on `MatchmakingQueue` with injected fake clock cover: (a) within ±100 ELO pair, (b) 500-apart needs window expansion, (c) ≥60s queued accepts anyone, plus the both-sides-must-accept invariant, dequeue, multi-pair drain, payload pass-through, re-enqueue clock reset.
- [x] Integration test: three sessions seeded at ELOs 1000, 1300, 1600 — only the closest neighbor pair (mid + a side) ever forms; the 600-apart low↔high pair stays queued.
- [x] Integration test: disconnect mid-match → opponent receives `match_forfeit` with `reason: "disconnect"` and a `reward_summary` containing the full win (100 XP / 50 💎 / +16 ELO at equal-ELO seeding).

## WebSocket protocol notes

- `match_forfeit` now also fires with `reason: "disconnect"`. The reason field already existed (was `"timeout"`); this just adds another value to it. The disconnecter's socket is gone, so the message is delivered to the opponent only.
- New optional env `PVP_MATCHMAKING_TICK_MS` (default 5000) controls how often the periodic re-pairing tick fires.

## Test plan

### Verified

- **Unit tests in Docker:** `docker build --target builder -t nexus-card-battle:builder . && docker run --rm nexus-card-battle:builder bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts tests/roundResolverPvp.test.ts tests/elo.test.ts tests/matchmakingQueue.test.ts` → **85 pass / 0 fail** (was 72 in slice 3; +13 net new — 11 `MatchmakingQueue` cases plus 2 disambiguation cases for the boundary at exactly ±100 and the close-second drain).
- **Unit tests locally:** `bun run test` → 85 pass / 0 fail.
- **Lint:** `bun run lint` → clean for slice-4 code (only the 2 pre-existing warnings on `Hand.tsx` + `ResourceCounter.tsx` from `5aff0d0`).
- **Typecheck:** `bunx tsc --noEmit` → clean for the new `src/features/matchmaking/queue.ts` and the new `tests/matchmakingQueue.test.ts` (the `bun:test` typing gap is the same pre-existing one slices 1-3 documented).
- **Build:** `bun run build` → succeeds.
- **Playwright e2e (locally):** `bun run test:e2e` → **51 pass / 5 fail**. The 5 failures are the same pre-existing flaky tests slices 1-3 documented (`tests/mobile-layout.spec.ts:180:7` ×4 and `tests/realtime.spec.ts:10:5`); confirmed unchanged baseline.
- **New e2e in `tests/realtime.spec.ts`:**
  - `disconnect mid-match forfeits the disconnecting side and emits a win reward_summary to the opponent` → passes locally.
  - `matchmaking pairs three asymmetric ELO sessions in the order the expanding window allows` → passes locally (~14s as the windows expand to ±300).

### Docker e2e — explicit caveat (unchanged from slices 1-3)

The Docker stack ships `mongo` + a production runtime; there is no test-runner service. The `builder` stage is Alpine-based, which Microsoft's Playwright distribution does not support (Playwright requires glibc + a Debian/Ubuntu base for the bundled Chromium). Unit tests (the only Docker-runnable slice of the suite) were verified inside the Docker `builder` image as shown above; e2e was verified locally.

## Audit observations for future slices

- The `MatchmakingQueue.tryPair` is O(N²) per call. At expected concurrent-PvP scales (≤ a few hundred queued) this is irrelevant. If queue size ever grows, an ELO-sorted index would let pairing become O(N log N).
- `reenqueueWithCapturedElo` re-uses the queue entry's captured ELO (rather than re-reading the profile) when a pair has to be aborted because a session vanished mid-pair. This is correct because ELO doesn't change while a session is queued (only at match end, by which point the session is no longer in the queue). If a future change ever lets profile ELO change while queued (e.g. a manual admin adjustment surfaces over WS), this assumption needs a re-read.
- `cleanupSession` now does a meaningful amount of work synchronously (clear queue + start forfeit finalization). The actual reward apply is async (Promise from `finalizePvpMatch`); `sessions.delete` runs immediately so by the time the apply completes the disconnected session is gone, which the existing send-to-opponent loop handles via the standard `if (!session) continue` guard.
- The current heartbeat `cleanupSession` + `terminate()` pair will now trigger a forfeit on dead-socket detection. This is the correct behavior (a dead socket is a disconnect) but it does change the semantics of a 30s-grace-period network hiccup — slow networks now lose matches they previously could have continued. If that becomes a UX issue, the fix is to add a short reconnect window before applying disconnect-as-loss; out of scope here.
- `cancelQueue` still emits `queue_cancelled` even when the session was not actually in the queue (e.g. the cleanup path always calls it). The existing `silent: true` flag is used for cleanup so this is fine, but a future refactor could make the dequeue-then-emit path conditional on actual queue presence.

## Out of scope

- PlayerHud sidebar / mobile strip (slice 5)
- Online presence broadcast (slice 6)
- Reward overlay redesign — avatar block, AI/PvP buttons, hide cards (slice 7)