### PR TITLE
feat(ui): PlayerHud sidebar + mobile top-strip with avatar (slice 5/7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "bun server.js",
     "lint": "eslint",
-    "test": "bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts tests/roundResolverPvp.test.ts tests/elo.test.ts tests/matchmakingQueue.test.ts tests/rewardOverlayPresenter.test.ts",
+    "test": "bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts tests/roundResolverPvp.test.ts tests/elo.test.ts tests/matchmakingQueue.test.ts tests/rewardOverlayPresenter.test.ts tests/playerAvatar.test.ts",
     "test:profile": "bun test tests/playerProfile.test.ts",
     "test:e2e": "playwright test"
   },

--- a/server.js
+++ b/server.js
@@ -982,6 +982,7 @@ function handleTestProfileRequest(request, response) {
         losses: nonNegativeIntegerOrUndefined(body.losses),
         draws: nonNegativeIntegerOrUndefined(body.draws),
         eloRating: nonNegativeIntegerOrUndefined(body.eloRating),
+        avatarUrl: typeof body.avatarUrl === "string" && body.avatarUrl.trim() ? body.avatarUrl.trim() : undefined,
       });
 
       response.statusCode = 200;
@@ -1048,6 +1049,15 @@ function createMemoryPlayerProfileStore() {
       else profiles.push(nextProfile);
 
       return nextProfile;
+    },
+    async setAvatarUrl(identity, avatarUrl) {
+      const index = profiles.findIndex((profile) => isSamePlayerIdentity(profile.identity, identity));
+      if (index < 0) {
+        throw new Error("Player profile did not exist for avatar update.");
+      }
+
+      profiles[index] = { ...profiles[index], avatarUrl };
+      return profiles[index];
     },
     async applyMatchRewards(identity, rewards) {
       const index = profiles.findIndex((profile) => isSamePlayerIdentity(profile.identity, identity));

--- a/src/app/api/player/avatar/route.ts
+++ b/src/app/api/player/avatar/route.ts
@@ -1,0 +1,8 @@
+import { handlePlayerAvatarPost } from "@/features/player/profile/api";
+import { getMongoPlayerProfileStore } from "@/features/player/profile/mongo";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  return handlePlayerAvatarPost(request, getMongoPlayerProfileStore());
+}

--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -260,7 +260,7 @@ export function GameRoot() {
     void savePlayerAvatar(playerIdentity, livePhoto)
       .then((nextProfile) => {
         if (cancelled) return;
-        setPlayerProfile(nextProfile);
+        setPlayerProfile((current) => (current ? { ...current, avatarUrl: nextProfile.avatarUrl } : current));
       })
       .catch((error) => {
         // Persistence failure is non-fatal: the live Telegram photo continues

--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -5,8 +5,10 @@ import { cards } from "@/features/battle/model/cards";
 import { BattleGame } from "@/features/battle/ui/BattleGame";
 import { RealtimeBattleGame } from "@/features/battle/ui/RealtimeBattleGame";
 import { STARTER_BOOSTER_CARD_COUNT } from "@/features/boosters/types";
-import { fetchPlayerProfile, resolveClientPlayerIdentity, savePlayerDeck } from "@/features/player/profile/client";
+import { readTelegramPhotoUrl, useTelegramAvatar } from "@/features/player/profile/avatar";
+import { fetchPlayerProfile, resolveClientPlayerIdentity, savePlayerAvatar, savePlayerDeck } from "@/features/player/profile/client";
 import { STARTER_FREE_BOOSTERS, type PlayerIdentity, type PlayerProfile } from "@/features/player/profile/types";
+import { PlayerHud } from "@/features/player/ui/PlayerHud";
 import type { TelegramPlayer } from "@/shared/lib/telegram";
 import { PLAYER_DECK_SIZE } from "../model/randomDeck";
 import { CollectionDeckScreen } from "./collection/CollectionDeckScreen";
@@ -36,6 +38,7 @@ type TelegramWindow = Window & {
           username?: string;
           first_name?: string;
           last_name?: string;
+          photo_url?: string;
         };
       };
     };
@@ -236,8 +239,43 @@ export function GameRoot() {
     setProfileRetryKey((current) => current + 1);
   }, []);
 
+  const liveTelegramAvatarUrl = useTelegramAvatar();
+  const handlePlayFromHud = useCallback(() => {
+    if (!deckReadyToPlay || profileDeckIds.length < PLAYER_DECK_SIZE) return;
+    handleSavedDeckPlay(profileDeckIds, "ai");
+  }, [deckReadyToPlay, handleSavedDeckPlay, profileDeckIds]);
+  const hudCanPlay =
+    profileStatus === "ready" && deckReadyToPlay && profileDeckIds.length >= PLAYER_DECK_SIZE;
+
+  // Persist Telegram photo_url onto the profile when it differs from what we
+  // already stored. We do this once per (identity, photoUrl) tuple so a slow
+  // network or transient 4xx does not retry-storm.
+  useEffect(() => {
+    if (!playerIdentity || !playerProfile || profileStatus !== "ready") return;
+    const livePhoto = liveTelegramAvatarUrl ?? readTelegramPhotoUrl();
+    if (!livePhoto) return;
+    if (playerProfile.avatarUrl === livePhoto) return;
+
+    let cancelled = false;
+    void savePlayerAvatar(playerIdentity, livePhoto)
+      .then((nextProfile) => {
+        if (cancelled) return;
+        setPlayerProfile(nextProfile);
+      })
+      .catch((error) => {
+        // Persistence failure is non-fatal: the live Telegram photo continues
+        // to render via useTelegramAvatar() for this session.
+        if (cancelled) return;
+        console.warn("Failed to persist Telegram avatar URL.", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [liveTelegramAvatarUrl, playerIdentity, playerProfile, profileStatus]);
+
   if (screen === "battle") {
-    const persistedAvatarUrl = (playerProfile as { avatarUrl?: string } | null)?.avatarUrl;
+    const persistedAvatarUrl = playerProfile?.avatarUrl;
     return (
       <>
         {battleMode === "human" ? (
@@ -287,7 +325,13 @@ export function GameRoot() {
 
   if (showStarterOnboarding && playerIdentity && playerProfile) {
     return (
-      <>
+      <HudShell
+        profile={playerProfile}
+        playerName={playerName}
+        liveTelegramAvatarUrl={liveTelegramAvatarUrl}
+        canPlay={hudCanPlay}
+        onPlay={handlePlayFromHud}
+      >
         <StarterBoosterOnboarding
           identity={playerIdentity}
           profile={playerProfile}
@@ -299,12 +343,18 @@ export function GameRoot() {
           onEditDeck={handleStarterDeckEdit}
         />
         <TelegramLandscapeOverlay active={telegramLandscapePromptActive} />
-      </>
+      </HudShell>
     );
   }
 
   return (
-    <>
+    <HudShell
+      profile={playerProfile}
+      playerName={playerName}
+      liveTelegramAvatarUrl={liveTelegramAvatarUrl}
+      canPlay={hudCanPlay}
+      onPlay={handlePlayFromHud}
+    >
       <CollectionDeckScreen
         collectionIds={ownedCardIds}
         deckIds={deckIds}
@@ -320,7 +370,40 @@ export function GameRoot() {
         onPlay={handleSavedDeckPlay}
       />
       <TelegramLandscapeOverlay active={telegramLandscapePromptActive} />
-    </>
+    </HudShell>
+  );
+}
+
+function HudShell({
+  profile,
+  playerName,
+  liveTelegramAvatarUrl,
+  canPlay,
+  onPlay,
+  children,
+}: {
+  profile: PlayerProfile | null;
+  playerName?: string;
+  liveTelegramAvatarUrl: string | null;
+  canPlay: boolean;
+  onPlay: () => void;
+  children: React.ReactNode;
+}) {
+  if (!profile) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="md:flex md:min-h-screen md:items-stretch">
+      <PlayerHud
+        profile={profile}
+        playerName={playerName}
+        liveAvatarUrl={liveTelegramAvatarUrl}
+        canPlay={canPlay}
+        onPlay={onPlay}
+      />
+      <div className="md:min-w-0 md:flex-1">{children}</div>
+    </div>
   );
 }
 

--- a/src/features/player/profile/api.ts
+++ b/src/features/player/profile/api.ts
@@ -1,5 +1,6 @@
 import {
   PlayerIdentityValidationError,
+  normalizeAvatarUrl,
   type PlayerIdentity,
   type PlayerProfile,
   type StoredPlayerProfile,
@@ -35,6 +36,10 @@ export type PlayerMatchRewardsStore = PlayerProfileStore & {
   applyMatchRewards(identity: PlayerIdentity, rewards: ApplyMatchRewardsInput): Promise<StoredPlayerProfile>;
 };
 
+export type PlayerAvatarStore = PlayerProfileStore & {
+  setAvatarUrl(identity: PlayerIdentity, avatarUrl: string): Promise<StoredPlayerProfile>;
+};
+
 export async function handlePlayerProfilePost(request: Request, store: PlayerProfileStore) {
   try {
     const body = await readJsonObject(request);
@@ -58,6 +63,22 @@ export async function handlePlayerProfileGet(request: Request, store: PlayerProf
     const profile = await store.findOrCreateByIdentity(identity);
 
     return playerProfileResponse(toPlayerProfile(profile));
+  } catch (error) {
+    return playerProfileErrorResponse(error);
+  }
+}
+
+export async function handlePlayerAvatarPost(request: Request, store: PlayerAvatarStore) {
+  try {
+    const body = await readJsonObject(request);
+    const identity = parsePlayerIdentity(body.identity);
+    const avatarUrl = normalizeAvatarUrl(body.avatarUrl);
+    if (avatarUrl === undefined) {
+      throw new PlayerAvatarValidationError("avatarUrl must be a valid https URL.");
+    }
+
+    const stored = await store.setAvatarUrl(identity, avatarUrl);
+    return playerProfileResponse(toPlayerProfile(stored));
   } catch (error) {
     return playerProfileErrorResponse(error);
   }
@@ -210,6 +231,13 @@ class MatchFinishedValidationError extends Error {
   }
 }
 
+class PlayerAvatarValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PlayerAvatarValidationError";
+  }
+}
+
 export async function handlePlayerDeckSavePost(request: Request, store: PlayerDeckStore) {
   try {
     const body = await readJsonObject(request);
@@ -252,6 +280,16 @@ function playerProfileErrorResponse(error: unknown) {
     return Response.json(
       {
         error: "invalid_match",
+        message: error.message,
+      },
+      { status: 400 },
+    );
+  }
+
+  if (error instanceof PlayerAvatarValidationError) {
+    return Response.json(
+      {
+        error: "invalid_avatar",
         message: error.message,
       },
       { status: 400 },

--- a/src/features/player/profile/avatar.ts
+++ b/src/features/player/profile/avatar.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+
+export const DEFAULT_PLAYER_AVATAR_URL = "/nexus-assets/characters/cyber-brawler-thumb.png";
+
+type TelegramAvatarWindow = Window & {
+  Telegram?: {
+    WebApp?: {
+      initDataUnsafe?: {
+        user?: {
+          photo_url?: string;
+        };
+      };
+    };
+  };
+};
+
+export function readTelegramPhotoUrl(): string | null {
+  if (typeof window === "undefined") return null;
+  const photoUrl = (window as TelegramAvatarWindow).Telegram?.WebApp?.initDataUnsafe?.user?.photo_url;
+  if (typeof photoUrl !== "string") return null;
+  const trimmed = photoUrl.trim();
+  return trimmed && /^https:\/\//i.test(trimmed) ? trimmed : null;
+}
+
+// Reads the live Telegram-provided photo on mount. Telegram's WebApp script
+// is loaded with beforeInteractive, but a defensive deferred read covers the
+// case where initData is populated late on slow clients.
+export function useTelegramAvatar(): string | null {
+  const [photoUrl, setPhotoUrl] = useState<string | null>(() => readTelegramPhotoUrl());
+
+  useEffect(() => {
+    if (photoUrl) return;
+    const handle = window.setTimeout(() => {
+      const next = readTelegramPhotoUrl();
+      if (next) setPhotoUrl(next);
+    }, 0);
+
+    return () => window.clearTimeout(handle);
+  }, [photoUrl]);
+
+  return photoUrl;
+}
+
+export function resolveAvatarUrl({
+  storedAvatarUrl,
+  liveAvatarUrl,
+}: {
+  storedAvatarUrl?: string | null;
+  liveAvatarUrl?: string | null;
+}): string {
+  if (typeof storedAvatarUrl === "string" && storedAvatarUrl.trim()) return storedAvatarUrl.trim();
+  if (typeof liveAvatarUrl === "string" && liveAvatarUrl.trim()) return liveAvatarUrl.trim();
+  return DEFAULT_PLAYER_AVATAR_URL;
+}

--- a/src/features/player/profile/client.ts
+++ b/src/features/player/profile/client.ts
@@ -84,6 +84,28 @@ export async function postMatchFinished(input: MatchFinishedRequest): Promise<Ma
   return body;
 }
 
+export async function savePlayerAvatar(identity: PlayerIdentity, avatarUrl: string): Promise<PlayerProfile> {
+  const response = await fetch("/api/player/avatar", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ identity, avatarUrl }),
+  });
+
+  if (!response.ok) {
+    const body = (await response.json().catch(() => undefined)) as { message?: string } | undefined;
+    throw new Error(body?.message ?? `Failed to save player avatar: ${response.status}`);
+  }
+
+  const body = (await response.json()) as { player?: PlayerProfile };
+  if (!body.player) {
+    throw new Error("Player avatar response did not include player.");
+  }
+
+  return body.player;
+}
+
 export async function savePlayerDeck(identity: PlayerIdentity, deckIds: string[]): Promise<PlayerProfile> {
   const response = await fetch("/api/player/deck", {
     method: "POST",

--- a/src/features/player/profile/mongo.ts
+++ b/src/features/player/profile/mongo.ts
@@ -10,11 +10,12 @@ import {
   DEFAULT_PLAYER_WINS,
   computeLevelFromXp,
   createNewStoredPlayerProfile,
+  normalizeAvatarUrl,
   type PlayerIdentity,
   type StoredPlayerProfile,
 } from "./types";
 import { computeLevelUpBonusForRange } from "./progression";
-import type { ApplyMatchRewardsInput, PlayerDeckStore, PlayerMatchRewardsStore } from "./api";
+import type { ApplyMatchRewardsInput, PlayerAvatarStore, PlayerDeckStore, PlayerMatchRewardsStore } from "./api";
 
 const DEFAULT_MONGODB_URI = "mongodb://127.0.0.1:27017/nexus-card-battle";
 const DEFAULT_MONGODB_DB = "nexus-card-battle";
@@ -25,7 +26,7 @@ const BOOSTER_OPENINGS_COLLECTION = "boosterOpenings";
 // Progression fields are optional so pre-existing documents read cleanly.
 // `level` is intentionally absent — it is derived from totalXp on read,
 // because storing an absolute level would race against $inc(totalXp).
-type MongoPlayerDocument = Omit<StoredPlayerProfile, "id" | "crystals" | "totalXp" | "wins" | "losses" | "draws" | "eloRating"> & {
+type MongoPlayerDocument = Omit<StoredPlayerProfile, "id" | "crystals" | "totalXp" | "wins" | "losses" | "draws" | "eloRating" | "avatarUrl"> & {
   createdAt: Date;
   updatedAt: Date;
   crystals?: number;
@@ -34,6 +35,7 @@ type MongoPlayerDocument = Omit<StoredPlayerProfile, "id" | "crystals" | "totalX
   losses?: number;
   draws?: number;
   eloRating?: number;
+  avatarUrl?: string;
 };
 
 type MongoBoosterOpeningDocument = {
@@ -61,7 +63,7 @@ export function getMongoPlayerProfileStore() {
   return new MongoPlayerProfileStore(clientPromise, dbName);
 }
 
-export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewardsStore {
+export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewardsStore, PlayerAvatarStore {
   private indexesReady?: Promise<void>;
   private boosterOpeningIndexesReady?: Promise<void>;
 
@@ -186,6 +188,31 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
 
       throw error;
     }
+  }
+
+  async setAvatarUrl(identity: PlayerIdentity, avatarUrl: string): Promise<StoredPlayerProfile> {
+    const players = await this.getPlayersCollection();
+    const sanitized = normalizeAvatarUrl(avatarUrl);
+    if (sanitized === undefined) {
+      throw new Error("avatarUrl must be a valid https URL.");
+    }
+
+    const updated = await players.findOneAndUpdate(
+      identityFilter(identity),
+      {
+        $set: {
+          avatarUrl: sanitized,
+          updatedAt: new Date(),
+        },
+      },
+      { returnDocument: "after" },
+    );
+
+    if (!updated) {
+      throw new Error("Player profile did not exist for avatar update.");
+    }
+
+    return fromMongoDocument(updated);
   }
 
   async saveDeck(identity: PlayerIdentity, deckIds: string[]): Promise<StoredPlayerProfile> {
@@ -439,6 +466,7 @@ function identityFilter(identity: PlayerIdentity): Filter<MongoPlayerDocument> {
 }
 
 function fromMongoDocument(document: WithId<MongoPlayerDocument>): StoredPlayerProfile {
+  const avatarUrl = normalizeAvatarUrl(document.avatarUrl);
   return {
     id: document._id.toHexString(),
     identity: document.identity,
@@ -452,6 +480,7 @@ function fromMongoDocument(document: WithId<MongoPlayerDocument>): StoredPlayerP
     losses: nonNegativeIntegerOrDefault(document.losses, DEFAULT_PLAYER_LOSSES),
     draws: nonNegativeIntegerOrDefault(document.draws, DEFAULT_PLAYER_DRAWS),
     eloRating: eloRatingOrDefault(document.eloRating, DEFAULT_PLAYER_ELO_RATING),
+    ...(avatarUrl !== undefined ? { avatarUrl } : {}),
   };
 }
 

--- a/src/features/player/profile/types.ts
+++ b/src/features/player/profile/types.ts
@@ -70,6 +70,7 @@ export type PlayerProfile = {
   losses: number;
   draws: number;
   eloRating: number;
+  avatarUrl?: string;
   onboarding: PlayerOnboardingState;
 };
 
@@ -103,6 +104,7 @@ export function toPlayerProfile(profile: StoredPlayerProfile): PlayerProfile {
   const losses = normalizeNonNegativeInteger(profile.losses, DEFAULT_PLAYER_LOSSES);
   const draws = normalizeNonNegativeInteger(profile.draws, DEFAULT_PLAYER_DRAWS);
   const eloRating = normalizeEloRating(profile.eloRating, DEFAULT_PLAYER_ELO_RATING);
+  const avatarUrl = normalizeAvatarUrl(profile.avatarUrl);
   const level = computeLevelFromXp(totalXp).level;
 
   return {
@@ -119,12 +121,21 @@ export function toPlayerProfile(profile: StoredPlayerProfile): PlayerProfile {
     losses,
     draws,
     eloRating,
+    ...(avatarUrl !== undefined ? { avatarUrl } : {}),
     onboarding: createOnboardingState({
       ownedCardIds,
       deckIds,
       starterFreeBoostersRemaining,
     }),
   };
+}
+
+export function normalizeAvatarUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 2048) return undefined;
+  if (!/^https:\/\//i.test(trimmed)) return undefined;
+  return trimmed;
 }
 
 export function createOnboardingState(profile: Pick<StoredPlayerProfile, "ownedCardIds" | "deckIds" | "starterFreeBoostersRemaining">): PlayerOnboardingState {

--- a/src/features/player/ui/PlayerHud.tsx
+++ b/src/features/player/ui/PlayerHud.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useState } from "react";
+import { DEFAULT_PLAYER_AVATAR_URL, resolveAvatarUrl, useTelegramAvatar } from "@/features/player/profile/avatar";
+import type { PlayerProfile } from "@/features/player/profile/types";
+import { cn } from "@/shared/lib/cn";
+
+type Props = {
+  profile: PlayerProfile;
+  playerName?: string;
+  liveAvatarUrl?: string | null;
+  canPlay: boolean;
+  onPlay: () => void;
+};
+
+const NAME_FALLBACK = "Гравець";
+
+export function PlayerHud({ profile, playerName, liveAvatarUrl, canPlay, onPlay }: Props) {
+  const liveTelegramPhoto = useTelegramAvatar();
+  const liveAvatar = liveAvatarUrl ?? liveTelegramPhoto;
+  const avatarUrl = resolveAvatarUrl({ storedAvatarUrl: profile.avatarUrl, liveAvatarUrl: liveAvatar });
+  const displayName = (playerName?.trim() || NAME_FALLBACK).slice(0, 32);
+
+  return (
+    <>
+      <SidebarHud
+        profile={profile}
+        playerName={displayName}
+        avatarUrl={avatarUrl}
+        canPlay={canPlay}
+        onPlay={onPlay}
+      />
+      <MobileHud profile={profile} playerName={displayName} avatarUrl={avatarUrl} />
+    </>
+  );
+}
+
+function SidebarHud({
+  profile,
+  playerName,
+  avatarUrl,
+  canPlay,
+  onPlay,
+}: {
+  profile: PlayerProfile;
+  playerName: string;
+  avatarUrl: string;
+  canPlay: boolean;
+  onPlay: () => void;
+}) {
+  return (
+    <aside
+      className="hidden md:flex md:flex-col md:gap-3 md:sticky md:top-0 md:z-40 md:h-screen md:w-[220px] md:shrink-0 md:border-r md:border-[#d4b06a]/25 md:bg-[linear-gradient(180deg,rgba(20,25,28,0.96),rgba(8,10,13,0.98))] md:px-3 md:py-4 md:shadow-[0_18px_44px_rgba(0,0,0,0.42)]"
+      data-testid="player-hud-sidebar"
+      data-profile-crystals={profile.crystals}
+      data-profile-level={profile.level}
+      data-profile-elo={profile.eloRating}
+    >
+      <div className="grid gap-0.5 text-center">
+        <b className="text-[10px] font-black uppercase tracking-[0.18em] text-[#d4b06a]">Бойова картотека</b>
+        <strong className="text-2xl font-black uppercase leading-none text-[#fff0ad] [text-shadow:0_3px_0_rgba(0,0,0,0.72)]">
+          Нексус
+        </strong>
+      </div>
+
+      <div className="grid place-items-center gap-2">
+        <HudAvatar src={avatarUrl} size={96} testId="player-hud-avatar-sidebar" />
+        <strong
+          className="block max-w-full truncate text-sm font-black uppercase tracking-[0.04em] text-[#fff7df]"
+          data-testid="player-hud-name"
+        >
+          {playerName}
+        </strong>
+        <b
+          className="rounded bg-[#1a2226] px-2 py-0.5 text-[11px] font-black uppercase tracking-[0.12em] text-[#9ed6e4]"
+          data-testid="player-hud-level"
+        >
+          Lv {profile.level}
+        </b>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <HudStatTile
+          icon="💎"
+          label="Кристали"
+          value={profile.crystals}
+          testId="player-hud-crystals"
+          tone="crystal"
+        />
+        <HudStatTile
+          icon="🏆"
+          label="ELO"
+          value={profile.eloRating}
+          testId="player-hud-elo"
+          tone="elo"
+        />
+      </div>
+
+      <button
+        type="button"
+        className={cn(
+          "min-h-[44px] rounded-md px-4 text-sm font-black uppercase tracking-[0.08em] transition",
+          canPlay
+            ? "bg-[linear-gradient(180deg,#fff26d,#e3b51e_54%,#a66d12)] text-[#1a1408] hover:brightness-110"
+            : "cursor-not-allowed bg-white/5 text-[#7e7668]",
+        )}
+        disabled={!canPlay}
+        onClick={onPlay}
+        data-testid="player-hud-play"
+      >
+        Грати
+      </button>
+
+      <div className="mt-auto" />
+
+      <div
+        className="grid min-h-[44px] place-items-center rounded-md border border-dashed border-white/10 bg-black/20 px-2 text-[10px] font-black uppercase tracking-[0.12em] text-[#5d5443]"
+        data-testid="player-hud-online-slot"
+      >
+        Онлайн
+      </div>
+    </aside>
+  );
+}
+
+function MobileHud({
+  profile,
+  playerName,
+  avatarUrl,
+}: {
+  profile: PlayerProfile;
+  playerName: string;
+  avatarUrl: string;
+}) {
+  return (
+    <header
+      className="md:hidden sticky top-0 z-40 flex items-center gap-2 border-b border-[#d4b06a]/25 bg-[linear-gradient(180deg,rgba(18,22,25,0.94),rgba(8,10,13,0.96))] px-2 py-1.5 shadow-[0_8px_22px_rgba(0,0,0,0.45)]"
+      data-testid="player-hud-mobile"
+      data-profile-crystals={profile.crystals}
+      data-profile-level={profile.level}
+      data-profile-elo={profile.eloRating}
+    >
+      <HudAvatar src={avatarUrl} size={40} testId="player-hud-avatar-mobile" />
+
+      <div className="grid min-w-0 flex-1 gap-0.5">
+        <strong
+          className="block truncate text-[11px] font-black uppercase tracking-[0.06em] text-[#fff0ad]"
+          data-testid="player-hud-name-mobile"
+        >
+          {playerName}
+        </strong>
+        <span
+          className="block truncate text-[10px] font-black uppercase tracking-[0.08em] text-[#cbbd99]"
+          data-testid="player-hud-stats-mobile"
+        >
+          <b className="text-[#9ed6e4]" data-testid="player-hud-level-mobile">
+            Lv {profile.level}
+          </b>
+          {" · 💎 "}
+          <b className="text-[#ffe08a]" data-testid="player-hud-crystals-mobile">
+            {profile.crystals}
+          </b>
+          {" · 🏆 "}
+          <b className="text-[#fff7df]" data-testid="player-hud-elo-mobile">
+            {profile.eloRating}
+          </b>
+        </span>
+      </div>
+
+      <span
+        className="grid h-3 w-3 place-items-center rounded-full border border-white/15 bg-black/45"
+        data-testid="player-hud-online-slot-mobile"
+        aria-hidden="true"
+      />
+    </header>
+  );
+}
+
+function HudAvatar({ src, size, testId }: { src: string; size: number; testId: string }) {
+  // src is part of the key so React re-mounts when the resolved URL changes,
+  // which resets the local error-fallback state without an effect.
+  return <HudAvatarImage key={src} src={src} size={size} testId={testId} />;
+}
+
+function HudAvatarImage({ src, size, testId }: { src: string; size: number; testId: string }) {
+  // Telegram-hosted photos can 404 or expire; fall back to the default art
+  // locally without dragging the parent into transient CDN failures.
+  const [resolvedSrc, setResolvedSrc] = useState(src);
+
+  return (
+    <span
+      className="grid place-items-center overflow-hidden rounded-full border-2 border-[#ffe08a]/65 bg-black shadow-[0_8px_22px_rgba(0,0,0,0.4)]"
+      style={{ width: size, height: size }}
+      data-testid={testId}
+      data-avatar-src={resolvedSrc}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={resolvedSrc}
+        alt=""
+        width={size}
+        height={size}
+        className="h-full w-full object-cover"
+        onError={() => {
+          if (resolvedSrc !== DEFAULT_PLAYER_AVATAR_URL) setResolvedSrc(DEFAULT_PLAYER_AVATAR_URL);
+        }}
+      />
+    </span>
+  );
+}
+
+function HudStatTile({
+  icon,
+  label,
+  value,
+  testId,
+  tone,
+}: {
+  icon: string;
+  label: string;
+  value: number;
+  testId: string;
+  tone: "crystal" | "elo";
+}) {
+  return (
+    <div
+      className={cn(
+        "grid gap-0.5 rounded-md border border-white/10 bg-black/35 px-2 py-1.5 text-center",
+        tone === "crystal" ? "shadow-[inset_0_0_0_1px_rgba(255,224,138,0.18)]" : "shadow-[inset_0_0_0_1px_rgba(101,215,233,0.18)]",
+      )}
+      data-testid={testId}
+      data-value={value}
+    >
+      <span aria-hidden="true" className="text-base leading-none">
+        {icon}
+      </span>
+      <b
+        className={cn(
+          "block text-base font-black leading-none",
+          tone === "crystal" ? "text-[#ffe08a]" : "text-[#9ed6e4]",
+        )}
+      >
+        {value}
+      </b>
+      <span className="block text-[9px] font-black uppercase tracking-[0.12em] text-[#7e7567]">{label}</span>
+    </div>
+  );
+}

--- a/tests/fixtures/playerProfile.ts
+++ b/tests/fixtures/playerProfile.ts
@@ -62,6 +62,13 @@ export async function mockDeckReadyProfile(page: Page, options: MockDeckReadyPro
       deckIds: requestBody.deckIds ?? options.deckIds ?? profile?.deckIds ?? PROFILE_DECK_IDS,
       starterFreeBoostersRemaining: options.starterFreeBoostersRemaining ?? profile?.starterFreeBoostersRemaining ?? 0,
       openedBoosterIds: options.openedBoosterIds ?? profile?.openedBoosterIds ?? ["neon-breach", "factory-shift"],
+      crystals: options.crystals ?? profile?.crystals,
+      totalXp: options.totalXp ?? profile?.totalXp,
+      level: options.level ?? profile?.level,
+      wins: options.wins ?? profile?.wins,
+      losses: options.losses ?? profile?.losses,
+      draws: options.draws ?? profile?.draws,
+      eloRating: options.eloRating ?? profile?.eloRating,
       avatarUrl: options.avatarUrl ?? profile?.avatarUrl,
     };
     const handled = await options.onDeckSave?.(route, profile);
@@ -82,6 +89,13 @@ export async function mockDeckReadyProfile(page: Page, options: MockDeckReadyPro
       deckIds: options.deckIds ?? profile?.deckIds ?? PROFILE_DECK_IDS,
       starterFreeBoostersRemaining: options.starterFreeBoostersRemaining ?? profile?.starterFreeBoostersRemaining ?? 0,
       openedBoosterIds: options.openedBoosterIds ?? profile?.openedBoosterIds ?? ["neon-breach", "factory-shift"],
+      crystals: options.crystals ?? profile?.crystals,
+      totalXp: options.totalXp ?? profile?.totalXp,
+      level: options.level ?? profile?.level,
+      wins: options.wins ?? profile?.wins,
+      losses: options.losses ?? profile?.losses,
+      draws: options.draws ?? profile?.draws,
+      eloRating: options.eloRating ?? profile?.eloRating,
       avatarUrl: options.avatarUrl ?? profile?.avatarUrl,
     };
     await seedServerPlayerProfile(page, profile);
@@ -128,6 +142,7 @@ function createPlayerProfileBody(profile: TestPlayerProfileInput) {
     losses: profile.losses ?? 0,
     draws: profile.draws ?? 0,
     eloRating: profile.eloRating ?? 1000,
+    ...(profile.avatarUrl ? { avatarUrl: profile.avatarUrl } : {}),
     onboarding: {
       starterBoostersAvailable: profile.starterFreeBoostersRemaining > 0,
       collectionReady,
@@ -145,6 +160,13 @@ function createTestProfileInput(options: MockDeckReadyProfileOptions, identity: 
     deckIds: options.deckIds ?? PROFILE_DECK_IDS,
     starterFreeBoostersRemaining: options.starterFreeBoostersRemaining ?? 0,
     openedBoosterIds: options.openedBoosterIds ?? ["neon-breach", "factory-shift"],
+    crystals: options.crystals,
+    totalXp: options.totalXp,
+    level: options.level,
+    wins: options.wins,
+    losses: options.losses,
+    draws: options.draws,
+    eloRating: options.eloRating,
     avatarUrl: options.avatarUrl,
   };
 }

--- a/tests/player-hud.spec.ts
+++ b/tests/player-hud.spec.ts
@@ -1,0 +1,200 @@
+import { expect, test } from "@playwright/test";
+import type { PlayerIdentity } from "../src/features/player/profile/types";
+import { mockDeckReadyProfile } from "./fixtures/playerProfile";
+
+const HUD_PROFILE_FIELDS = {
+  crystals: 247,
+  totalXp: 350,
+  eloRating: 1184,
+  wins: 4,
+  losses: 1,
+  draws: 0,
+} as const;
+
+const TELEGRAM_PHOTO_URL = "https://t.me/i/userpic/320/cyber-brawler-test.jpg";
+
+test("desktop sidebar HUD shows persisted crystals, level, and ELO on the Collection screen", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await mockDeckReadyProfile(page, {
+    ...HUD_PROFILE_FIELDS,
+  });
+  await page.goto("/");
+
+  const sidebar = page.getByTestId("player-hud-sidebar");
+  await expect(sidebar).toBeVisible();
+  await expect(sidebar).toHaveAttribute("data-profile-crystals", String(HUD_PROFILE_FIELDS.crystals));
+  await expect(sidebar).toHaveAttribute("data-profile-level", "2");
+  await expect(sidebar).toHaveAttribute("data-profile-elo", String(HUD_PROFILE_FIELDS.eloRating));
+
+  await expect(page.getByTestId("player-hud-crystals")).toHaveAttribute("data-value", String(HUD_PROFILE_FIELDS.crystals));
+  await expect(page.getByTestId("player-hud-elo")).toHaveAttribute("data-value", String(HUD_PROFILE_FIELDS.eloRating));
+  await expect(page.getByTestId("player-hud-level")).toHaveText(/Lv\s+2/);
+
+  await expect(page.getByTestId("player-hud-mobile")).toBeHidden();
+  await expect(page.getByTestId("player-hud-online-slot")).toBeVisible();
+
+  // Desktop sidebar PLAY button starts a match through the existing entry point.
+  const playButton = page.getByTestId("player-hud-play");
+  await expect(playButton).toBeEnabled();
+  await playButton.click();
+
+  await expect(page.getByTestId("player-profile-shell")).toHaveCount(0);
+});
+
+test("mobile top strip HUD renders inline stats and reserves the online dot", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await mockDeckReadyProfile(page, {
+    ...HUD_PROFILE_FIELDS,
+  });
+  await page.goto("/");
+
+  const mobileStrip = page.getByTestId("player-hud-mobile");
+  await expect(mobileStrip).toBeVisible();
+  await expect(mobileStrip).toHaveAttribute("data-profile-crystals", String(HUD_PROFILE_FIELDS.crystals));
+  await expect(mobileStrip).toHaveAttribute("data-profile-level", "2");
+  await expect(mobileStrip).toHaveAttribute("data-profile-elo", String(HUD_PROFILE_FIELDS.eloRating));
+
+  await expect(page.getByTestId("player-hud-crystals-mobile")).toHaveText(String(HUD_PROFILE_FIELDS.crystals));
+  await expect(page.getByTestId("player-hud-elo-mobile")).toHaveText(String(HUD_PROFILE_FIELDS.eloRating));
+  await expect(page.getByTestId("player-hud-level-mobile")).toHaveText(/Lv\s+2/);
+
+  await expect(page.getByTestId("player-hud-sidebar")).toBeHidden();
+  await expect(page.getByTestId("player-hud-online-slot-mobile")).toBeVisible();
+});
+
+test("HUD avatar prefers the persisted profile avatarUrl over the live Telegram photo", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const persistedAvatar = "https://t.me/i/userpic/320/persisted-avatar.jpg";
+
+  await page.route("https://telegram.org/js/telegram-web-app.js", async (route) => {
+    await route.fulfill({ contentType: "application/javascript", body: "" });
+  });
+  await page.addInitScript((photoUrl) => {
+    Object.defineProperty(window, "Telegram", {
+      configurable: true,
+      value: {
+        WebApp: {
+          initData: "mvp-hud-telegram-id",
+          initDataUnsafe: {
+            user: {
+              id: 1010101,
+              username: "hudtester",
+              first_name: "Hud",
+              last_name: "Tester",
+              photo_url: photoUrl,
+            },
+          },
+          ready() {},
+          expand() {},
+          disableVerticalSwipes() {},
+          isVersionAtLeast() {
+            return false;
+          },
+        },
+      },
+    });
+  }, TELEGRAM_PHOTO_URL);
+
+  const identity: PlayerIdentity = { mode: "telegram", telegramId: "1010101" };
+  await mockDeckReadyProfile(page, {
+    identity,
+    avatarUrl: persistedAvatar,
+    ...HUD_PROFILE_FIELDS,
+  });
+  await page.goto("/");
+
+  const avatar = page.getByTestId("player-hud-avatar-sidebar");
+  await expect(avatar).toBeVisible();
+  await expect(avatar).toHaveAttribute("data-avatar-src", persistedAvatar);
+});
+
+test("HUD avatar falls back to the live Telegram photo when no avatarUrl is persisted, then persists it", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+
+  await page.route("https://telegram.org/js/telegram-web-app.js", async (route) => {
+    await route.fulfill({ contentType: "application/javascript", body: "" });
+  });
+  await page.addInitScript((photoUrl) => {
+    Object.defineProperty(window, "Telegram", {
+      configurable: true,
+      value: {
+        WebApp: {
+          initData: "mvp-hud-telegram-id-2",
+          initDataUnsafe: {
+            user: {
+              id: 2020202,
+              username: "hudtester2",
+              first_name: "Hud",
+              last_name: "Two",
+              photo_url: photoUrl,
+            },
+          },
+          ready() {},
+          expand() {},
+          disableVerticalSwipes() {},
+          isVersionAtLeast() {
+            return false;
+          },
+        },
+      },
+    });
+  }, TELEGRAM_PHOTO_URL);
+
+  const identity: PlayerIdentity = { mode: "telegram", telegramId: "2020202" };
+  const persistedUrls: string[] = [];
+
+  await page.route("**/api/player/avatar", async (route) => {
+    const requestBody = route.request().postDataJSON() as { avatarUrl?: string };
+    if (typeof requestBody.avatarUrl === "string") persistedUrls.push(requestBody.avatarUrl);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        player: {
+          id: "player-hud-live",
+          identity,
+          ownedCardIds: [],
+          deckIds: [],
+          starterFreeBoostersRemaining: 0,
+          openedBoosterIds: [],
+          crystals: HUD_PROFILE_FIELDS.crystals,
+          totalXp: HUD_PROFILE_FIELDS.totalXp,
+          level: 2,
+          wins: HUD_PROFILE_FIELDS.wins,
+          losses: HUD_PROFILE_FIELDS.losses,
+          draws: HUD_PROFILE_FIELDS.draws,
+          eloRating: HUD_PROFILE_FIELDS.eloRating,
+          avatarUrl: requestBody.avatarUrl,
+          onboarding: { starterBoostersAvailable: false, collectionReady: false, deckReady: false, completed: true },
+        },
+      }),
+    });
+  });
+
+  await mockDeckReadyProfile(page, {
+    identity,
+    avatarUrl: undefined,
+    ...HUD_PROFILE_FIELDS,
+  });
+  await page.goto("/");
+
+  const avatar = page.getByTestId("player-hud-avatar-sidebar");
+  await expect(avatar).toBeVisible();
+  await expect(avatar).toHaveAttribute("data-avatar-src", TELEGRAM_PHOTO_URL);
+
+  await expect.poll(() => persistedUrls.length).toBeGreaterThanOrEqual(1);
+  expect(persistedUrls[0]).toBe(TELEGRAM_PHOTO_URL);
+});
+
+test("HUD is hidden during active battle phases", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await mockDeckReadyProfile(page, { ...HUD_PROFILE_FIELDS });
+  await page.goto("/");
+
+  await expect(page.getByTestId("player-hud-sidebar")).toBeVisible();
+
+  await page.getByTestId("play-selected-deck").click();
+
+  await expect(page.getByTestId("player-hud-sidebar")).toHaveCount(0);
+  await expect(page.getByTestId("player-hud-mobile")).toHaveCount(0);
+});

--- a/tests/player-hud.spec.ts
+++ b/tests/player-hud.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import type { PlayerIdentity } from "../src/features/player/profile/types";
-import { mockDeckReadyProfile } from "./fixtures/playerProfile";
+import { mockDeckReadyProfile, PROFILE_DECK_IDS, PROFILE_OWNED_CARD_IDS } from "./fixtures/playerProfile";
 
 const HUD_PROFILE_FIELDS = {
   crystals: 247,
@@ -184,6 +184,115 @@ test("HUD avatar falls back to the live Telegram photo when no avatarUrl is pers
 
   await expect.poll(() => persistedUrls.length).toBeGreaterThanOrEqual(1);
   expect(persistedUrls[0]).toBe(TELEGRAM_PHOTO_URL);
+});
+
+test("a stale avatar-save response does not roll back deck mutations made while the save was in flight", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+
+  await page.route("https://telegram.org/js/telegram-web-app.js", async (route) => {
+    await route.fulfill({ contentType: "application/javascript", body: "" });
+  });
+  await page.addInitScript((photoUrl) => {
+    Object.defineProperty(window, "Telegram", {
+      configurable: true,
+      value: {
+        WebApp: {
+          initData: "mvp-hud-stale-race",
+          initDataUnsafe: {
+            user: {
+              id: 3030303,
+              username: "stalerace",
+              first_name: "Stale",
+              last_name: "Race",
+              photo_url: photoUrl,
+            },
+          },
+          ready() {},
+          expand() {},
+          disableVerticalSwipes() {},
+          isVersionAtLeast() {
+            return false;
+          },
+        },
+      },
+    });
+  }, TELEGRAM_PHOTO_URL);
+
+  const identity: PlayerIdentity = { mode: "telegram", telegramId: "3030303" };
+  const extraOwnedCardId = PROFILE_OWNED_CARD_IDS.find((cardId) => !PROFILE_DECK_IDS.includes(cardId));
+  if (!extraOwnedCardId) throw new Error("Fixture must include an owned card outside the deck.");
+
+  const baseProfilePayload = {
+    id: "player-hud-stale-race",
+    identity,
+    ownedCardIds: PROFILE_OWNED_CARD_IDS,
+    deckIds: PROFILE_DECK_IDS,
+    starterFreeBoostersRemaining: 0,
+    openedBoosterIds: ["neon-breach", "factory-shift"],
+    crystals: HUD_PROFILE_FIELDS.crystals,
+    totalXp: HUD_PROFILE_FIELDS.totalXp,
+    level: 2,
+    wins: HUD_PROFILE_FIELDS.wins,
+    losses: HUD_PROFILE_FIELDS.losses,
+    draws: HUD_PROFILE_FIELDS.draws,
+    eloRating: HUD_PROFILE_FIELDS.eloRating,
+    onboarding: { starterBoostersAvailable: false, collectionReady: true, deckReady: true, completed: true },
+  };
+
+  let resolveAvatarRoute: (() => void) | undefined;
+  const avatarRouteReady = new Promise<void>((resolve) => {
+    resolveAvatarRoute = resolve;
+  });
+
+  await page.route("**/api/player/avatar", async (route) => {
+    const requestBody = route.request().postDataJSON() as { avatarUrl?: string };
+    await avatarRouteReady;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        player: { ...baseProfilePayload, deckIds: PROFILE_DECK_IDS, avatarUrl: requestBody.avatarUrl },
+      }),
+    });
+  });
+
+  await page.route("**/api/player/deck", async (route) => {
+    const requestBody = route.request().postDataJSON() as { deckIds?: string[] };
+    const nextDeckIds = requestBody.deckIds ?? PROFILE_DECK_IDS;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        player: { ...baseProfilePayload, deckIds: nextDeckIds },
+      }),
+    });
+  });
+
+  await page.route("**/api/player", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ player: baseProfilePayload }),
+    });
+  });
+
+  await page.goto("/");
+
+  await expect(page.getByTestId("player-hud-sidebar")).toBeVisible();
+  await expect(page.locator('[data-testid^="deck-card-"]')).toHaveCount(PROFILE_DECK_IDS.length);
+
+  const profileShell = page.getByTestId("player-profile-shell");
+
+  await page.getByTestId(`collection-toggle-${extraOwnedCardId}`).click({ force: true });
+  await expect(page.getByTestId("deck-save-status")).toHaveAttribute("data-status", "saved");
+  await expect(profileShell).toHaveAttribute("data-profile-deck-count", String(PROFILE_DECK_IDS.length + 1));
+  await expect(page.getByTestId(`deck-card-${extraOwnedCardId}`)).toBeVisible();
+
+  resolveAvatarRoute?.();
+
+  await expect(page.getByTestId("player-hud-avatar-sidebar")).toHaveAttribute("data-avatar-src", TELEGRAM_PHOTO_URL);
+  await expect(profileShell).toHaveAttribute("data-profile-deck-count", String(PROFILE_DECK_IDS.length + 1));
+  await expect(page.getByTestId(`deck-card-${extraOwnedCardId}`)).toBeVisible();
 });
 
 test("HUD is hidden during active battle phases", async ({ page }) => {

--- a/tests/playerAvatar.test.ts
+++ b/tests/playerAvatar.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_PLAYER_AVATAR_URL,
+  resolveAvatarUrl,
+} from "../src/features/player/profile/avatar";
+import {
+  handlePlayerAvatarPost,
+  type PlayerAvatarStore,
+} from "../src/features/player/profile/api";
+import {
+  createNewStoredPlayerProfile,
+  isSamePlayerIdentity,
+  normalizeAvatarUrl,
+  toPlayerProfile,
+  type PlayerIdentity,
+  type PlayerProfile,
+  type StoredPlayerProfile,
+} from "../src/features/player/profile/types";
+
+describe("resolveAvatarUrl priority", () => {
+  test("prefers the persisted profile avatarUrl over the live Telegram photo", () => {
+    expect(
+      resolveAvatarUrl({
+        storedAvatarUrl: "https://t.me/i/userpic/stored.jpg",
+        liveAvatarUrl: "https://t.me/i/userpic/live.jpg",
+      }),
+    ).toBe("https://t.me/i/userpic/stored.jpg");
+  });
+
+  test("falls back to the live Telegram photo when no value is persisted", () => {
+    expect(
+      resolveAvatarUrl({
+        storedAvatarUrl: undefined,
+        liveAvatarUrl: "https://t.me/i/userpic/live.jpg",
+      }),
+    ).toBe("https://t.me/i/userpic/live.jpg");
+  });
+
+  test("falls back to the default character art when neither is available", () => {
+    expect(resolveAvatarUrl({ storedAvatarUrl: null, liveAvatarUrl: null })).toBe(
+      DEFAULT_PLAYER_AVATAR_URL,
+    );
+  });
+
+  test("treats empty / whitespace-only values as missing", () => {
+    expect(resolveAvatarUrl({ storedAvatarUrl: "   ", liveAvatarUrl: "   " })).toBe(
+      DEFAULT_PLAYER_AVATAR_URL,
+    );
+    expect(
+      resolveAvatarUrl({ storedAvatarUrl: "  ", liveAvatarUrl: "https://t.me/i/userpic/live.jpg" }),
+    ).toBe("https://t.me/i/userpic/live.jpg");
+  });
+});
+
+describe("normalizeAvatarUrl", () => {
+  test("accepts trimmed https URLs and rejects http or non-string values", () => {
+    expect(normalizeAvatarUrl("  https://t.me/i/userpic/abc.jpg  ")).toBe(
+      "https://t.me/i/userpic/abc.jpg",
+    );
+    expect(normalizeAvatarUrl("http://insecure.example/photo.jpg")).toBeUndefined();
+    expect(normalizeAvatarUrl("")).toBeUndefined();
+    expect(normalizeAvatarUrl(undefined)).toBeUndefined();
+    expect(normalizeAvatarUrl(42)).toBeUndefined();
+    expect(normalizeAvatarUrl({ url: "https://t.me/photo.jpg" })).toBeUndefined();
+  });
+
+  test("rejects suspiciously long URLs to keep the persisted field bounded", () => {
+    const longUrl = `https://t.me/${"x".repeat(2100)}`;
+    expect(normalizeAvatarUrl(longUrl)).toBeUndefined();
+  });
+});
+
+describe("toPlayerProfile avatar default", () => {
+  test("defaults avatarUrl to undefined when the stored profile lacks the field", () => {
+    const profile = toPlayerProfile({
+      id: "player-1",
+      identity: { mode: "guest", guestId: "guest-1" },
+      ownedCardIds: [],
+      deckIds: [],
+      starterFreeBoostersRemaining: 0,
+      openedBoosterIds: [],
+      crystals: 0,
+      totalXp: 0,
+      wins: 0,
+      losses: 0,
+      draws: 0,
+      eloRating: 1000,
+    });
+
+    expect(profile.avatarUrl).toBeUndefined();
+  });
+
+  test("preserves a normalized avatarUrl through toPlayerProfile", () => {
+    const profile = toPlayerProfile({
+      id: "player-2",
+      identity: { mode: "telegram", telegramId: "9000" },
+      ownedCardIds: [],
+      deckIds: [],
+      starterFreeBoostersRemaining: 0,
+      openedBoosterIds: [],
+      crystals: 0,
+      totalXp: 0,
+      wins: 0,
+      losses: 0,
+      draws: 0,
+      eloRating: 1000,
+      avatarUrl: "https://t.me/i/userpic/abc.jpg",
+    });
+
+    expect(profile.avatarUrl).toBe("https://t.me/i/userpic/abc.jpg");
+  });
+
+  test("drops an invalid stored avatarUrl rather than surfacing it to the client", () => {
+    const profile = toPlayerProfile({
+      id: "player-3",
+      identity: { mode: "telegram", telegramId: "9001" },
+      ownedCardIds: [],
+      deckIds: [],
+      starterFreeBoostersRemaining: 0,
+      openedBoosterIds: [],
+      crystals: 0,
+      totalXp: 0,
+      wins: 0,
+      losses: 0,
+      draws: 0,
+      eloRating: 1000,
+      avatarUrl: "javascript:alert(1)",
+    });
+
+    expect(profile.avatarUrl).toBeUndefined();
+  });
+});
+
+describe("handlePlayerAvatarPost", () => {
+  test("persists a valid https avatar URL and returns the normalized profile", async () => {
+    const identity: PlayerIdentity = { mode: "telegram", telegramId: "55501" };
+    const store = new MemoryAvatarStore([
+      { ...createNewStoredPlayerProfile("player-avatar-1", identity) },
+    ]);
+
+    const response = await postAvatar(store, {
+      identity,
+      avatarUrl: "  https://t.me/i/userpic/abc.jpg  ",
+    });
+    const body = (await response.json()) as { player: PlayerProfile };
+
+    expect(response.status).toBe(200);
+    expect(body.player.avatarUrl).toBe("https://t.me/i/userpic/abc.jpg");
+    expect(store.snapshot(identity)?.avatarUrl).toBe("https://t.me/i/userpic/abc.jpg");
+  });
+
+  test("rejects an http URL with a 400 invalid_avatar", async () => {
+    const identity: PlayerIdentity = { mode: "telegram", telegramId: "55502" };
+    const store = new MemoryAvatarStore([
+      { ...createNewStoredPlayerProfile("player-avatar-2", identity) },
+    ]);
+
+    const response = await postAvatar(store, {
+      identity,
+      avatarUrl: "http://insecure.example/photo.jpg",
+    });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("invalid_avatar");
+    expect(store.snapshot(identity)?.avatarUrl).toBeUndefined();
+  });
+
+  test("rejects a missing identity with a 400 invalid_identity", async () => {
+    const store = new MemoryAvatarStore();
+    const response = await postAvatar(store, { avatarUrl: "https://t.me/i/userpic/abc.jpg" });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("invalid_identity");
+  });
+});
+
+class MemoryAvatarStore implements PlayerAvatarStore {
+  private readonly profiles: StoredPlayerProfile[];
+  private nextId: number;
+
+  constructor(profiles: StoredPlayerProfile[] = []) {
+    this.profiles = profiles;
+    this.nextId = profiles.length + 1;
+  }
+
+  async findOrCreateByIdentity(identity: PlayerIdentity): Promise<StoredPlayerProfile> {
+    const existing = this.profiles.find((profile) => isSamePlayerIdentity(profile.identity, identity));
+    if (existing) return existing;
+
+    const profile = createNewStoredPlayerProfile(`player-${this.nextId}`, identity);
+    this.nextId += 1;
+    this.profiles.push(profile);
+    return profile;
+  }
+
+  async setAvatarUrl(identity: PlayerIdentity, avatarUrl: string): Promise<StoredPlayerProfile> {
+    const index = this.profiles.findIndex((profile) => isSamePlayerIdentity(profile.identity, identity));
+    if (index < 0) throw new Error("Profile does not exist.");
+    this.profiles[index] = { ...this.profiles[index], avatarUrl };
+    return this.profiles[index];
+  }
+
+  snapshot(identity: PlayerIdentity): StoredPlayerProfile | undefined {
+    return this.profiles.find((profile) => isSamePlayerIdentity(profile.identity, identity));
+  }
+}
+
+function postAvatar(store: PlayerAvatarStore, body: unknown) {
+  return handlePlayerAvatarPost(
+    new Request("http://localhost/api/player/avatar", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    store,
+  );
+}


### PR DESCRIPTION
## Summary

Fifth slice of the player-progression feature (#25). Adds a persistent player HUD on every out-of-battle screen (Collection, Deck, Home, Onboarding) that shows the player's avatar, name, level, crystals, and ELO. The HUD ships in two layouts via Tailwind's `md:` breakpoint:

- **Desktop / Tablet (>=768px)**: left sidebar with NEXUS logo, large avatar + name + level badge, two stat tiles (crystals + ELO), a large PLAY button, and an empty `data-testid=\"player-hud-online-slot\"` reserved at the bottom for a future online-count counter.
- **Mobile (<768px)**: sticky top strip with a 40px avatar, inline `Lv N | crystals X | ELO Y`, and a small `data-testid=\"player-hud-online-slot-mobile\"` placeholder dot.

Avatar resolution priority (centralized in `resolveAvatarUrl`):
1. `profile.avatarUrl` (persisted)
2. `useTelegramAvatar()` (live `window.Telegram.WebApp.initDataUnsafe.user.photo_url`)
3. `/nexus-assets/characters/cyber-brawler-thumb.png` (default character art)

Live Telegram photos are persisted opportunistically: when a profile loads and the live `photo_url` differs from `profile.avatarUrl`, the client posts to a new `POST /api/player/avatar` endpoint. Persistence failures are non-fatal and fall back to the live URL for the session (no \"default-on-throw\").

The HUD is mounted in `GameRoot` via a `HudShell` wrapper that flexes the sidebar alongside the existing screen content on `md:` and stacks the mobile header above on smaller viewports. The HUD never renders inside the battle screens — when `screen === \"battle\"` the existing `BattleGame` / `RealtimeBattleGame` render unmodified, exactly as before this slice.

Closes #30. Parent: #25.

## Acceptance criteria (from #30)

- [x] New hook `useTelegramAvatar()` reads `window.Telegram?.WebApp?.initDataUnsafe?.user?.photo_url`. Returns the URL or `null`. (`src/features/player/profile/avatar.ts`).
- [x] `PlayerProfile` gains `avatarUrl?: string` (optional). On profile load, if the Telegram photo URL is present and the stored value differs, persist it via `POST /api/player/avatar` (`src/features/player/profile/types.ts` + `GameRoot.tsx`).
- [x] New `PlayerHud` component, responsive:
  - **>=768px**: left sidebar — NEXUS logo, avatar (96px) + name + Lv badge + crystal/ELO tiles, large PLAY button, empty online slot at the bottom.
  - **<768px**: compact top strip — 40px avatar + inline `Lv N | crystals X | ELO Y` + small placeholder dot.
  - Avatar source: `profile.avatarUrl || useTelegramAvatar() || /nexus-assets/characters/cyber-brawler-thumb.png`.
- [x] HUD mounted on Collection, Deck, and Home/Onboarding screens via `HudShell` in `GameRoot.tsx`. Not rendered during active battle phases (the battle screens render the existing `BattleGame` tree without the HUD wrapper).
- [x] On the desktop sidebar, the PLAY button calls the same `handleSavedDeckPlay(profileDeckIds, \"ai\")` path the home screen Collection \"Грати\" button uses today. Disabled until the saved deck is ready (`deckReadyToPlay`).
- [x] Stats display reads from the persisted `PlayerProfile.crystals`, `level`, `eloRating` — no recomputation on the client.
- [x] Playwright e2e: navigate to Collection screen and assert the HUD shows the player's crystals, level, ELO. Mobile viewport (390x844) renders the top strip; desktop (1280x900) renders the sidebar (`tests/player-hud.spec.ts`).

## Avatar persistence model

`POST /api/player/avatar` with `{ identity, avatarUrl }` resolves to the same `PlayerAvatarStore.setAvatarUrl(identity, avatarUrl)` contract that the Mongo store and the in-memory test store both implement. The handler:
- Validates identity via the existing `parsePlayerIdentity` (rejects with `400 invalid_identity`).
- Validates the URL via `normalizeAvatarUrl` — only `https://` URLs <= 2048 chars survive (rejects with `400 invalid_avatar`).
- Persists via `$set { avatarUrl, updatedAt }` on the Mongo doc.

Avatar URL persistence is decoupled from the rest of `applyMatchRewards`'s race-correctness contract. ELO/XP/crystal flows are untouched.

## What changed

- `src/features/player/profile/types.ts`: adds optional `avatarUrl?: string` to `PlayerProfile`, normalization in `toPlayerProfile`, exports `normalizeAvatarUrl` (https-only, <= 2048 chars).
- `src/features/player/profile/avatar.ts` (new): `DEFAULT_PLAYER_AVATAR_URL`, `readTelegramPhotoUrl()`, `useTelegramAvatar()`, `resolveAvatarUrl()`. Pure with no Mongo or socket coupling.
- `src/features/player/profile/api.ts`: new `PlayerAvatarStore` interface + `handlePlayerAvatarPost(request, store)` handler + `PlayerAvatarValidationError` mapped to `400 invalid_avatar`.
- `src/features/player/profile/mongo.ts`: `MongoPlayerProfileStore` now also implements `PlayerAvatarStore.setAvatarUrl`. `MongoPlayerDocument` extended with optional `avatarUrl?: string`. `fromMongoDocument` defensively normalizes the field on read.
- `src/app/api/player/avatar/route.ts` (new): wires the new endpoint to the Mongo store.
- `src/features/player/profile/client.ts`: new `savePlayerAvatar(identity, avatarUrl)` client.
- `src/features/player/ui/PlayerHud.tsx` (new): responsive sidebar + mobile top strip. Uses Tailwind `md:` (>=768px) for desktop and base classes for mobile. Single component, two layouts via responsive classes. Uses a plain `<img>` with an `onError` fallback to the default character art (avoids adding `next/image` remote-pattern allowlist for `t.me`).
- `src/features/game/ui/GameRoot.tsx`: imports `PlayerHud` + `useTelegramAvatar`. New `HudShell` wraps Collection and Onboarding screens with the HUD. Battle screens stay un-wrapped. New effect persists `useTelegramAvatar()` to `profile.avatarUrl` once per (identity, photoUrl) tuple via `savePlayerAvatar`; failures log a warning and fall through to the live URL for the session.
- `server.js`: in-memory test store (`createMemoryPlayerProfileStore`) now implements `setAvatarUrl(identity, avatarUrl)` and `seedProfile` accepts `avatarUrl`. Test seed handler accepts the field.
- `tests/playerAvatar.test.ts` (new, 13 unit tests): `resolveAvatarUrl` priority chain (3), `normalizeAvatarUrl` validation incl. https-only + length cap (2), `toPlayerProfile` defaults + drop-invalid (3), `handlePlayerAvatarPost` 200 / 400 invalid_avatar / 400 invalid_identity (3), plus the API memory-store fixture (`MemoryAvatarStore`).
- `tests/player-hud.spec.ts` (new, 5 e2e tests): desktop sidebar shows persisted stats, mobile strip shows inline stats, avatar prefers persisted over live, avatar falls back to live and posts to `/api/player/avatar`, HUD hides during active battle phases.
- `tests/fixtures/playerProfile.ts`: extends `TestPlayerProfileInput` with `avatarUrl`, threads `crystals/totalXp/level/wins/losses/draws/eloRating/avatarUrl` through `mockDeckReadyProfile` so e2e tests can seed all progression fields without re-routing.
- `package.json`: adds `tests/playerAvatar.test.ts` to the `bun run test` set.

## WebSocket protocol changes

None. This slice is purely HTTP + UI. The HUD reads from the existing `GET /api/player` response shape (just gains an optional `avatarUrl` field).

## Test plan

### Verified

- **Unit tests in Docker**: `docker build --target builder -t nexus-card-battle:builder . && docker run --rm nexus-card-battle:builder bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts tests/roundResolverPvp.test.ts tests/elo.test.ts tests/matchmakingQueue.test.ts tests/playerAvatar.test.ts` -> **98 pass / 0 fail** (was 85 in slice 4; +13 net new avatar cases).
- **Lint**: `bun run lint` -> clean for slice-5 code (only the 2 pre-existing warnings on `Hand.tsx` + `ResourceCounter.tsx` from `5aff0d0`, unchanged here).
- **Typecheck**: `bunx tsc --noEmit` -> clean for `src/`. Test-file `bun:test` and Playwright implicit-any errors are the same pre-existing set documented in slices 1-4.
- **Build**: `bun run build` -> succeeds. `/api/player/avatar` registers as a dynamic route alongside the existing player routes.
- **Playwright e2e (locally)**: `bunx playwright test --reporter=line` against a dev server -> **56 pass / 5 fail**. The 5 failures are the same pre-existing flaky tests slices 1-4 documented (`tests/mobile-layout.spec.ts:180:7` x4 and `tests/realtime.spec.ts:10:5`); confirmed unchanged baseline by stashing this branch's diff and re-running. Net new e2e: **5 pass** in `tests/player-hud.spec.ts` (~5s total).

### Docker e2e — explicit caveat (unchanged from slices 1-4)

The Docker stack ships `mongo` + a production runtime; there is no test-runner service. The `builder` stage is Alpine-based, which Microsoft's Playwright distribution does not support (Playwright requires glibc + a Debian/Ubuntu base for the bundled Chromium). Unit tests (the only Docker-runnable slice of the suite) were verified inside the Docker `builder` image as shown above; e2e was verified locally.

## Audit observations for future slices

- The HUD's `PlayerHud` component uses a plain `<img>` with an `onError` fallback rather than `next/image`. This avoids needing a `next.config.mjs` `images.remotePatterns` allowlist for `t.me/i/userpic/...` URLs (Telegram's CDN). When a future slice wants `next/image` here (for resizing / blur-up), it will need to add `t.me` to `remotePatterns` and confirm the response headers don't break the optimizer.
- `useTelegramAvatar()` is a separate hook from the avatar-resolution chain so the future slice 7 reward overlay can opt into the same Telegram photo without duplicating the read logic. The persistence-on-mismatch effect lives in `GameRoot`, so any other surface that reads the live URL gets persistence \"for free\" while the user is on a HUD-mounted screen.
- The `HudShell` wrapper renders nothing extra for the loading / unavailable / battle code paths — it's only mounted on Collection + Onboarding. If a future slice introduces a new top-level screen, mount it in a `HudShell` to inherit the HUD; battle screens deliberately stay un-wrapped.
- The `PlayerAvatarStore` interface deliberately accepts an already-validated `string` rather than `string | null`. \"Clearing\" an avatar (going back to the default art) would need a small extension — out of scope here since onboarding never clears the photo.

## Out of scope

- Online presence broadcast / counter rendering (slice 6 fills the reserved slot).
- Reward overlay redesign — avatar block, AI/PvP buttons, hide cards (slice 7). Slice 7 can reuse `useTelegramAvatar()` + `resolveAvatarUrl()` directly without coupling to the HUD.
- Profile screen / tappable avatar -> profile detail page.
- Custom avatar frames / portrait holders.