### PR TITLE
feat(realtime): online presence count broadcast (slice 6/7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "bun server.js",
     "lint": "eslint",
-    "test": "bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts tests/roundResolverPvp.test.ts tests/elo.test.ts tests/matchmakingQueue.test.ts tests/rewardOverlayPresenter.test.ts tests/playerAvatar.test.ts",
+    "test": "bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts tests/roundResolverPvp.test.ts tests/elo.test.ts tests/matchmakingQueue.test.ts tests/rewardOverlayPresenter.test.ts tests/playerAvatar.test.ts tests/onlinePresence.test.ts",
     "test:profile": "bun test tests/playerProfile.test.ts",
     "test:e2e": "playwright test"
   },

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ const { makeFighter } = require("./src/features/battle/model/domain/fighters.ts"
 const { resolveRound } = require("./src/features/battle/model/domain/roundResolver.ts");
 const { DAMAGE_BOOST_COST } = require("./src/features/battle/model/constants.ts");
 const { MatchmakingQueue } = require("./src/features/matchmaking/queue.ts");
+const { OnlinePresence } = require("./src/features/presence/onlinePresence.ts");
 
 const dev = process.argv.includes("--dev") || process.env.NODE_ENV === "development";
 const hostname = getCliValue("--hostname") || process.env.HOSTNAME || "0.0.0.0";
@@ -38,6 +39,7 @@ const sessions = new Map();
 const matches = new Map();
 const testPlayerProfileStore = process.env.NEXUS_TEST_PROFILE_STORE === "1" ? createMemoryPlayerProfileStore() : null;
 const matchmakingQueue = new MatchmakingQueue();
+const onlinePresence = new OnlinePresence();
 const BATTLE_HAND_SIZE = 4;
 const MIN_DECK_SIZE = 9;
 const TURN_SECONDS = Number.parseInt(process.env.PVP_TURN_SECONDS || "75", 10);
@@ -76,7 +78,9 @@ app.prepare().then(() => {
     };
 
     sessions.set(session.id, session);
+    onlinePresence.add(session);
     send(session, { type: "session", clientId: session.id });
+    broadcastOnlineCount();
 
     ws.on("pong", () => {
       session.alive = true;
@@ -712,6 +716,8 @@ function cleanupSession(session) {
   }
 
   sessions.delete(session.id);
+  onlinePresence.remove(session);
+  broadcastOnlineCount();
 }
 
 function forfeitMatchByDisconnect(match, loserId) {
@@ -753,6 +759,17 @@ function broadcast(match, message) {
 function send(session, message) {
   if (!session || !isOpen(session.ws)) return;
   session.ws.send(JSON.stringify(message));
+}
+
+function broadcastOnlineCount() {
+  onlinePresence.broadcastCount({
+    send: (sessionId, payload) => {
+      send(sessions.get(sessionId), payload);
+    },
+    onSendError: ({ sessionId, error }) => {
+      console.error("Online presence broadcast failed for session.", { sessionId, error });
+    },
+  });
 }
 
 function sendError(session, message) {

--- a/src/features/player/ui/PlayerHud.tsx
+++ b/src/features/player/ui/PlayerHud.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useOnlineCount } from "@/features/presence/client";
 import { DEFAULT_PLAYER_AVATAR_URL, resolveAvatarUrl, useTelegramAvatar } from "@/features/player/profile/avatar";
 import type { PlayerProfile } from "@/features/player/profile/types";
 import { cn } from "@/shared/lib/cn";
@@ -20,6 +21,7 @@ export function PlayerHud({ profile, playerName, liveAvatarUrl, canPlay, onPlay 
   const liveAvatar = liveAvatarUrl ?? liveTelegramPhoto;
   const avatarUrl = resolveAvatarUrl({ storedAvatarUrl: profile.avatarUrl, liveAvatarUrl: liveAvatar });
   const displayName = (playerName?.trim() || NAME_FALLBACK).slice(0, 32);
+  const onlineCount = useOnlineCount();
 
   return (
     <>
@@ -29,8 +31,14 @@ export function PlayerHud({ profile, playerName, liveAvatarUrl, canPlay, onPlay 
         avatarUrl={avatarUrl}
         canPlay={canPlay}
         onPlay={onPlay}
+        onlineCount={onlineCount}
       />
-      <MobileHud profile={profile} playerName={displayName} avatarUrl={avatarUrl} />
+      <MobileHud
+        profile={profile}
+        playerName={displayName}
+        avatarUrl={avatarUrl}
+        onlineCount={onlineCount}
+      />
     </>
   );
 }
@@ -41,12 +49,14 @@ function SidebarHud({
   avatarUrl,
   canPlay,
   onPlay,
+  onlineCount,
 }: {
   profile: PlayerProfile;
   playerName: string;
   avatarUrl: string;
   canPlay: boolean;
   onPlay: () => void;
+  onlineCount: number | null;
 }) {
   return (
     <aside
@@ -114,10 +124,26 @@ function SidebarHud({
       <div className="mt-auto" />
 
       <div
-        className="grid min-h-[44px] place-items-center rounded-md border border-dashed border-white/10 bg-black/20 px-2 text-[10px] font-black uppercase tracking-[0.12em] text-[#5d5443]"
+        className={cn(
+          "grid min-h-[44px] place-items-center rounded-md border px-2 text-[11px] font-black uppercase tracking-[0.12em]",
+          onlineCount === null
+            ? "border-dashed border-white/10 bg-black/20 text-[#5d5443]"
+            : "border-[#3da06a]/40 bg-[#0d2017] text-[#bff0c4]",
+        )}
         data-testid="player-hud-online-slot"
+        data-online-count={onlineCount === null ? "" : String(onlineCount)}
       >
-        Онлайн
+        {onlineCount === null ? (
+          "Онлайн"
+        ) : (
+          <span className="flex items-center gap-1.5">
+            <span aria-hidden="true">🟢</span>
+            <b className="text-[#dff7d8]" data-testid="player-hud-online-count">
+              {onlineCount}
+            </b>
+            <span className="tracking-[0.14em] text-[#9bd3a4]">онлайн</span>
+          </span>
+        )}
       </div>
     </aside>
   );
@@ -127,10 +153,12 @@ function MobileHud({
   profile,
   playerName,
   avatarUrl,
+  onlineCount,
 }: {
   profile: PlayerProfile;
   playerName: string;
   avatarUrl: string;
+  onlineCount: number | null;
 }) {
   return (
     <header
@@ -168,10 +196,25 @@ function MobileHud({
       </div>
 
       <span
-        className="grid h-3 w-3 place-items-center rounded-full border border-white/15 bg-black/45"
+        className={cn(
+          "inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-black leading-none tracking-[0.04em]",
+          onlineCount === null
+            ? "border border-white/15 bg-black/45 text-transparent"
+            : "border border-[#3da06a]/40 bg-[#0d2017] text-[#dff7d8]",
+        )}
         data-testid="player-hud-online-slot-mobile"
-        aria-hidden="true"
-      />
+        data-online-count={onlineCount === null ? "" : String(onlineCount)}
+        aria-hidden={onlineCount === null ? "true" : undefined}
+      >
+        {onlineCount === null ? (
+          <span className="block h-2 w-2 rounded-full bg-white/15" />
+        ) : (
+          <>
+            <span aria-hidden="true">🟢</span>
+            <b data-testid="player-hud-online-count-mobile">{onlineCount}</b>
+          </>
+        )}
+      </span>
     </header>
   );
 }

--- a/src/features/presence/client.ts
+++ b/src/features/presence/client.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type OnlineCountMessage = {
+  type: "online_count";
+  count: number;
+};
+
+// Listens to the presence WebSocket and exposes the latest broadcast count.
+// Returns `null` until the first `online_count` message arrives so callers can
+// distinguish "haven't heard from the server yet" from a real "0 online".
+export function useOnlineCount(): number | null {
+  const [count, setCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof WebSocket === "undefined") return;
+
+    let disposed = false;
+    const url = getPresenceSocketUrl();
+    const socket = new WebSocket(url);
+
+    socket.addEventListener("message", (event) => {
+      if (disposed) return;
+      const parsed = parseOnlineCountMessage(event.data);
+      if (parsed === null) return;
+      setCount(parsed);
+    });
+
+    return () => {
+      disposed = true;
+      try {
+        socket.close();
+      } catch {
+        // Closing an already-closed socket is fine; nothing to do.
+      }
+    };
+  }, []);
+
+  return count;
+}
+
+export function parseOnlineCountMessage(raw: unknown): number | null {
+  if (typeof raw !== "string") return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const message = parsed as Partial<OnlineCountMessage>;
+  if (message.type !== "online_count") return null;
+  if (typeof message.count !== "number" || !Number.isFinite(message.count) || message.count < 0) return null;
+  return Math.floor(message.count);
+}
+
+function getPresenceSocketUrl() {
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${window.location.host}/ws`;
+}

--- a/src/features/presence/onlinePresence.ts
+++ b/src/features/presence/onlinePresence.ts
@@ -1,0 +1,47 @@
+export type PresenceSession = { id: string };
+
+export type OnlinePresenceSendError = {
+  sessionId: string;
+  error: unknown;
+};
+
+export type OnlinePresenceBroadcastOptions = {
+  send: (sessionId: string, payload: { type: "online_count"; count: number }) => void;
+  onSendError?: (failure: OnlinePresenceSendError) => void;
+};
+
+export class OnlinePresence {
+  private readonly sessionIds = new Set<string>();
+
+  add(session: PresenceSession): void {
+    if (!session || typeof session.id !== "string" || session.id.length === 0) return;
+    this.sessionIds.add(session.id);
+  }
+
+  remove(session: PresenceSession): void {
+    if (!session || typeof session.id !== "string" || session.id.length === 0) return;
+    this.sessionIds.delete(session.id);
+  }
+
+  has(sessionId: string): boolean {
+    return this.sessionIds.has(sessionId);
+  }
+
+  count(): number {
+    return this.sessionIds.size;
+  }
+
+  // Invokes `send` once per active session with the current count. A throw from
+  // any single send is caught and reported via `onSendError` so a failing
+  // socket cannot prevent the broadcast from reaching the rest of the room.
+  broadcastCount(options: OnlinePresenceBroadcastOptions): void {
+    const payload = { type: "online_count" as const, count: this.sessionIds.size };
+    for (const sessionId of this.sessionIds) {
+      try {
+        options.send(sessionId, payload);
+      } catch (error) {
+        options.onSendError?.({ sessionId, error });
+      }
+    }
+  }
+}

--- a/tests/online-presence.spec.ts
+++ b/tests/online-presence.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import type { PlayerIdentity } from "../src/features/player/profile/types";
+import { mockDeckReadyProfile } from "./fixtures/playerProfile";
+
+function presenceIdentity(slug: string): PlayerIdentity {
+  return { mode: "guest", guestId: `guest-presence-${slug}` };
+}
+
+// The dev server is shared across the whole test run (Playwright's
+// `reuseExistingServer: true`). Other tests' WebSocket connections take time
+// to close after their browser context exits, so the absolute presence count
+// drifts up and down asynchronously. We assert the *directional* behavior of
+// our two contexts: opening pageB makes the slotA count ≥ baseline+1 at some
+// observable moment; closing contextB makes the slotA count drop strictly
+// below the post-connect peak.
+
+async function readPresenceCount(slot: Locator): Promise<number> {
+  const raw = await slot.getAttribute("data-online-count");
+  if (raw === null || raw === "") return Number.NaN;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+async function waitForPresenceCountAtLeast(slot: Locator, minimum: number, timeout = 15_000) {
+  await expect
+    .poll(
+      async () => {
+        const value = await readPresenceCount(slot);
+        return Number.isFinite(value) && value >= minimum;
+      },
+      { timeout },
+    )
+    .toBe(true);
+}
+
+async function waitForCount(slot: Locator, predicate: (current: number) => boolean, timeout = 20_000) {
+  await expect
+    .poll(
+      async () => {
+        const value = await readPresenceCount(slot);
+        return Number.isFinite(value) && predicate(value);
+      },
+      { timeout },
+    )
+    .toBe(true);
+}
+
+async function expectVisibleOnlineLabel(page: Page, slotTestId: string) {
+  const slot = page.getByTestId(slotTestId);
+  await expect(slot).toBeVisible({ timeout: 15_000 });
+  return slot;
+}
+
+test("desktop sidebar HUD shows the live online count and increments on connect, decrements on disconnect", async ({ baseURL, browser }) => {
+  const contextA = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const contextB = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const pageA = await contextA.newPage();
+  const pageB = await contextB.newPage();
+
+  try {
+    await mockDeckReadyProfile(pageA, { identity: presenceIdentity("a"), eloRating: 1100 });
+    await mockDeckReadyProfile(pageB, { identity: presenceIdentity("b"), eloRating: 1100 });
+
+    await pageA.goto(baseURL ?? "/");
+    const slotA = await expectVisibleOnlineLabel(pageA, "player-hud-online-slot");
+    await waitForPresenceCountAtLeast(slotA, 1);
+
+    const beforeConnect = await readPresenceCount(slotA);
+    expect(beforeConnect).toBeGreaterThanOrEqual(1);
+    await expect(pageA.getByTestId("player-hud-online-count")).toBeVisible();
+
+    await pageB.goto(baseURL ?? "/");
+    const slotB = await expectVisibleOnlineLabel(pageB, "player-hud-online-slot");
+
+    // After pageB connects, both clients should observe a count ≥ baseline+1
+    // at some point; absolute parity is racy because other tests' sockets are
+    // closing in parallel.
+    await waitForCount(slotA, (current) => current >= beforeConnect + 1);
+    await waitForCount(slotB, (current) => current >= beforeConnect + 1);
+
+    const peakA = await readPresenceCount(slotA);
+
+    await contextB.close();
+
+    // After pageB disconnects, slotA should observe a count strictly less than
+    // its post-connect peak.
+    await waitForCount(slotA, (current) => current < peakA);
+  } finally {
+    await contextA.close().catch(() => {});
+    await contextB.close().catch(() => {});
+  }
+});
+
+test("mobile top-strip HUD renders a compact online indicator that reflects connect/disconnect", async ({ baseURL, browser }) => {
+  const contextA = await browser.newContext({ viewport: { width: 390, height: 844 } });
+  const contextB = await browser.newContext({ viewport: { width: 390, height: 844 } });
+  const pageA = await contextA.newPage();
+  const pageB = await contextB.newPage();
+
+  try {
+    await mockDeckReadyProfile(pageA, { identity: presenceIdentity("mobile-a"), eloRating: 1100 });
+    await mockDeckReadyProfile(pageB, { identity: presenceIdentity("mobile-b"), eloRating: 1100 });
+
+    await pageA.goto(baseURL ?? "/");
+    const slotA = await expectVisibleOnlineLabel(pageA, "player-hud-online-slot-mobile");
+    await waitForPresenceCountAtLeast(slotA, 1);
+
+    const beforeConnect = await readPresenceCount(slotA);
+    expect(beforeConnect).toBeGreaterThanOrEqual(1);
+    await expect(pageA.getByTestId("player-hud-online-count-mobile")).toBeVisible();
+
+    await pageB.goto(baseURL ?? "/");
+
+    await waitForCount(slotA, (current) => current >= beforeConnect + 1);
+    const peakA = await readPresenceCount(slotA);
+
+    await contextB.close();
+
+    await waitForCount(slotA, (current) => current < peakA);
+  } finally {
+    await contextA.close().catch(() => {});
+    await contextB.close().catch(() => {});
+  }
+});

--- a/tests/onlinePresence.test.ts
+++ b/tests/onlinePresence.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { OnlinePresence } from "../src/features/presence/onlinePresence";
+
+describe("OnlinePresence", () => {
+  test("starts empty", () => {
+    const presence = new OnlinePresence();
+    expect(presence.count()).toBe(0);
+    expect(presence.has("anything")).toBe(false);
+  });
+
+  test("add tracks unique session ids", () => {
+    const presence = new OnlinePresence();
+    presence.add({ id: "a" });
+    presence.add({ id: "b" });
+    expect(presence.count()).toBe(2);
+    expect(presence.has("a")).toBe(true);
+    expect(presence.has("b")).toBe(true);
+  });
+
+  test("add is idempotent for the same session id", () => {
+    const presence = new OnlinePresence();
+    presence.add({ id: "a" });
+    presence.add({ id: "a" });
+    expect(presence.count()).toBe(1);
+  });
+
+  test("remove drops the session", () => {
+    const presence = new OnlinePresence();
+    presence.add({ id: "a" });
+    presence.add({ id: "b" });
+    presence.remove({ id: "a" });
+    expect(presence.count()).toBe(1);
+    expect(presence.has("a")).toBe(false);
+    expect(presence.has("b")).toBe(true);
+  });
+
+  test("remove is idempotent for an unknown session id", () => {
+    const presence = new OnlinePresence();
+    presence.add({ id: "a" });
+    presence.remove({ id: "ghost" });
+    presence.remove({ id: "ghost" });
+    expect(presence.count()).toBe(1);
+  });
+
+  test("ignores sessions without a usable id", () => {
+    const presence = new OnlinePresence();
+    presence.add({ id: "" });
+    presence.add({} as { id: string });
+    expect(presence.count()).toBe(0);
+    presence.add({ id: "real" });
+    presence.remove({ id: "" });
+    expect(presence.count()).toBe(1);
+    expect(presence.has("real")).toBe(true);
+  });
+
+  test("broadcastCount delivers the current count to every active session", () => {
+    const presence = new OnlinePresence();
+    presence.add({ id: "a" });
+    presence.add({ id: "b" });
+    presence.add({ id: "c" });
+
+    const calls: { sessionId: string; payload: { type: string; count: number } }[] = [];
+    presence.broadcastCount({
+      send: (sessionId, payload) => {
+        calls.push({ sessionId, payload });
+      },
+    });
+
+    expect(calls).toHaveLength(3);
+    expect(new Set(calls.map((call) => call.sessionId))).toEqual(new Set(["a", "b", "c"]));
+    for (const call of calls) {
+      expect(call.payload).toEqual({ type: "online_count", count: 3 });
+    }
+  });
+
+  test("broadcastCount with no sessions emits zero sends", () => {
+    const presence = new OnlinePresence();
+    let invocations = 0;
+    presence.broadcastCount({
+      send: () => {
+        invocations += 1;
+      },
+    });
+    expect(invocations).toBe(0);
+  });
+
+  test("a thrown send for one session does not block delivery to the rest", () => {
+    const presence = new OnlinePresence();
+    presence.add({ id: "a" });
+    presence.add({ id: "broken" });
+    presence.add({ id: "c" });
+
+    const delivered: string[] = [];
+    const failed: { sessionId: string; error: unknown }[] = [];
+
+    presence.broadcastCount({
+      send: (sessionId) => {
+        if (sessionId === "broken") throw new Error("send failed");
+        delivered.push(sessionId);
+      },
+      onSendError: (failure) => {
+        failed.push(failure);
+      },
+    });
+
+    expect(new Set(delivered)).toEqual(new Set(["a", "c"]));
+    expect(failed).toHaveLength(1);
+    expect(failed[0]?.sessionId).toBe("broken");
+    expect((failed[0]?.error as Error).message).toBe("send failed");
+  });
+
+  test("count reflects the current set after add/remove churn", () => {
+    const presence = new OnlinePresence();
+    presence.add({ id: "a" });
+    presence.add({ id: "b" });
+    presence.remove({ id: "a" });
+    presence.add({ id: "c" });
+    presence.remove({ id: "b" });
+    presence.remove({ id: "b" });
+    expect(presence.count()).toBe(1);
+    expect(presence.has("c")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Sixth slice of the player-progression feature (#25). Adds a live "X online" counter to the player HUD that updates whenever a client connects to or disconnects from the realtime WebSocket.

Closes #31. Parent: #25.

## What changed

- **`src/features/presence/onlinePresence.ts` (new)**: pure `OnlinePresence` class. Tracks the active session-id set with idempotent `add(session)` / `remove(session)`, exposes `count()` / `has()`, and a `broadcastCount({ send, onSendError })` that wraps each per-session `send` invocation in try/catch so a single failing socket cannot block delivery to the rest.
- **`server.js`**: imports `OnlinePresence`, instantiates it alongside the `MatchmakingQueue`, calls `onlinePresence.add(session)` on every WebSocket connect, calls `onlinePresence.remove(session)` inside `cleanupSession` (which is the single funnel for graceful close, error events, and heartbeat-driven termination), and broadcasts `{type: "online_count", count: N}` to every active session after each change. The new `broadcastOnlineCount` helper bridges the pure class to the existing `send(session, message)` plumbing.
- **`src/features/presence/client.ts` (new)**: `useOnlineCount` hook opens its own `/ws` WebSocket inside the HUD, listens for `online_count` messages via a small `parseOnlineCountMessage` helper, and returns `null` until the first broadcast arrives so the HUD does not flash a misleading "0 online" before the server has spoken. The socket lives only as long as the HUD does — it is not opened during active battle phases (where `BattleGame` already owns its own connection and the HUD is not rendered).
- **`src/features/player/ui/PlayerHud.tsx`**: fills the two slots reserved by the prior HUD slice with the live count.
  - **Desktop sidebar (`data-testid="player-hud-online-slot"`)**: clearly labeled `🟢 N онлайн` in the sticky-bottom slot. The slot also exposes `data-online-count={count}` for tests.
  - **Mobile top strip (`data-testid="player-hud-online-slot-mobile"`)**: compact `🟢 N` pill. Stays within its reserved bounding box and does not push neighboring HUD content; the placeholder dot is preserved while the count is `null`.
- **`tests/onlinePresence.test.ts` (new, 10 unit tests)**: starts empty, add tracks unique ids, add/remove are idempotent, ignores empty session ids, `broadcastCount` delivers the current count to every active session, broadcasts to zero sessions emit zero sends, a thrown send for one session does not block delivery to the rest (the resilience contract), and count reflects churn correctly.
- **`tests/online-presence.spec.ts` (new, 2 e2e tests)**: two-context Playwright tests for desktop and mobile. Both assert the directional behavior: opening a second client increments slot A's count; closing the second client decrements it. The dev server is shared across the test run (`reuseExistingServer: true`) and other tests' WebSockets close asynchronously, so the tests assert delta direction rather than absolute counts to avoid flake.
- **`package.json`**: adds `tests/onlinePresence.test.ts` to the `bun run test` set.

## Acceptance criteria (from #31)

- [x] New `OnlinePresence` class on the server. Methods: `add(session)`, `remove(session)`, `broadcastCount()` (sends `{type: "online_count", count: N}` to every active session). Implemented as `broadcastCount({ send, onSendError })` so the pure class accepts a sender utility from the I/O-bound caller — a perfectly equivalent shape to the spec's "holds an internal reference to a sender utility OR invokes a passed-in broadcaster".
- [x] `server.js` wires `add` on connect and `remove` on `cleanupSession` (covers graceful close, `ws.error`, and heartbeat-driven termination), calling `broadcastOnlineCount()` after each.
- [x] Client subscribes to the `online_count` message and updates a small in-memory store (`useOnlineCount` hook); HUD reads from it.
- [x] Desktop sidebar HUD renders a clearly labeled `🟢 N онлайн` counter at the bottom slot reserved by slice #30. Mobile top-strip renders a compact `🟢 N` indicator within its reserved bounding box.
- [x] Playwright with two browser contexts: open a second client → slot A's count strictly increases; close it → slot A's count strictly decreases.

## WebSocket protocol changes

New `online_count` server-to-client message: `{type: "online_count", count: number}`. Sent to every active session on every connect and disconnect. Carries no PII or session ids — only the count. No client-to-server message in this slice; the broadcast is purely server-driven.

## Race-condition considerations

- The connect-time broadcast happens after `sessions.set(...)` and `onlinePresence.add(session)`, so the broadcast loop sees the new session in the set and the new session itself receives the first count message.
- The disconnect-time broadcast happens after `sessions.delete(...)` and `onlinePresence.remove(session)`, so the broadcast loop never tries to send to the gone session.
- Per the bulletproofing requirement: each per-session send inside `broadcastCount` is wrapped in try/catch via the pure class. A throw on one socket logs through `onSendError` (`server.js` logs to `console.error`) and the loop continues to the next session.
- No persistence is added — the count is ephemeral. No DB writes touch the presence path.
- No "default-on-throw" surfaces are introduced. The `OnlinePresence` class never silently substitutes a count; the only error surface is the per-session send failure path, which is logged and otherwise non-fatal.

## Test plan

### Verified

- **Unit tests in Docker:** `docker build --target builder -t nexus-card-battle:builder . && docker run --rm nexus-card-battle:builder bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts tests/roundResolverPvp.test.ts tests/elo.test.ts tests/matchmakingQueue.test.ts tests/rewardOverlayPresenter.test.ts tests/playerAvatar.test.ts tests/onlinePresence.test.ts` → **129 pass / 0 fail** (was 119 in slice 5; +10 net new `OnlinePresence` cases).
- **Lint:** `bun run lint` → clean for slice-6 code (only the 2 pre-existing warnings on `Hand.tsx` + `ResourceCounter.tsx`, unchanged here).
- **Build:** `bun run build` → succeeds.
- **Playwright e2e (locally):** `bun run test:e2e` → **63 pass / 5 fail**. The 5 failures are the same pre-existing flaky tests slices 1-5 documented (`tests/mobile-layout.spec.ts:180:7` ×4 and `tests/realtime.spec.ts:10:5`); confirmed unchanged baseline. The 2 new `tests/online-presence.spec.ts` tests pass both in isolation and in the full suite.

### Docker e2e — explicit caveat (unchanged from slices 1-5)

The Docker stack ships `mongo` + a production runtime; there is no test-runner service. The `builder` stage is Alpine-based, which Microsoft's Playwright distribution does not support (Playwright requires glibc + a Debian/Ubuntu base for the bundled Chromium). Unit tests (the only Docker-runnable slice of the suite) were verified inside the Docker `builder` image as shown above; e2e was verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)