### PR TITLE
feat(economy): sell-to-city + PvP reward rebalance (slice 2/4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "bun server.js",
     "lint": "eslint",
-    "test": "bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts tests/roundResolverPvp.test.ts tests/elo.test.ts tests/matchmakingQueue.test.ts tests/rewardOverlayPresenter.test.ts tests/playerAvatar.test.ts tests/onlinePresence.test.ts tests/inventoryOps.test.ts",
+    "test": "bun test tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts tests/roundResolverPvp.test.ts tests/elo.test.ts tests/matchmakingQueue.test.ts tests/rewardOverlayPresenter.test.ts tests/playerAvatar.test.ts tests/onlinePresence.test.ts tests/inventoryOps.test.ts tests/sellPricing.test.ts",
     "test:profile": "bun test tests/playerProfile.test.ts",
     "test:e2e": "playwright test"
   },

--- a/src/app/api/player/sell/route.ts
+++ b/src/app/api/player/sell/route.ts
@@ -1,0 +1,8 @@
+import { handlePlayerSellPost } from "@/features/player/profile/api";
+import { getMongoPlayerProfileStore } from "@/features/player/profile/mongo";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  return handlePlayerSellPost(request, getMongoPlayerProfileStore());
+}

--- a/src/features/economy/sellPricing.ts
+++ b/src/features/economy/sellPricing.ts
@@ -1,0 +1,23 @@
+import type { Card, Rarity } from "@/features/battle/model/types";
+
+// Single source of truth for the sell economy. Adjusting values here
+// also updates server-authoritative payouts and any UI badge that displays
+// "за N кристалів" — keep them in sync rather than copy-pasting elsewhere.
+export const SELL_PRICES_BY_RARITY: Record<Rarity, number> = {
+  Common: 5,
+  Rare: 15,
+  Unique: 50,
+  Legend: 200,
+};
+
+export function getSellPrice(rarity: Rarity): number {
+  return SELL_PRICES_BY_RARITY[rarity];
+}
+
+export function computeSellRevenue(card: Pick<Card, "rarity">, count: number): number {
+  if (typeof count !== "number" || !Number.isInteger(count) || count < 0) {
+    throw new Error(`computeSellRevenue: count must be a non-negative integer, received ${String(count)}.`);
+  }
+
+  return count * getSellPrice(card.rarity);
+}

--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -368,6 +368,8 @@ export function GameRoot() {
         deckSaveStatus={deckSaveStatus}
         deckReadyToPlay={deckReadyToPlay}
         starterFreeBoostersRemaining={starterFreeBoostersRemaining}
+        playerIdentity={playerIdentity}
+        onPlayerUpdated={setPlayerProfile}
         onDeckChange={handleDeckChange}
         onPlay={handleSavedDeckPlay}
       />

--- a/src/features/game/ui/collection/CollectionDeckScreen.tsx
+++ b/src/features/game/ui/collection/CollectionDeckScreen.tsx
@@ -801,11 +801,20 @@ function CardDetails({
               </span>
             </div>
 
+            {/*
+              When the card is in any saved deck the server rejects every sell
+              with `card_in_deck` regardless of count, so quoting "запасних"
+              would mislead the player about what's actually sellable. Drop the
+              spares segment in that branch — the helper text below explains
+              why no spares are sellable.
+            */}
             <p
               className="text-[11px] font-bold leading-snug text-[#efe3c5]"
               data-testid="collection-sell-summary"
             >
-              Ви маєте: {ownedCount} ({inDeckCount} у колоді, {reserveCount} запасних)
+              {cardInDeck
+                ? `Ви маєте: ${ownedCount} (${inDeckCount} у колоді)`
+                : `Ви маєте: ${ownedCount} (${inDeckCount} у колоді, ${reserveCount} запасних)`}
             </p>
 
             {cardInDeck ? (

--- a/src/features/game/ui/collection/CollectionDeckScreen.tsx
+++ b/src/features/game/ui/collection/CollectionDeckScreen.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import type { CSSProperties } from "react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { cards } from "@/features/battle/model/cards";
 import { clanList } from "@/features/battle/model/clans";
 import type { Card, Rarity } from "@/features/battle/model/types";
 import { BattleCard } from "@/features/battle/ui/components/BattleCard";
-import { getOwnedCount, type OwnedCardEntry } from "@/features/inventory/inventoryOps";
+import { SELL_PRICES_BY_RARITY } from "@/features/economy/sellPricing";
+import { getOwnedCount, getSellableCount, type OwnedCardEntry } from "@/features/inventory/inventoryOps";
+import { sellPlayerCards } from "@/features/player/profile/client";
+import type { PlayerIdentity, PlayerProfile } from "@/features/player/profile/types";
 import { cn } from "@/shared/lib/cn";
 import { PLAYER_DECK_SIZE } from "../../model/randomDeck";
 
@@ -22,9 +25,16 @@ type Props = {
   deckSaveStatus: "idle" | "saving" | "saved" | "error";
   deckReadyToPlay: boolean;
   starterFreeBoostersRemaining: number;
+  playerIdentity?: PlayerIdentity | null;
+  onPlayerUpdated?: (profile: PlayerProfile) => void;
   onDeckChange: (deckIds: string[]) => void;
   onPlay: (deckIds: string[], mode: "ai" | "human") => void;
 };
+
+type SellStatus =
+  | { kind: "idle" }
+  | { kind: "selling" }
+  | { kind: "error"; message: string };
 
 type CollectionMode = "owned" | "base";
 type RarityFilter = Rarity | "all";
@@ -74,6 +84,8 @@ export function CollectionDeckScreen({
   deckSaveStatus,
   deckReadyToPlay,
   starterFreeBoostersRemaining,
+  playerIdentity,
+  onPlayerUpdated,
   onDeckChange,
   onPlay,
 }: Props) {
@@ -92,6 +104,35 @@ export function CollectionDeckScreen({
   const [rarity, setRarity] = useState<RarityFilter>("all");
   const [sortMode, setSortMode] = useState<SortMode>("rarity");
   const [visiblePage, setVisiblePage] = useState({ key: "", limit: GRID_LIMIT });
+  const [sellStatus, setSellStatus] = useState<SellStatus>({ kind: "idle" });
+
+  const handleSellCard = useCallback(
+    async (card: Card, count: number) => {
+      if (!playerIdentity || !onPlayerUpdated) return;
+      if (count <= 0) return;
+
+      const ownedCount = getOwnedCount(ownedCards, card.id);
+      const lastCopy = ownedCount === count;
+      const requiresConfirm = card.rarity === "Legend" || lastCopy;
+      if (requiresConfirm && typeof window !== "undefined") {
+        const message = lastCopy
+          ? `Видалити останню копію ${card.name}?`
+          : `Продати ${count} × ${card.name}?`;
+        if (!window.confirm(message)) return;
+      }
+
+      setSellStatus({ kind: "selling" });
+      const result = await sellPlayerCards(playerIdentity, card.id, count);
+      if (result.ok) {
+        onPlayerUpdated(result.player);
+        setSellStatus({ kind: "idle" });
+        return;
+      }
+
+      setSellStatus({ kind: "error", message: sellErrorMessage(result.error) });
+    },
+    [onPlayerUpdated, ownedCards, playerIdentity],
+  );
 
   const deckCards = useMemo(() => deckIds.map((cardId) => cards.find((card) => card.id === cardId)).filter(Boolean) as Card[], [deckIds]);
   const browsingCardIds = useMemo(() => new Set(browsingCards.map((card) => card.id)), [browsingCards]);
@@ -369,6 +410,12 @@ export function CollectionDeckScreen({
                   owned={ownedSet.has(selectedCard.id)}
                   editable={canEditDeck && ownedSet.has(selectedCard.id)}
                   canRemove={canRemoveCard}
+                  ownedCount={getOwnedCount(ownedCards, selectedCard.id)}
+                  sellableCount={getSellableCount(ownedCards, deckIds, selectedCard.id)}
+                  cardInDeck={deckIds.includes(selectedCard.id)}
+                  canSell={Boolean(playerIdentity && onPlayerUpdated) && profileStatus === "ready"}
+                  sellStatus={sellStatus}
+                  onSell={(count) => void handleSellCard(selectedCard, count)}
                   onToggle={() => (deckIds.includes(selectedCard.id) ? removeCard(selectedCard.id) : addCard(selectedCard))}
                 />
               ) : null}
@@ -676,6 +723,12 @@ function CardDetails({
   owned,
   editable,
   canRemove,
+  ownedCount,
+  sellableCount,
+  cardInDeck,
+  canSell,
+  sellStatus,
+  onSell,
   onToggle,
 }: {
   card: Card;
@@ -683,9 +736,19 @@ function CardDetails({
   owned: boolean;
   editable: boolean;
   canRemove: boolean;
+  ownedCount: number;
+  sellableCount: number;
+  cardInDeck: boolean;
+  canSell: boolean;
+  sellStatus: SellStatus;
+  onSell: (count: number) => void;
   onToggle: () => void;
 }) {
   const disableRemove = editable && inDeck && !canRemove;
+  const inDeckCount = cardInDeck ? 1 : 0;
+  const reserveCount = Math.max(0, ownedCount - inDeckCount);
+  const sellPrice = SELL_PRICES_BY_RARITY[card.rarity];
+  const isSelling = sellStatus.kind === "selling";
 
   return (
     <section className="card-details rounded-md bg-black/40 p-3 max-[860px]:grid max-[860px]:grid-cols-[minmax(190px,216px)_minmax(0,1fr)] max-[860px]:gap-3 max-[560px]:grid-cols-[minmax(112px,132px)_minmax(0,1fr)] max-[420px]:p-2">
@@ -724,6 +787,67 @@ function CardDetails({
           <DetailRow label="Уміння" title={card.ability.name} description={card.ability.description} />
           <DetailRow label="Бонус" title={card.bonus.name} description={card.bonus.description} />
         </dl>
+
+        {owned && canSell ? (
+          <section
+            className="mt-3 grid gap-2 rounded-md border border-white/10 bg-black/35 p-2"
+            data-testid="collection-sell-panel"
+            data-card-id={card.id}
+          >
+            <div className="flex items-baseline justify-between gap-2">
+              <strong className="text-[10px] font-black uppercase tracking-[0.12em] text-[#d4b06a]">Продати</strong>
+              <span className="text-[10px] font-bold uppercase tracking-[0.1em] text-[#9ed6e4]">
+                {sellPrice} 💎 / шт.
+              </span>
+            </div>
+
+            <p
+              className="text-[11px] font-bold leading-snug text-[#efe3c5]"
+              data-testid="collection-sell-summary"
+            >
+              Ви маєте: {ownedCount} ({inDeckCount} у колоді, {reserveCount} запасних)
+            </p>
+
+            {cardInDeck ? (
+              <p
+                className="text-[10px] font-black uppercase tracking-[0.08em] text-[#ffb39d]"
+                data-testid="collection-sell-disabled-reason"
+              >
+                Видали з колоди, щоб продати
+              </p>
+            ) : null}
+
+            <div className="grid grid-cols-2 gap-2 max-[560px]:grid-cols-1">
+              <button
+                className={sellButtonClass()}
+                type="button"
+                disabled={cardInDeck || sellableCount < 1 || isSelling}
+                onClick={() => onSell(1)}
+                data-testid="collection-sell-1"
+              >
+                {sellableCount === 1 && !cardInDeck ? "Продати" : "Продати 1"}
+              </button>
+              <button
+                className={sellButtonClass()}
+                type="button"
+                disabled={cardInDeck || sellableCount < 2 || isSelling}
+                onClick={() => onSell(sellableCount)}
+                data-testid="collection-sell-all"
+              >
+                Продати всі дублікати
+              </button>
+            </div>
+
+            {sellStatus.kind === "error" ? (
+              <p
+                className="text-[10px] font-black uppercase tracking-[0.08em] text-[#ffb39d]"
+                data-testid="collection-sell-error"
+              >
+                {sellStatus.message}
+              </p>
+            ) : null}
+          </section>
+        ) : null}
       </div>
     </section>
   );
@@ -856,4 +980,16 @@ function factionButtonClass(active: boolean) {
 
 function utilityButtonClass() {
   return "rounded bg-white/[0.06] px-3 py-2 text-xs font-black uppercase text-[#efe3c5] transition hover:bg-[#ffe08a]/14 disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-white/[0.06]";
+}
+
+function sellButtonClass() {
+  return "min-h-[36px] rounded-md bg-[linear-gradient(180deg,rgba(255,224,138,0.18),rgba(211,162,72,0.08))] px-3 text-[11px] font-black uppercase text-[#ffe8a6] transition hover:bg-[#ffe08a]/16 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-[linear-gradient(180deg,rgba(255,224,138,0.18),rgba(211,162,72,0.08))]";
+}
+
+function sellErrorMessage(error: "invalid_card_id" | "invalid_sell_count" | "insufficient_stock" | "card_in_deck" | "unknown") {
+  if (error === "card_in_deck") return "Видали з колоди, щоб продати";
+  if (error === "insufficient_stock") return "Недостатньо копій для продажу";
+  if (error === "invalid_card_id") return "Невідома карта";
+  if (error === "invalid_sell_count") return "Невірна кількість";
+  return "Не вдалося продати";
 }

--- a/src/features/inventory/inventoryOps.ts
+++ b/src/features/inventory/inventoryOps.ts
@@ -60,6 +60,10 @@ export function getOwnedCount(inventory: readonly OwnedCardEntry[], cardId: stri
   return 0;
 }
 
+// Spare copies ignoring in-deck protection — the server enforces stricter
+// `card_in_deck` rejection (any sell of an in-deck cardId is refused), so UI
+// callers must gate the sell action on `deckIds.includes(cardId)` separately
+// rather than relying on the N-1 returned here.
 export function getSellableCount(
   inventory: readonly OwnedCardEntry[],
   deckIds: readonly string[],

--- a/src/features/player/profile/api.ts
+++ b/src/features/player/profile/api.ts
@@ -14,6 +14,15 @@ import { computeMatchRewards, type MatchResultBucket } from "./progression";
 import { computeLevelFromXp } from "./types";
 import type { RewardSummary } from "@/features/battle/model/types";
 
+export type SellErrorCode = "invalid_card_id" | "invalid_sell_count" | "insufficient_stock" | "card_in_deck";
+
+export class SellError extends Error {
+  constructor(public readonly code: SellErrorCode, message: string, public readonly status: number) {
+    super(message);
+    this.name = "SellError";
+  }
+}
+
 export type PlayerProfileStore = {
   findOrCreateByIdentity(identity: PlayerIdentity): Promise<StoredPlayerProfile>;
 };
@@ -39,6 +48,10 @@ export type PlayerMatchRewardsStore = PlayerProfileStore & {
 
 export type PlayerAvatarStore = PlayerProfileStore & {
   setAvatarUrl(identity: PlayerIdentity, avatarUrl: string): Promise<StoredPlayerProfile>;
+};
+
+export type PlayerSellStore = PlayerProfileStore & {
+  applySellCards(identity: PlayerIdentity, cardId: string, count: number): Promise<StoredPlayerProfile>;
 };
 
 export async function handlePlayerProfilePost(request: Request, store: PlayerProfileStore) {
@@ -83,6 +96,42 @@ export async function handlePlayerAvatarPost(request: Request, store: PlayerAvat
   } catch (error) {
     return playerProfileErrorResponse(error);
   }
+}
+
+export async function handlePlayerSellPost(request: Request, store: PlayerSellStore) {
+  try {
+    const body = await readJsonObject(request);
+    const identity = parsePlayerIdentity(body.identity);
+    const cardId = parseSellCardId(body.cardId);
+    const count = parseSellCount(body.count);
+
+    const stored = await store.applySellCards(identity, cardId, count);
+
+    return Response.json(
+      { player: toPlayerProfile(stored) },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    return playerProfileErrorResponse(error);
+  }
+}
+
+function parseSellCardId(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new SellError("invalid_card_id", "cardId must be a string.", 400);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new SellError("invalid_card_id", "cardId must not be empty.", 400);
+  }
+  return trimmed;
+}
+
+function parseSellCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new SellError("invalid_sell_count", "count must be a positive integer.", 400);
+  }
+  return value;
 }
 
 export async function handlePlayerMatchFinishedPost(request: Request, store: PlayerMatchRewardsStore) {
@@ -267,6 +316,16 @@ function playerProfileResponse(player: PlayerProfile) {
 }
 
 function playerProfileErrorResponse(error: unknown) {
+  if (error instanceof SellError) {
+    return Response.json(
+      {
+        error: error.code,
+        message: error.message,
+      },
+      { status: error.status },
+    );
+  }
+
   if (error instanceof PlayerDeckValidationError) {
     return Response.json(
       {

--- a/src/features/player/profile/client.ts
+++ b/src/features/player/profile/client.ts
@@ -106,6 +106,35 @@ export async function savePlayerAvatar(identity: PlayerIdentity, avatarUrl: stri
   return body.player;
 }
 
+export type SellCardsResult =
+  | { ok: true; player: PlayerProfile }
+  | { ok: false; error: "invalid_card_id" | "invalid_sell_count" | "insufficient_stock" | "card_in_deck" | "unknown"; message?: string };
+
+export async function sellPlayerCards(identity: PlayerIdentity, cardId: string, count: number): Promise<SellCardsResult> {
+  const response = await fetch("/api/player/sell", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ identity, cardId, count }),
+  });
+
+  if (response.ok) {
+    const body = (await response.json()) as { player?: PlayerProfile };
+    if (!body.player) {
+      return { ok: false, error: "unknown", message: "Sell response did not include player." };
+    }
+    return { ok: true, player: body.player };
+  }
+
+  const body = (await response.json().catch(() => undefined)) as { error?: string; message?: string } | undefined;
+  const code = body?.error;
+  if (code === "invalid_card_id" || code === "invalid_sell_count" || code === "insufficient_stock" || code === "card_in_deck") {
+    return { ok: false, error: code, message: body?.message };
+  }
+  return { ok: false, error: "unknown", message: body?.message ?? `Sell failed: ${response.status}` };
+}
+
 export async function savePlayerDeck(identity: PlayerIdentity, deckIds: string[]): Promise<PlayerProfile> {
   const response = await fetch("/api/player/deck", {
     method: "POST",

--- a/src/features/player/profile/mongo.ts
+++ b/src/features/player/profile/mongo.ts
@@ -549,8 +549,12 @@ async function createOrLoadStarterOpening(
   };
 }
 
-// TODO(slice-2): once cards become removable via /sell, deck-membership is no
-// longer a reliable proxy for "this booster was applied"; revisit.
+// Verified safe in slice 2: openedBoosterIds.includes(boosterId) is the
+// short-circuit left-hand of the AND, so recovery only consults deck/owned
+// state when the booster was already recorded as opened. Subsequent /sell
+// calls cannot strip openedBoosterIds, and applyStarterOpeningToPlayer's
+// duplicate-call branch returns the prior write directly rather than
+// re-running this predicate, so post-open sells do not break recovery.
 function hasAppliedStarterOpening(player: MongoPlayerDocument, boosterId: string, cardIds: string[]) {
   const ownedCards = readOwnedCards(player);
   const deckIds = new Set(player.deckIds);

--- a/src/features/player/profile/mongo.ts
+++ b/src/features/player/profile/mongo.ts
@@ -1,7 +1,9 @@
 import { MongoClient, MongoServerError, ObjectId, type Collection, type Filter, type WithId } from "mongodb";
 import { BoosterOpeningError } from "@/features/boosters/opening";
 import type { BoosterOpeningSource, PersistStarterBoosterOpeningInput, PersistedStarterBoosterOpening, StoredBoosterOpeningRecord } from "@/features/boosters/types";
-import { getOwnedCount, type OwnedCardEntry } from "@/features/inventory/inventoryOps";
+import { cards } from "@/features/battle/model/cards";
+import { getOwnedCount, getSellableCount, type OwnedCardEntry } from "@/features/inventory/inventoryOps";
+import { computeSellRevenue } from "@/features/economy/sellPricing";
 import {
   DEFAULT_PLAYER_CRYSTALS,
   DEFAULT_PLAYER_DRAWS,
@@ -16,7 +18,7 @@ import {
   type StoredPlayerProfile,
 } from "./types";
 import { computeLevelUpBonusForRange } from "./progression";
-import type { ApplyMatchRewardsInput, PlayerAvatarStore, PlayerDeckStore, PlayerMatchRewardsStore } from "./api";
+import { SellError, type ApplyMatchRewardsInput, type PlayerAvatarStore, type PlayerDeckStore, type PlayerMatchRewardsStore, type PlayerSellStore } from "./api";
 
 const DEFAULT_MONGODB_URI = "mongodb://127.0.0.1:27017/nexus-card-battle";
 const DEFAULT_MONGODB_DB = "nexus-card-battle";
@@ -69,7 +71,7 @@ export function getMongoPlayerProfileStore() {
   return new MongoPlayerProfileStore(clientPromise, dbName);
 }
 
-export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewardsStore, PlayerAvatarStore {
+export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewardsStore, PlayerAvatarStore, PlayerSellStore {
   private indexesReady?: Promise<void>;
   private boosterOpeningIndexesReady?: Promise<void>;
 
@@ -283,6 +285,11 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
     throw new Error("Player deck could not be saved.");
   }
 
+  async applySellCards(identity: PlayerIdentity, cardId: string, count: number): Promise<StoredPlayerProfile> {
+    const players = await this.getPlayersCollection();
+    return applySellCardsToPlayer(players, identity, cardId, count);
+  }
+
   private async getPlayersCollection() {
     const client = await this.clientPromise;
     const collection = client.db(this.dbName).collection<MongoPlayerDocument>(PLAYERS_COLLECTION);
@@ -387,6 +394,91 @@ async function applyStarterOpeningToPlayer(
   }
 
   throw new BoosterOpeningError("starter_booster_unavailable", "Starter booster opening could not be saved for the current player state.", 409);
+}
+
+async function applySellCardsToPlayer(
+  players: Collection<MongoPlayerDocument>,
+  identity: PlayerIdentity,
+  cardId: string,
+  count: number,
+): Promise<StoredPlayerProfile> {
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new SellError("invalid_sell_count", "count must be a positive integer.", 400);
+  }
+
+  const card = cards.find((entry) => entry.id === cardId);
+  if (!card) {
+    throw new SellError("invalid_card_id", `Unknown card id: ${cardId}`, 400);
+  }
+
+  const revenue = computeSellRevenue(card, count);
+  const now = new Date();
+
+  // Pipeline-update so the multiset decrement runs server-side: two concurrent
+  // sells of the same cardId compose against the post-write document state and
+  // can't drive the count negative or skip a debit. The filter pre-checks both
+  // "enough sellable stock" and "card not in any saved deck" so a no-op match
+  // is always due to one of those server-authoritative invariants.
+  const updated = await players.findOneAndUpdate(
+    {
+      ...identityFilter(identity),
+      ownedCards: { $elemMatch: { cardId, count: { $gte: count } } },
+      deckIds: { $ne: cardId },
+    },
+    [
+      {
+        $set: {
+          ownedCards: {
+            $filter: {
+              input: {
+                $map: {
+                  input: { $ifNull: ["$ownedCards", []] },
+                  as: "entry",
+                  in: {
+                    $cond: [
+                      { $eq: ["$$entry.cardId", cardId] },
+                      { cardId: "$$entry.cardId", count: { $subtract: ["$$entry.count", count] } },
+                      "$$entry",
+                    ],
+                  },
+                },
+              },
+              as: "entry",
+              cond: { $gt: ["$$entry.count", 0] },
+            },
+          },
+          crystals: { $add: [{ $ifNull: ["$crystals", 0] }, revenue] },
+          updatedAt: now,
+        },
+      },
+    ],
+    { returnDocument: "after" },
+  );
+
+  if (updated) {
+    return fromMongoDocument(updated);
+  }
+
+  // Filter rejected the update — disambiguate the failure cause for the API
+  // surface so a UI can render a precise error.
+  const current = await players.findOne(identityFilter(identity));
+  if (!current) {
+    throw new SellError("insufficient_stock", "Player profile did not exist for sell apply.", 409);
+  }
+
+  const ownedCards = readOwnedCards(current);
+  const deckIds = Array.isArray(current.deckIds) ? current.deckIds : [];
+  if (deckIds.includes(cardId)) {
+    throw new SellError("card_in_deck", "Cannot sell a card that is in a saved deck.", 409);
+  }
+
+  if (count > getSellableCount(ownedCards, deckIds, cardId)) {
+    throw new SellError("insufficient_stock", "Not enough sellable copies for this sell.", 409);
+  }
+
+  // Filter rejected, but post-read invariants now satisfy the precondition —
+  // most likely a concurrent write briefly raced us. Surface as conflict.
+  throw new SellError("insufficient_stock", "Sell could not be applied due to a concurrent write.", 409);
 }
 
 function buildOwnedCardsIncrementPipeline(cardIds: readonly string[]) {

--- a/src/features/player/profile/progression.ts
+++ b/src/features/player/profile/progression.ts
@@ -23,8 +23,8 @@ export const PVP_XP_REWARDS = {
 } as const;
 
 export const PVP_CRYSTAL_REWARDS = {
-  win: 50,
-  draw: 20,
+  win: 10,
+  draw: 3,
   loss: 0,
 } as const;
 

--- a/tests/fixtures/playerProfile.ts
+++ b/tests/fixtures/playerProfile.ts
@@ -16,10 +16,14 @@ export const PROFILE_DECK_IDS = [
 ];
 export const PROFILE_OWNED_CARD_IDS = [...PROFILE_DECK_IDS, "dahack-363"];
 
+export type TestPlayerProfileOwnedCardEntry = { cardId: string; count: number };
+
 export type TestPlayerProfileInput = {
   id: string;
   identity: PlayerIdentity;
   ownedCardIds: string[];
+  // Optional explicit multiset; takes precedence over ownedCardIds when provided.
+  ownedCards?: TestPlayerProfileOwnedCardEntry[];
   deckIds: string[];
   starterFreeBoostersRemaining: number;
   openedBoosterIds?: string[];
@@ -59,6 +63,7 @@ export async function mockDeckReadyProfile(page: Page, options: MockDeckReadyPro
       id: options.id ?? profile?.id ?? "player-deck-ready-e2e",
       identity,
       ownedCardIds: options.ownedCardIds ?? profile?.ownedCardIds ?? PROFILE_OWNED_CARD_IDS,
+      ownedCards: options.ownedCards ?? profile?.ownedCards,
       deckIds: requestBody.deckIds ?? options.deckIds ?? profile?.deckIds ?? PROFILE_DECK_IDS,
       starterFreeBoostersRemaining: options.starterFreeBoostersRemaining ?? profile?.starterFreeBoostersRemaining ?? 0,
       openedBoosterIds: options.openedBoosterIds ?? profile?.openedBoosterIds ?? ["neon-breach", "factory-shift"],
@@ -86,6 +91,7 @@ export async function mockDeckReadyProfile(page: Page, options: MockDeckReadyPro
       id: options.id ?? profile?.id ?? "player-deck-ready-e2e",
       identity,
       ownedCardIds: options.ownedCardIds ?? profile?.ownedCardIds ?? PROFILE_OWNED_CARD_IDS,
+      ownedCards: options.ownedCards ?? profile?.ownedCards,
       deckIds: options.deckIds ?? profile?.deckIds ?? PROFILE_DECK_IDS,
       starterFreeBoostersRemaining: options.starterFreeBoostersRemaining ?? profile?.starterFreeBoostersRemaining ?? 0,
       openedBoosterIds: options.openedBoosterIds ?? profile?.openedBoosterIds ?? ["neon-breach", "factory-shift"],
@@ -128,12 +134,14 @@ export async function fulfillBoosterCatalog(route: Route, profile: TestPlayerPro
 }
 
 function createPlayerProfileBody(profile: TestPlayerProfileInput) {
-  const collectionReady = profile.ownedCardIds.length > 0;
+  const ownedCards = profile.ownedCards ?? profile.ownedCardIds.map((cardId) => ({ cardId, count: 1 }));
+  const collectionReady = ownedCards.length > 0 || profile.ownedCardIds.length > 0;
   const deckReady = profile.deckIds.length > 0;
   const totalXp = profile.totalXp ?? 0;
 
   return {
     ...profile,
+    ownedCards,
     openedBoosterIds: profile.openedBoosterIds ?? [],
     crystals: profile.crystals ?? 0,
     totalXp,
@@ -157,6 +165,7 @@ function createTestProfileInput(options: MockDeckReadyProfileOptions, identity: 
     id: options.id ?? "player-deck-ready-e2e",
     identity,
     ownedCardIds: options.ownedCardIds ?? PROFILE_OWNED_CARD_IDS,
+    ownedCards: options.ownedCards,
     deckIds: options.deckIds ?? PROFILE_DECK_IDS,
     starterFreeBoostersRemaining: options.starterFreeBoostersRemaining ?? 0,
     openedBoosterIds: options.openedBoosterIds ?? ["neon-breach", "factory-shift"],

--- a/tests/playerProfile.test.ts
+++ b/tests/playerProfile.test.ts
@@ -1,17 +1,22 @@
 import { describe, expect, test } from "bun:test";
 import { cards } from "../src/features/battle/model/cards";
 import {
+  SellError,
   applyAndSummarizeMatchRewards,
   applyPvpMatchRewardsForBothSides,
   handlePlayerDeckSavePost,
   handlePlayerMatchFinishedPost,
   handlePlayerProfileGet,
   handlePlayerProfilePost,
+  handlePlayerSellPost,
   type ApplyMatchRewardsInput,
   type PlayerDeckStore,
   type PlayerMatchRewardsStore,
   type PlayerProfileStore,
+  type PlayerSellStore,
 } from "../src/features/player/profile/api";
+import { computeSellRevenue } from "../src/features/economy/sellPricing";
+import { addToInventory, getOwnedCount, getSellableCount, removeFromInventory } from "../src/features/inventory/inventoryOps";
 import { computeLevelFromXp, createNewStoredPlayerProfile, isSamePlayerIdentity, type PlayerIdentity, type PlayerProfile, type StoredPlayerProfile } from "../src/features/player/profile/types";
 import { computeLevelUpBonusForRange } from "../src/features/player/profile/progression";
 import type { RewardSummary } from "../src/features/battle/model/types";
@@ -306,10 +311,10 @@ describe("player match-finished API (PvE)", () => {
     const loser = await applyAndSummarizeMatchRewards(store, loserIdentity, { mode: "pvp", result: "loss" });
 
     expect(winner.summary.deltaXp).toBe(100);
-    expect(winner.summary.deltaCrystals).toBe(50);
+    expect(winner.summary.deltaCrystals).toBe(10);
     expect(winner.summary.leveledUp).toBe(false);
-    expect(winner.summary.newTotals).toEqual({ crystals: 50, totalXp: 100, level: 1 });
-    expect(winner.persisted.crystals).toBe(50);
+    expect(winner.summary.newTotals).toEqual({ crystals: 10, totalXp: 100, level: 1 });
+    expect(winner.persisted.crystals).toBe(10);
     expect(winner.persisted.totalXp).toBe(100);
     expect(winner.persisted.wins).toBe(1);
 
@@ -320,7 +325,7 @@ describe("player match-finished API (PvE)", () => {
 
     const persistedWinner = store.snapshot(winnerIdentity);
     const persistedLoser = store.snapshot(loserIdentity);
-    expect(persistedWinner?.crystals).toBe(50);
+    expect(persistedWinner?.crystals).toBe(10);
     expect(persistedWinner?.totalXp).toBe(100);
     expect(persistedWinner?.wins).toBe(1);
     expect(persistedLoser?.totalXp).toBe(10);
@@ -340,8 +345,8 @@ describe("player match-finished API (PvE)", () => {
 
     const persisted = store.snapshot(racyIdentity);
     expect(persisted?.totalXp).toBe(195 + 100 + 100);
-    // 50 (match win) * 2 + 50 (single level-up bonus to level 2)
-    expect(persisted?.crystals).toBe(50 + 50 + 50);
+    // 10 (match win) * 2 + 50 (single level-up bonus to level 2)
+    expect(persisted?.crystals).toBe(10 + 10 + 50);
     expect(persisted?.wins).toBe(2);
   });
 
@@ -508,7 +513,7 @@ describe("player match-finished API (PvE)", () => {
     const loserSummary = loserOutcome!.summary as RewardSummary;
 
     expect(winnerSummary.deltaXp).toBe(100);
-    expect(winnerSummary.deltaCrystals).toBe(50);
+    expect(winnerSummary.deltaCrystals).toBe(10);
     expect(loserSummary.deltaXp).toBe(10);
     expect(loserSummary.deltaCrystals).toBe(0);
 
@@ -555,7 +560,194 @@ describe("player match-finished API (PvE)", () => {
   });
 });
 
-class MemoryPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewardsStore {
+describe("player sell API", () => {
+  const sellIdentity: PlayerIdentity = { mode: "guest", guestId: "guest-sell-flow" };
+  const commonCard = cards.find((card) => card.rarity === "Common");
+  const legendCard = cards.find((card) => card.rarity === "Legend");
+  if (!commonCard) throw new Error("Test fixture requires at least one Common card.");
+  if (!legendCard) throw new Error("Test fixture requires at least one Legend card.");
+
+  const commonSellPrice = 5;
+  const legendSellPrice = 200;
+
+  function createSellableProfile(options: {
+    ownedCards: { cardId: string; count: number }[];
+    deckIds?: string[];
+    crystals?: number;
+  }): StoredPlayerProfile {
+    return {
+      ...createNewStoredPlayerProfile("player-sell-flow", sellIdentity),
+      ownedCards: options.ownedCards.map((entry) => ({ ...entry })),
+      deckIds: options.deckIds ?? [],
+      starterFreeBoostersRemaining: 0,
+      openedBoosterIds: [],
+      crystals: options.crystals ?? 0,
+    };
+  }
+
+  test("happy path: sells two of a duplicated Common, removes the entry, credits 2 * 5 = 10 crystals", async () => {
+    const store = new MemoryPlayerProfileStore([
+      createSellableProfile({ ownedCards: [{ cardId: commonCard.id, count: 2 }], crystals: 100 }),
+    ]);
+
+    const response = await postSell(store, { identity: sellIdentity, cardId: commonCard.id, count: 2 });
+    const body = (await response.json()) as { player: PlayerProfile };
+
+    expect(response.status).toBe(200);
+    expect(body.player.crystals).toBe(100 + 2 * commonSellPrice);
+    expect(body.player.ownedCards.find((entry) => entry.cardId === commonCard.id)).toBeUndefined();
+
+    const persisted = store.snapshot(sellIdentity);
+    expect(persisted?.crystals).toBe(110);
+    expect(getOwnedCount(persisted?.ownedCards ?? [], commonCard.id)).toBe(0);
+  });
+
+  test("happy path: count: 1 of a 3-stack decrements to 2 and credits one unit of revenue", async () => {
+    const store = new MemoryPlayerProfileStore([
+      createSellableProfile({ ownedCards: [{ cardId: commonCard.id, count: 3 }], crystals: 0 }),
+    ]);
+
+    const response = await postSell(store, { identity: sellIdentity, cardId: commonCard.id, count: 1 });
+    const body = (await response.json()) as { player: PlayerProfile };
+
+    expect(response.status).toBe(200);
+    expect(getOwnedCount(body.player.ownedCards, commonCard.id)).toBe(2);
+    expect(body.player.crystals).toBe(commonSellPrice);
+  });
+
+  test("Legend cards pay the Legend rarity (200 per copy)", async () => {
+    const store = new MemoryPlayerProfileStore([
+      createSellableProfile({ ownedCards: [{ cardId: legendCard.id, count: 2 }], crystals: 0 }),
+    ]);
+
+    const response = await postSell(store, { identity: sellIdentity, cardId: legendCard.id, count: 2 });
+    const body = (await response.json()) as { player: PlayerProfile };
+
+    expect(response.status).toBe(200);
+    expect(body.player.crystals).toBe(2 * legendSellPrice);
+    expect(getOwnedCount(body.player.ownedCards, legendCard.id)).toBe(0);
+  });
+
+  test("rejects sell when the card is in any saved deck (409 card_in_deck), profile unchanged", async () => {
+    const profile = createSellableProfile({
+      ownedCards: [{ cardId: commonCard.id, count: 5 }],
+      deckIds: [commonCard.id],
+      crystals: 12,
+    });
+    const store = new MemoryPlayerProfileStore([profile]);
+
+    const response = await postSell(store, { identity: sellIdentity, cardId: commonCard.id, count: 1 });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(409);
+    expect(body.error).toBe("card_in_deck");
+
+    const persisted = store.snapshot(sellIdentity);
+    expect(persisted?.crystals).toBe(12);
+    expect(getOwnedCount(persisted?.ownedCards ?? [], commonCard.id)).toBe(5);
+  });
+
+  test("rejects sell when count > sellable copies (409 insufficient_stock), profile unchanged", async () => {
+    const store = new MemoryPlayerProfileStore([
+      createSellableProfile({ ownedCards: [{ cardId: commonCard.id, count: 2 }], crystals: 7 }),
+    ]);
+
+    const response = await postSell(store, { identity: sellIdentity, cardId: commonCard.id, count: 3 });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(409);
+    expect(body.error).toBe("insufficient_stock");
+
+    const persisted = store.snapshot(sellIdentity);
+    expect(persisted?.crystals).toBe(7);
+    expect(getOwnedCount(persisted?.ownedCards ?? [], commonCard.id)).toBe(2);
+  });
+
+  test("rejects sell against an unknown cardId (400 invalid_card_id), profile unchanged", async () => {
+    const store = new MemoryPlayerProfileStore([
+      createSellableProfile({ ownedCards: [{ cardId: commonCard.id, count: 2 }], crystals: 0 }),
+    ]);
+
+    const response = await postSell(store, { identity: sellIdentity, cardId: "not-a-real-card", count: 1 });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("invalid_card_id");
+
+    const persisted = store.snapshot(sellIdentity);
+    expect(getOwnedCount(persisted?.ownedCards ?? [], commonCard.id)).toBe(2);
+  });
+
+  test("rejects sell with count: 0 (400 invalid_sell_count)", async () => {
+    const store = new MemoryPlayerProfileStore([
+      createSellableProfile({ ownedCards: [{ cardId: commonCard.id, count: 2 }] }),
+    ]);
+
+    const response = await postSell(store, { identity: sellIdentity, cardId: commonCard.id, count: 0 });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("invalid_sell_count");
+  });
+
+  test("rejects sell with count: -1 (400 invalid_sell_count)", async () => {
+    const store = new MemoryPlayerProfileStore([
+      createSellableProfile({ ownedCards: [{ cardId: commonCard.id, count: 2 }] }),
+    ]);
+
+    const response = await postSell(store, { identity: sellIdentity, cardId: commonCard.id, count: -1 });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("invalid_sell_count");
+  });
+
+  test("rejects sell with non-integer count (400 invalid_sell_count)", async () => {
+    const store = new MemoryPlayerProfileStore([
+      createSellableProfile({ ownedCards: [{ cardId: commonCard.id, count: 2 }] }),
+    ]);
+
+    const response = await postSell(store, { identity: sellIdentity, cardId: commonCard.id, count: 1.5 });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("invalid_sell_count");
+  });
+
+  test("deck-protection: with 2 owned and the card in deck, sellableCount is 1 — selling 2 fails 409 insufficient_stock or card_in_deck", async () => {
+    // Per slice-1 inventoryOps: a card in deck reserves exactly one copy.
+    // With ownedCount = 2 and the card in deck, sellableCount = 1.
+    const profile = createSellableProfile({
+      ownedCards: [{ cardId: commonCard.id, count: 2 }],
+      deckIds: [commonCard.id],
+      crystals: 0,
+    });
+    const store = new MemoryPlayerProfileStore([profile]);
+    expect(getSellableCount(profile.ownedCards, profile.deckIds, commonCard.id)).toBe(1);
+
+    const response = await postSell(store, { identity: sellIdentity, cardId: commonCard.id, count: 2 });
+    const body = (await response.json()) as { error: string };
+
+    // The deck-membership guard fires first in our implementation.
+    expect(response.status).toBe(409);
+    expect(["card_in_deck", "insufficient_stock"]).toContain(body.error);
+
+    const persisted = store.snapshot(sellIdentity);
+    expect(persisted?.crystals).toBe(0);
+    expect(getOwnedCount(persisted?.ownedCards ?? [], commonCard.id)).toBe(2);
+  });
+
+  test("the multiset addToInventory + sell round-trip is consistent with computeSellRevenue", () => {
+    // Sanity check that the in-memory store mirrors what production does:
+    // ownedCards updates flow through inventoryOps and crystals through the
+    // pricing module, so the test exercises the same composition.
+    const seedOwned = addToInventory([], commonCard.id, 4);
+    expect(getOwnedCount(seedOwned, commonCard.id)).toBe(4);
+    expect(computeSellRevenue(commonCard, 4)).toBe(20);
+  });
+});
+
+class MemoryPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewardsStore, PlayerSellStore {
   private readonly profiles: StoredPlayerProfile[];
   private nextId: number;
   createdCount = 0;
@@ -621,6 +813,40 @@ class MemoryPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewardsSto
     return afterBonus;
   }
 
+  async applySellCards(identity: PlayerIdentity, cardId: string, count: number): Promise<StoredPlayerProfile> {
+    if (!Number.isInteger(count) || count <= 0) {
+      throw new SellError("invalid_sell_count", "count must be a positive integer.", 400);
+    }
+
+    const card = cards.find((entry) => entry.id === cardId);
+    if (!card) {
+      throw new SellError("invalid_card_id", `Unknown card id: ${cardId}`, 400);
+    }
+
+    const index = this.profiles.findIndex((profile) => isSamePlayerIdentity(profile.identity, identity));
+    if (index < 0) {
+      throw new SellError("insufficient_stock", "Profile does not exist.", 409);
+    }
+
+    const current = this.profiles[index];
+    if (current.deckIds.includes(cardId)) {
+      throw new SellError("card_in_deck", "Cannot sell a card that is in a saved deck.", 409);
+    }
+
+    if (count > getSellableCount(current.ownedCards, current.deckIds, cardId)) {
+      throw new SellError("insufficient_stock", "Not enough sellable copies.", 409);
+    }
+
+    const revenue = computeSellRevenue(card, count);
+    const next: StoredPlayerProfile = {
+      ...current,
+      ownedCards: removeFromInventory(current.ownedCards, cardId, count),
+      crystals: current.crystals + revenue,
+    };
+    this.profiles[index] = next;
+    return next;
+  }
+
   snapshot(identity: PlayerIdentity): StoredPlayerProfile | undefined {
     return this.profiles.find((profile) => isSamePlayerIdentity(profile.identity, identity));
   }
@@ -676,6 +902,19 @@ function postMatchFinished(store: PlayerMatchRewardsStore, body: unknown) {
 function postDeck(store: PlayerDeckStore, body: unknown) {
   return handlePlayerDeckSavePost(
     new Request("http://localhost/api/player/deck", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }),
+    store,
+  );
+}
+
+function postSell(store: PlayerSellStore, body: unknown) {
+  return handlePlayerSellPost(
+    new Request("http://localhost/api/player/sell", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/tests/playerProgression.test.ts
+++ b/tests/playerProgression.test.ts
@@ -148,29 +148,29 @@ describe("computeMatchRewards (PvE)", () => {
 describe("computeMatchRewards (PvP)", () => {
   const freshProfile = { crystals: 0, totalXp: 0, level: 1 };
 
-  test("PvP win awards 50 crystals + 100 XP", () => {
+  test("PvP win awards 10 crystals + 100 XP", () => {
     const rewards = computeMatchRewards(freshProfile, { mode: "pvp", result: "win" });
 
     expect(rewards.deltaXp).toBe(PVP_XP_REWARDS.win);
     expect(rewards.deltaXp).toBe(100);
     expect(rewards.matchCrystals).toBe(PVP_CRYSTAL_REWARDS.win);
-    expect(rewards.matchCrystals).toBe(50);
-    expect(rewards.deltaCrystals).toBe(50);
+    expect(rewards.matchCrystals).toBe(10);
+    expect(rewards.deltaCrystals).toBe(10);
     expect(rewards.leveledUp).toBe(false);
     expect(rewards.levelUpBonusCrystals).toBe(0);
-    expect(rewards.newTotals).toEqual({ crystals: 50, totalXp: 100, level: 1 });
+    expect(rewards.newTotals).toEqual({ crystals: 10, totalXp: 100, level: 1 });
   });
 
-  test("PvP draw awards 20 crystals + 50 XP", () => {
+  test("PvP draw awards 3 crystals + 50 XP", () => {
     const rewards = computeMatchRewards(freshProfile, { mode: "pvp", result: "draw" });
 
     expect(rewards.deltaXp).toBe(PVP_XP_REWARDS.draw);
     expect(rewards.deltaXp).toBe(50);
     expect(rewards.matchCrystals).toBe(PVP_CRYSTAL_REWARDS.draw);
-    expect(rewards.matchCrystals).toBe(20);
-    expect(rewards.deltaCrystals).toBe(20);
+    expect(rewards.matchCrystals).toBe(3);
+    expect(rewards.deltaCrystals).toBe(3);
     expect(rewards.leveledUp).toBe(false);
-    expect(rewards.newTotals).toEqual({ crystals: 20, totalXp: 50, level: 1 });
+    expect(rewards.newTotals).toEqual({ crystals: 3, totalXp: 50, level: 1 });
   });
 
   test("PvP loss awards 0 crystals + 10 XP", () => {
@@ -192,12 +192,12 @@ describe("computeMatchRewards (PvP)", () => {
     );
 
     expect(rewards.deltaXp).toBe(100);
-    expect(rewards.matchCrystals).toBe(50);
+    expect(rewards.matchCrystals).toBe(10);
     expect(rewards.leveledUp).toBe(true);
     expect(rewards.levelUpBonusCrystals).toBe(2 * LEVEL_UP_CRYSTAL_BONUS_PER_LEVEL);
     expect(rewards.levelUpBonusCrystals).toBe(50);
-    expect(rewards.deltaCrystals).toBe(100);
-    expect(rewards.newTotals).toEqual({ crystals: 130, totalXp: 250, level: 2 });
+    expect(rewards.deltaCrystals).toBe(60);
+    expect(rewards.newTotals).toEqual({ crystals: 90, totalXp: 250, level: 2 });
   });
 });
 

--- a/tests/pvp-rewards.spec.ts
+++ b/tests/pvp-rewards.spec.ts
@@ -61,9 +61,9 @@ test("PvP reward overlay renders the crystal tile after a server-pushed forfeit 
     const losingPage = winnerTileCount === 1 ? loserPage : winnerPage;
 
     const crystalsTile = winningPage.getByTestId("reward-crystals-tile");
-    await expect(crystalsTile).toHaveAttribute("data-delta-crystals", "50");
-    await expect(crystalsTile).toHaveAttribute("data-new-crystals", "50");
-    await expect(winningPage.getByTestId("reward-crystals-line")).toContainText("всього 50");
+    await expect(crystalsTile).toHaveAttribute("data-delta-crystals", "10");
+    await expect(crystalsTile).toHaveAttribute("data-new-crystals", "10");
+    await expect(winningPage.getByTestId("reward-crystals-line")).toContainText("всього 10");
 
     // Match-result title is color-coded per outcome (victory / defeat tone).
     await expect(winningPage.getByTestId("reward-title")).toHaveText("ПЕРЕМОГА");

--- a/tests/realtime.spec.ts
+++ b/tests/realtime.spec.ts
@@ -161,8 +161,8 @@ test("emits server-authoritative reward_summary to both PvP sessions on a forfei
   expect(moverPayload.newTotals).toMatchObject({ crystals: 0, totalXp: 10, level: 1 });
 
   expect(otherPayload.deltaXp).toBe(100);
-  expect(otherPayload.deltaCrystals).toBe(50);
-  expect(otherPayload.newTotals).toMatchObject({ crystals: 50, totalXp: 100, level: 1 });
+  expect(otherPayload.deltaCrystals).toBe(10);
+  expect(otherPayload.newTotals).toMatchObject({ crystals: 10, totalXp: 100, level: 1 });
 
   expect(firstMoverIdentity).toBeDefined();
   expect(otherIdentity).toBeDefined();
@@ -256,8 +256,8 @@ test("disconnect mid-match forfeits the disconnecting side and emits a win rewar
   const survivorPayload = survivorReward.payload as RewardSummary;
 
   expect(survivorPayload.deltaXp).toBe(100);
-  expect(survivorPayload.deltaCrystals).toBe(50);
-  expect(survivorPayload.newTotals).toMatchObject({ crystals: 50, totalXp: 100, level: 1 });
+  expect(survivorPayload.deltaCrystals).toBe(10);
+  expect(survivorPayload.newTotals).toMatchObject({ crystals: 10, totalXp: 100, level: 1 });
   // Equal pre-match ELOs → +16 / -16 zero-sum.
   expect(survivorPayload.deltaElo).toBe(16);
   expect(survivorPayload.newTotals.eloRating).toBe(1116);

--- a/tests/sell-flow.spec.ts
+++ b/tests/sell-flow.spec.ts
@@ -21,6 +21,9 @@ test("Collection card detail sells a duplicate Common, decrements badge, and cre
   }
 
   const sellIdentity: PlayerIdentity = { mode: "guest", guestId: "guest-sell-flow-e2e" };
+  const startingCrystals = 0;
+  let currentCrystals = startingCrystals;
+  let currentExtraCount = 2;
 
   await mockDeckReadyProfile(page, {
     identity: sellIdentity,
@@ -31,17 +34,21 @@ test("Collection card detail sells a duplicate Common, decrements badge, and cre
       cardId,
       count: cardId === sellableExtraCardId ? 2 : 1,
     })),
-    crystals: 0,
+    crystals: startingCrystals,
   });
 
   // Mock POST /api/player/sell so the spec runs offline-friendly: returns the
-  // expected post-sell profile without depending on the Mongo store.
+  // expected post-sell profile without depending on the Mongo store. Reads
+  // currentCrystals from test scope so future seed edits do not silently
+  // make the assertion fire on a "happens to be zero" baseline.
   await page.route("**/api/player/sell", async (route) => {
     const body = route.request().postDataJSON() as { identity: PlayerIdentity; cardId: string; count: number };
     const sellPrice = SELL_PRICES_BY_RARITY[sellableCard.rarity];
+    currentCrystals += body.count * sellPrice;
+    currentExtraCount = Math.max(0, currentExtraCount - body.count);
     const ownedCards = PROFILE_OWNED_CARD_IDS.map((cardId) => ({
       cardId,
-      count: cardId === sellableExtraCardId ? 2 - body.count : 1,
+      count: cardId === sellableExtraCardId ? currentExtraCount : 1,
     })).filter((entry) => entry.count > 0);
     const totalXp = 0;
 
@@ -57,7 +64,7 @@ test("Collection card detail sells a duplicate Common, decrements badge, and cre
           deckIds: PROFILE_DECK_IDS,
           starterFreeBoostersRemaining: 0,
           openedBoosterIds: ["neon-breach", "factory-shift"],
-          crystals: body.count * sellPrice,
+          crystals: currentCrystals,
           totalXp,
           level: computeLevelFromXp(totalXp).level,
           wins: 0,
@@ -91,8 +98,13 @@ test("Collection card detail sells a duplicate Common, decrements badge, and cre
   // Owned-count badge decrements from 2 to 1.
   await expect(page.getByTestId(`collection-owned-count-${sellableCard.id}`)).toHaveText("Ви маєте: 1");
 
-  // HUD crystals incremented by Common sell price (5).
-  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-crystals", "5");
+  // HUD crystals incremented by Common sell price (5). data-profile-crystals
+  // is emitted by player-hud-sidebar (visible on the desktop chromium project)
+  // and player-hud-mobile, NOT by player-profile-shell.
+  await expect(page.getByTestId("player-hud-sidebar")).toHaveAttribute(
+    "data-profile-crystals",
+    String(startingCrystals + SELL_PRICES_BY_RARITY[sellableCard.rarity]),
+  );
 });
 
 test("Collection card detail disables sell when the card is in any saved deck", async ({ page }) => {

--- a/tests/sell-flow.spec.ts
+++ b/tests/sell-flow.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "@playwright/test";
+import { cards } from "../src/features/battle/model/cards";
+import { SELL_PRICES_BY_RARITY } from "../src/features/economy/sellPricing";
+import { computeLevelFromXp, type PlayerIdentity } from "../src/features/player/profile/types";
+import { mockDeckReadyProfile, PROFILE_DECK_IDS, PROFILE_OWNED_CARD_IDS } from "./fixtures/playerProfile";
+
+// Pick a Common card outside the saved deck so the sell button is enabled.
+const sellableExtraCardId = "dahack-363";
+// First deck card is locked (it's in the saved deck).
+const inDeckCardId = PROFILE_DECK_IDS[0];
+
+test("Collection card detail sells a duplicate Common, decrements badge, and credits the HUD crystals", async ({ page }) => {
+  if (!PROFILE_OWNED_CARD_IDS.includes(sellableExtraCardId)) {
+    throw new Error(`Sellable extra ${sellableExtraCardId} must be in fixture ownedCardIds.`);
+  }
+
+  const sellableCard = cards.find((card) => card.id === sellableExtraCardId);
+  if (!sellableCard) throw new Error(`Card ${sellableExtraCardId} must exist in card pool.`);
+  if (sellableCard.rarity !== "Common") {
+    throw new Error(`Sell-flow fixture expects ${sellableExtraCardId} to be Common (got ${sellableCard.rarity}).`);
+  }
+
+  const sellIdentity: PlayerIdentity = { mode: "guest", guestId: "guest-sell-flow-e2e" };
+
+  await mockDeckReadyProfile(page, {
+    identity: sellIdentity,
+    ownedCardIds: PROFILE_OWNED_CARD_IDS,
+    // Same set as ownedCardIds, except the extra card has count 2 — so one
+    // copy is sellable and one stays in the inventory after the sell.
+    ownedCards: PROFILE_OWNED_CARD_IDS.map((cardId) => ({
+      cardId,
+      count: cardId === sellableExtraCardId ? 2 : 1,
+    })),
+    crystals: 0,
+  });
+
+  // Mock POST /api/player/sell so the spec runs offline-friendly: returns the
+  // expected post-sell profile without depending on the Mongo store.
+  await page.route("**/api/player/sell", async (route) => {
+    const body = route.request().postDataJSON() as { identity: PlayerIdentity; cardId: string; count: number };
+    const sellPrice = SELL_PRICES_BY_RARITY[sellableCard.rarity];
+    const ownedCards = PROFILE_OWNED_CARD_IDS.map((cardId) => ({
+      cardId,
+      count: cardId === sellableExtraCardId ? 2 - body.count : 1,
+    })).filter((entry) => entry.count > 0);
+    const totalXp = 0;
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        player: {
+          id: "player-sell-flow-e2e",
+          identity: body.identity,
+          ownedCardIds: ownedCards.map((entry) => entry.cardId),
+          ownedCards,
+          deckIds: PROFILE_DECK_IDS,
+          starterFreeBoostersRemaining: 0,
+          openedBoosterIds: ["neon-breach", "factory-shift"],
+          crystals: body.count * sellPrice,
+          totalXp,
+          level: computeLevelFromXp(totalXp).level,
+          wins: 0,
+          losses: 0,
+          draws: 0,
+          eloRating: 1000,
+          onboarding: {
+            starterBoostersAvailable: false,
+            collectionReady: true,
+            deckReady: true,
+            completed: true,
+          },
+        },
+      }),
+    });
+  });
+
+  await page.goto("/");
+
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-collection-mode", "owned");
+
+  // Open the card detail by selecting the tile.
+  await page.getByLabel(`Обрати ${sellableCard.name}`).click();
+
+  // Sell summary line appears with the expected breakdown.
+  await expect(page.getByTestId("collection-sell-summary")).toContainText("Ви маєте: 2 (0 у колоді, 2 запасних)");
+
+  // Sell 1 duplicate (no confirm needed — not last copy, not Legend).
+  await page.getByTestId("collection-sell-1").click();
+
+  // Owned-count badge decrements from 2 to 1.
+  await expect(page.getByTestId(`collection-owned-count-${sellableCard.id}`)).toHaveText("Ви маєте: 1");
+
+  // HUD crystals incremented by Common sell price (5).
+  await expect(page.getByTestId("player-profile-shell")).toHaveAttribute("data-profile-crystals", "5");
+});
+
+test("Collection card detail disables sell when the card is in any saved deck", async ({ page }) => {
+  if (!inDeckCardId) throw new Error("Fixture must include at least one deck card.");
+
+  const sellIdentity: PlayerIdentity = { mode: "guest", guestId: "guest-sell-disabled-e2e" };
+
+  await mockDeckReadyProfile(page, {
+    identity: sellIdentity,
+    crystals: 0,
+  });
+
+  await page.goto("/");
+
+  const inDeckCard = cards.find((card) => card.id === inDeckCardId);
+  if (!inDeckCard) throw new Error(`Card ${inDeckCardId} must exist in card pool.`);
+
+  await page.getByLabel(`Обрати ${inDeckCard.name}`).click();
+
+  // Helper text uses the exact uk-UA phrase.
+  await expect(page.getByTestId("collection-sell-disabled-reason")).toHaveText("Видали з колоди, щоб продати");
+
+  // Both sell buttons are present but disabled.
+  await expect(page.getByTestId("collection-sell-1")).toBeDisabled();
+  await expect(page.getByTestId("collection-sell-all")).toBeDisabled();
+});

--- a/tests/sellPricing.test.ts
+++ b/tests/sellPricing.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SELL_PRICES_BY_RARITY,
+  computeSellRevenue,
+  getSellPrice,
+} from "../src/features/economy/sellPricing";
+import type { Card } from "../src/features/battle/model/types";
+
+describe("SELL_PRICES_BY_RARITY", () => {
+  test("exposes the canonical 5 / 15 / 50 / 200 ladder for the four rarities", () => {
+    expect(SELL_PRICES_BY_RARITY).toEqual({
+      Common: 5,
+      Rare: 15,
+      Unique: 50,
+      Legend: 200,
+    });
+  });
+});
+
+describe("getSellPrice", () => {
+  test("returns the per-rarity unit price", () => {
+    expect(getSellPrice("Common")).toBe(5);
+    expect(getSellPrice("Rare")).toBe(15);
+    expect(getSellPrice("Unique")).toBe(50);
+    expect(getSellPrice("Legend")).toBe(200);
+  });
+});
+
+describe("computeSellRevenue", () => {
+  const sampleCard = (rarity: Card["rarity"]): Pick<Card, "rarity"> => ({ rarity });
+
+  test("scales the per-rarity unit price linearly by count", () => {
+    expect(computeSellRevenue(sampleCard("Common"), 1)).toBe(5);
+    expect(computeSellRevenue(sampleCard("Common"), 4)).toBe(20);
+    expect(computeSellRevenue(sampleCard("Rare"), 3)).toBe(45);
+    expect(computeSellRevenue(sampleCard("Unique"), 2)).toBe(100);
+    expect(computeSellRevenue(sampleCard("Legend"), 1)).toBe(200);
+    expect(computeSellRevenue(sampleCard("Legend"), 5)).toBe(1000);
+  });
+
+  test("count = 0 is a no-op revenue of 0 and does not throw", () => {
+    expect(computeSellRevenue(sampleCard("Legend"), 0)).toBe(0);
+  });
+
+  test("rejects negative, fractional, NaN, Infinity, and non-numeric counts", () => {
+    expect(() => computeSellRevenue(sampleCard("Common"), -1)).toThrow(/non-negative integer/);
+    expect(() => computeSellRevenue(sampleCard("Common"), 1.5)).toThrow(/non-negative integer/);
+    expect(() => computeSellRevenue(sampleCard("Common"), Number.NaN)).toThrow(/non-negative integer/);
+    expect(() => computeSellRevenue(sampleCard("Common"), Number.POSITIVE_INFINITY)).toThrow(/non-negative integer/);
+    expect(() => computeSellRevenue(sampleCard("Common"), "2" as unknown as number)).toThrow(/non-negative integer/);
+  });
+});


### PR DESCRIPTION
Closes #44. Parent PRD #42. **Stacked on #47** (slice 1).

## Summary

- New pure module `src/features/economy/sellPricing.ts` (`SELL_PRICES_BY_RARITY`, `getSellPrice`, `computeSellRevenue`). Common 5 / Rare 15 / Unique 50 / Legend 200 💎.
- New `MongoPlayerProfileStore.applySellCards(identity, cardId, count)` — single Mongo aggregation-pipeline update with `{ ownedCards: { \$elemMatch: { count: { \$gte } } }, deckIds: { \$ne: cardId } }` precondition. Atomic; safe under double-tap.
- New `POST /api/player/sell` route + `handlePlayerSellPost`. Returns `{player: PlayerProfile}` on 200; 4xx codes: `invalid_card_id` (400), `invalid_sell_count` (400), `insufficient_stock` (409), `card_in_deck` (409).
- Collection card-detail sell flow: `[Продати 1]` / `[Продати всі дублікати]` / last-copy confirm / Legend confirm. In-deck cards have buttons disabled with helper "Видали з колоди, щоб продати".
- Badge wording: `Ви маєте: N (X у колоді, Y запасних)` when not in deck, `Ви маєте: N (1 у колоді)` when in deck (no "запасних" segment when sells are blocked).
- `PVP_CRYSTAL_REWARDS` rebalanced from `{50, 20, 0}` to `{10, 3, 0}`. PvP XP unchanged. PvE unchanged.
- HUD crystal balance + ownedCards refresh without reload via existing `onPlayerUpdated` wiring.
- Stale `TODO(slice-2)` in `hasAppliedStarterOpening` replaced with a verified-safe note.

## Test plan

- [x] `bun test` — 174 passing across 11 files (was 158 in slice 1).
- [x] `bun run lint` — clean (only pre-existing warnings).
- [x] Unit: `tests/sellPricing.test.ts` covers all four rarities + invalid input.
- [x] Integration: `tests/playerProfile.test.ts` extended with happy paths (sell partial / sell-all-spares / sell removes the entry) and 4xx error paths (in-deck, insufficient stock, unknown cardId, count<=0).
- [x] PvP rebalance asserts updated in `tests/playerProgression.test.ts`, `tests/pvp-rewards.spec.ts`, `tests/realtime.spec.ts`.
- [x] Aggregation-pipeline update is atomic; concurrent same-card sells cannot drive count negative or double-spend.
- [ ] Playwright e2e `tests/sell-flow.spec.ts` — author-only this PR; full Docker run during umbrella merge.
- [ ] Manual smoke (Docker dev, sell duplicate Common, confirm HUD updates; try selling Legend, confirm extra prompt; try selling in-deck card, confirm disabled).

## Out of scope (other slices)

- Inventory multiset foundation — slice 1 (#47).
- Milestone card rewards — slice 3 (#45).
- Static "Як грати" guide — slice 4 (#48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)