### PR TITLE
feat(integrations): ingest group clans/cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "bun server.js",
     "lint": "eslint",
-    "test": "bun test tests/playerAuth.test.ts tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/playerProgression.test.ts tests/battleEffectRules.test.ts tests/roundResolverPvp.test.ts tests/opponentStrategy.test.ts tests/battleAiOpenrouter.test.ts tests/elo.test.ts tests/matchmakingQueue.test.ts tests/rewardOverlayPresenter.test.ts tests/playerAvatar.test.ts tests/onlinePresence.test.ts tests/inventoryOps.test.ts tests/sellPricing.test.ts tests/milestones.test.ts tests/sessionName.test.ts",
+    "test": "bun test tests/playerAuth.test.ts tests/playerProfile.test.ts tests/boosterOpening.test.ts tests/integrations.test.ts tests/playerProgression.test.ts tests/battleEffectRules.test.ts tests/roundResolverPvp.test.ts tests/opponentStrategy.test.ts tests/battleAiOpenrouter.test.ts tests/elo.test.ts tests/matchmakingQueue.test.ts tests/rewardOverlayPresenter.test.ts tests/playerAvatar.test.ts tests/onlinePresence.test.ts tests/inventoryOps.test.ts tests/sellPricing.test.ts tests/milestones.test.ts tests/sessionName.test.ts",
     "test:profile": "bun test tests/playerProfile.test.ts",
     "test:e2e": "playwright test",
     "generate:sfx": "bun scripts/generate-elevenlabs-projectile-sfx.mjs",

--- a/src/app/api/integrations/group-cards/route.ts
+++ b/src/app/api/integrations/group-cards/route.ts
@@ -1,0 +1,6 @@
+import { handleGroupCardPost } from "@/features/integrations/api";
+import { getMongoPlayerProfileStore } from "@/features/player/profile/mongo";
+
+export async function POST(request: Request) {
+  return handleGroupCardPost(request, getMongoPlayerProfileStore());
+}

--- a/src/app/api/integrations/groups/[chatId]/route.ts
+++ b/src/app/api/integrations/groups/[chatId]/route.ts
@@ -1,0 +1,6 @@
+import { handleGroupUpsertPut } from "@/features/integrations/api";
+import { getMongoPlayerProfileStore } from "@/features/player/profile/mongo";
+
+export async function PUT(request: Request, context: { params: Promise<{ chatId: string }> }) {
+  return handleGroupUpsertPut(request, context, getMongoPlayerProfileStore());
+}

--- a/src/features/integrations/api.ts
+++ b/src/features/integrations/api.ts
@@ -1,0 +1,348 @@
+import { cards } from "@/features/battle/model/cards";
+import type { Bonus, EffectCondition, EffectMode, EffectOutcomeCondition, EffectSpec, EffectTarget, StatusKind } from "@/features/battle/model/types";
+import { toPlayerProfile, type PlayerIdentity, type PlayerProfile } from "@/features/player/profile/types";
+import { IntegrationAssetError, ingestRemoteImage, type FetchAsset } from "./assets";
+import {
+  groupBoosterId,
+  groupCardId,
+  registerGroupCardRuntime,
+  registerGroupRuntime,
+  type GroupCardInput,
+  type GroupCardIntegrationRecord,
+  type GroupIntegrationRecord,
+} from "./runtime";
+
+export type IntegrationStore = {
+  upsertGroup(input: UpsertGroupInput): Promise<GroupIntegrationRecord>;
+  findGroupCardByIdempotencyKey?(idempotencyKey: string): Promise<CreateGroupCardResult | undefined>;
+  createGroupCard(input: CreateGroupCardInput): Promise<CreateGroupCardResult>;
+  findOrCreateByIdentity(identity: PlayerIdentity): Promise<Parameters<typeof toPlayerProfile>[0]>;
+};
+
+export type UpsertGroupInput = {
+  chatId: string;
+  displayName: string;
+  glyphUrl: string;
+  bonus: Bonus;
+};
+
+export type CreateGroupCardInput = GroupCardInput;
+
+export type CreateGroupCardResult = {
+  group: GroupIntegrationRecord;
+  groupCard: GroupCardIntegrationRecord;
+  cardInput: CreateGroupCardInput;
+  player: Parameters<typeof toPlayerProfile>[0];
+  idempotent: boolean;
+};
+
+export async function handleGroupUpsertPut(
+  request: Request,
+  context: { params: Promise<{ chatId: string }> | { chatId: string } },
+  store: IntegrationStore,
+  options: { fetcher?: FetchAsset } = {},
+) {
+  try {
+    requireIntegrationAuth(request);
+    const { chatId } = await context.params;
+    const body = await readJsonObject(request);
+    const displayName = parseName(body.displayName ?? body.title ?? body.chatTitle, "displayName");
+    const bonus = parseBonus(body.bonus);
+    const glyphSourceUrl = parseUrlString(body.glyphUrl, "glyphUrl");
+    const storedGlyphUrl = await ingestRemoteImage({
+      url: glyphSourceUrl,
+      kind: "glyph",
+      ownerId: chatId,
+      assetId: "glyph",
+      fetcher: options.fetcher,
+    });
+
+    const group = await store.upsertGroup({
+      chatId: parseId(chatId, "chatId"),
+      displayName,
+      glyphUrl: storedGlyphUrl,
+      bonus,
+    });
+    registerGroupRuntime(group);
+
+    return json({ group: serializeGroup(group) });
+  } catch (error) {
+    return integrationErrorResponse(error);
+  }
+}
+
+export async function handleGroupCardPost(request: Request, store: IntegrationStore, options: { fetcher?: FetchAsset } = {}) {
+  try {
+    requireIntegrationAuth(request);
+    const body = await readJsonObject(request);
+    const chatId = parseId(body.chatId, "chatId");
+    const creatorTelegramId = parseId(body.creatorTelegramId, "creatorTelegramId");
+    const idempotencyKey = parseId(body.idempotencyKey, "idempotencyKey");
+    const imageSourceUrl = parseUrlString(body.imageUrl, "imageUrl");
+    const dropWeight = parseDropWeight(body.dropWeight);
+    const existing = await store.findGroupCardByIdempotencyKey?.(idempotencyKey);
+    if (existing) {
+      const card = registerGroupCardRuntime(existing.group, existing.cardInput);
+      return json({
+        card,
+        group: serializeGroup(existing.group),
+        player: toPlayerProfile(existing.player),
+        idempotent: true,
+      });
+    }
+
+    const artUrl = await ingestRemoteImage({
+      url: imageSourceUrl,
+      kind: "card",
+      ownerId: chatId,
+      assetId: idempotencyKey,
+      fetcher: options.fetcher,
+    });
+
+    const result = await store.createGroupCard({
+      chatId,
+      creatorTelegramId,
+      idempotencyKey,
+      name: parseName(body.name, "name"),
+      power: parseStat(body.power, "power"),
+      damage: parseStat(body.damage, "damage"),
+      ability: parseAbility(body.ability),
+      imageUrl: imageSourceUrl,
+      artUrl,
+      dropWeight,
+    });
+    const card = registerGroupCardRuntime(result.group, {
+      chatId,
+      creatorTelegramId,
+      idempotencyKey,
+      name: parseName(body.name, "name"),
+      power: parseStat(body.power, "power"),
+      damage: parseStat(body.damage, "damage"),
+      ability: parseAbility(body.ability),
+      imageUrl: imageSourceUrl,
+      artUrl,
+      dropWeight,
+    });
+
+    return json({
+      card,
+      group: serializeGroup(result.group),
+      player: toPlayerProfile(result.player),
+      idempotent: result.idempotent,
+    });
+  } catch (error) {
+    return integrationErrorResponse(error);
+  }
+}
+
+export async function serializeCreatorProfile(store: Pick<IntegrationStore, "findOrCreateByIdentity">, telegramId: string): Promise<PlayerProfile> {
+  return toPlayerProfile(await store.findOrCreateByIdentity({ mode: "telegram", telegramId }));
+}
+
+export function validateGroupBonusChange(current: GroupIntegrationRecord | undefined, nextBonus: Bonus) {
+  if (!current || current.cardIds.length === 0) return;
+  if (JSON.stringify(current.bonus) !== JSON.stringify(nextBonus)) {
+    throw new IntegrationValidationError("group_bonus_locked", "Group bonus cannot be changed after group cards exist.", 409);
+  }
+}
+
+export function createNewGroup(input: UpsertGroupInput, now = new Date()): GroupIntegrationRecord {
+  return {
+    chatId: input.chatId,
+    clan: input.displayName,
+    boosterId: groupBoosterId(input.chatId),
+    displayName: input.displayName,
+    glyphUrl: input.glyphUrl,
+    bonus: cloneBonus(input.bonus),
+    cardIds: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function createGroupCardRecord(input: CreateGroupCardInput, now = new Date()): GroupCardIntegrationRecord {
+  return {
+    id: groupCardId(input.chatId, input.idempotencyKey),
+    chatId: input.chatId,
+    creatorTelegramId: input.creatorTelegramId,
+    idempotencyKey: input.idempotencyKey,
+    dropWeight: input.dropWeight,
+    createdAt: now,
+  };
+}
+
+function requireIntegrationAuth(request: Request) {
+  const expected = process.env.INTEGRATION_API_TOKEN;
+  if (!expected) {
+    throw new IntegrationValidationError("integration_auth_unconfigured", "Integration API token is not configured.", 500);
+  }
+
+  const header = request.headers.get("authorization") ?? "";
+  const prefix = "Bearer ";
+  if (!header.startsWith(prefix) || header.slice(prefix.length) !== expected) {
+    throw new IntegrationValidationError("unauthorized", "Missing or invalid integration bearer token.", 401);
+  }
+}
+
+function parseBonus(value: unknown): Bonus {
+  if (!isRecord(value)) throw new IntegrationValidationError("invalid_bonus", "bonus must be an object.", 400);
+  const bonus = {
+    id: parseName(value.id, "bonus.id"),
+    name: parseName(value.name, "bonus.name"),
+    description: parseName(value.description, "bonus.description"),
+    effects: parseEffects(value.effects, "bonus.effects"),
+  };
+  return bonus;
+}
+
+function parseAbility(value: unknown) {
+  if (!isRecord(value)) throw new IntegrationValidationError("invalid_ability", "ability must be an object.", 400);
+  return {
+    id: parseName(value.id, "ability.id"),
+    name: parseName(value.name, "ability.name"),
+    description: parseName(value.description, "ability.description"),
+    effects: parseEffects(value.effects, "ability.effects"),
+  };
+}
+
+function parseEffects(value: unknown, field: string): EffectSpec[] {
+  if (!Array.isArray(value)) throw new IntegrationValidationError("invalid_effect", `${field} must be an array.`, 400);
+  return value.map((entry) => parseEffect(entry));
+}
+
+const EFFECT_KEY_WHITELIST = new Set(cards.flatMap((card) => [...card.ability.effects, ...card.bonus.effects].map((effect) => effect.key)));
+const EFFECT_TARGETS = new Set(["self", "opponent"]);
+const EFFECT_CONDITIONS = new Set(["always", "owner_hp_below_opponent", "on_win", "on_loss"]);
+const EFFECT_OUTCOMES = new Set(["always", "on_win", "on_loss"]);
+const EFFECT_MODES = new Set(["add", "reduce_with_min", "mirror_opponent_card_damage", "mirror_opponent_card_power", "per_damage", "per_owner_energy", "per_opponent_energy", "per_owner_hp", "per_opponent_hp"]);
+const STATUS_KINDS = new Set(["poison", "blessing"]);
+
+function parseEffect(value: unknown): EffectSpec {
+  if (!isRecord(value)) throw new IntegrationValidationError("invalid_effect", "effect must be an object.", 400);
+  const key = parseName(value.key, "effect.key");
+  if (!EFFECT_KEY_WHITELIST.has(key)) {
+    throw new IntegrationValidationError("unsupported_effect", `Unsupported effect key: ${key}`, 400);
+  }
+
+  const effect: EffectSpec = { key };
+  if (value.id !== undefined) effect.id = parseName(value.id, "effect.id");
+  if (value.label !== undefined) effect.label = parseName(value.label, "effect.label");
+  if (value.amount !== undefined) effect.amount = parseFinite(value.amount, "effect.amount");
+  if (value.min !== undefined) effect.min = parseFinite(value.min, "effect.min");
+  if (value.target !== undefined) effect.target = parseEnum<EffectTarget>(value.target, EFFECT_TARGETS, "effect.target");
+  if (value.condition !== undefined) effect.condition = parseEnum<EffectCondition>(value.condition, EFFECT_CONDITIONS, "effect.condition");
+  if (value.outcome !== undefined) effect.outcome = parseEnum<EffectOutcomeCondition>(value.outcome, EFFECT_OUTCOMES, "effect.outcome");
+  if (value.mode !== undefined) effect.mode = parseEnum<EffectMode>(value.mode, EFFECT_MODES, "effect.mode");
+  if (value.statusKind !== undefined) effect.statusKind = parseEnum<StatusKind>(value.statusKind, STATUS_KINDS, "effect.statusKind");
+  if (value.unblockable !== undefined) {
+    if (typeof value.unblockable !== "boolean") throw new IntegrationValidationError("invalid_effect", "effect.unblockable must be boolean.", 400);
+    effect.unblockable = value.unblockable;
+  }
+  return effect;
+}
+
+function parseDropWeight(value: unknown) {
+  if (value === undefined) return 1;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new IntegrationValidationError("invalid_drop_weight", "dropWeight must be a positive finite number.", 400);
+  }
+  return value;
+}
+
+function parseStat(value: unknown, field: string) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new IntegrationValidationError("invalid_card", `${field} must be a positive integer.`, 400);
+  }
+  return value;
+}
+
+function parseFinite(value: unknown, field: string) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new IntegrationValidationError("invalid_effect", `${field} must be finite.`, 400);
+  }
+  return value;
+}
+
+function parseEnum<T extends string>(value: unknown, allowed: Set<string>, field: string): T {
+  if (typeof value !== "string" || !allowed.has(value)) {
+    throw new IntegrationValidationError("invalid_effect", `${field} is unsupported.`, 400);
+  }
+  return value as T;
+}
+
+function parseId(value: unknown, field: string) {
+  if (typeof value !== "string") throw new IntegrationValidationError("invalid_request", `${field} must be a string.`, 400);
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 160) throw new IntegrationValidationError("invalid_request", `${field} must be 1-160 characters.`, 400);
+  return trimmed;
+}
+
+function parseName(value: unknown, field: string) {
+  if (typeof value !== "string") throw new IntegrationValidationError("invalid_request", `${field} must be a string.`, 400);
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 160) throw new IntegrationValidationError("invalid_request", `${field} must be 1-160 characters.`, 400);
+  return trimmed;
+}
+
+function parseUrlString(value: unknown, field: string) {
+  const url = parseName(value, field);
+  if (url.length > 2048) throw new IntegrationValidationError("invalid_request", `${field} must be 2048 characters or less.`, 400);
+  return url;
+}
+
+function serializeGroup(group: GroupIntegrationRecord) {
+  return {
+    chatId: group.chatId,
+    clan: group.clan,
+    boosterId: group.boosterId,
+    displayName: group.displayName,
+    glyphUrl: group.glyphUrl,
+    bonus: group.bonus,
+    cardIds: group.cardIds,
+  };
+}
+
+function integrationErrorResponse(error: unknown) {
+  if (error instanceof IntegrationValidationError) {
+    return json({ error: error.code, message: error.message }, error.status);
+  }
+  if (error instanceof IntegrationAssetError) {
+    return json({ error: "invalid_asset", message: error.message }, 400);
+  }
+  if (error instanceof SyntaxError) {
+    return json({ error: "invalid_request", message: error.message }, 400);
+  }
+
+  console.error("Integration API failed.", error);
+  return json({ error: "integration_unavailable", message: "Integration API is unavailable." }, 500);
+}
+
+function json(body: unknown, status = 200) {
+  return Response.json(body, { status, headers: { "Cache-Control": "no-store" } });
+}
+
+async function readJsonObject(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    throw new SyntaxError("request body must be valid JSON.");
+  }
+  if (!isRecord(body)) throw new SyntaxError("request body must be an object.");
+  return body;
+}
+
+function cloneBonus(bonus: Bonus): Bonus {
+  return { ...bonus, effects: bonus.effects.map((effect) => ({ ...effect })) };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export class IntegrationValidationError extends Error {
+  constructor(public readonly code: string, message: string, public readonly status: number) {
+    super(message);
+    this.name = "IntegrationValidationError";
+  }
+}

--- a/src/features/integrations/api.ts
+++ b/src/features/integrations/api.ts
@@ -14,7 +14,7 @@ import {
 
 export type IntegrationStore = {
   upsertGroup(input: UpsertGroupInput): Promise<GroupIntegrationRecord>;
-  findGroupCardByIdempotencyKey?(idempotencyKey: string): Promise<CreateGroupCardResult | undefined>;
+  findGroupCardByIdempotencyKey?(chatId: string, idempotencyKey: string): Promise<CreateGroupCardResult | undefined>;
   createGroupCard(input: CreateGroupCardInput): Promise<CreateGroupCardResult>;
   findOrCreateByIdentity(identity: PlayerIdentity): Promise<Parameters<typeof toPlayerProfile>[0]>;
 };
@@ -80,7 +80,7 @@ export async function handleGroupCardPost(request: Request, store: IntegrationSt
     const idempotencyKey = parseId(body.idempotencyKey, "idempotencyKey");
     const imageSourceUrl = parseUrlString(body.imageUrl, "imageUrl");
     const dropWeight = parseDropWeight(body.dropWeight);
-    const existing = await store.findGroupCardByIdempotencyKey?.(idempotencyKey);
+    const existing = await store.findGroupCardByIdempotencyKey?.(chatId, idempotencyKey);
     if (existing) {
       const card = registerGroupCardRuntime(existing.group, existing.cardInput);
       return json({
@@ -295,6 +295,16 @@ function serializeGroup(group: GroupIntegrationRecord) {
     chatId: group.chatId,
     clan: group.clan,
     boosterId: group.boosterId,
+    booster: {
+      id: group.boosterId,
+      name: group.displayName,
+      clans: [group.clan],
+      cardCount: group.cardIds.length,
+      opening: {
+        available: false,
+        reason: "group_booster_opening_out_of_scope",
+      },
+    },
     displayName: group.displayName,
     glyphUrl: group.glyphUrl,
     bonus: group.bonus,

--- a/src/features/integrations/assets.ts
+++ b/src/features/integrations/assets.ts
@@ -1,0 +1,90 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import sharp from "sharp";
+
+const PUBLIC_ASSET_ROOT = path.join(/*turbopackIgnore: true*/ process.cwd(), "public", "nexus-assets", "integrations");
+const PUBLIC_ASSET_URL_ROOT = "/nexus-assets/integrations";
+const MAX_BYTES = 5 * 1024 * 1024;
+const MIN_DIMENSION = 32;
+const MAX_DIMENSION = 4096;
+const SUPPORTED_FORMATS = new Set(["png", "jpeg", "webp", "gif"]);
+const EXT_BY_FORMAT: Record<string, string> = {
+  jpeg: "jpg",
+  png: "png",
+  webp: "webp",
+  gif: "gif",
+};
+
+export class IntegrationAssetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IntegrationAssetError";
+  }
+}
+
+export type FetchAsset = typeof fetch;
+
+export async function ingestRemoteImage(input: {
+  url: string;
+  kind: "glyph" | "card";
+  ownerId: string;
+  assetId: string;
+  fetcher?: FetchAsset;
+}) {
+  const remoteUrl = parseRemoteAssetUrl(input.url);
+  const response = await (input.fetcher ?? fetch)(remoteUrl);
+  if (!response.ok) {
+    throw new IntegrationAssetError(`${input.kind} URL returned ${response.status}.`);
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (bytes.length <= 0 || bytes.length > MAX_BYTES) {
+    throw new IntegrationAssetError(`${input.kind} image must be between 1 byte and ${MAX_BYTES} bytes.`);
+  }
+
+  let metadata: sharp.Metadata;
+  try {
+    metadata = await sharp(bytes, { animated: false }).metadata();
+  } catch {
+    throw new IntegrationAssetError(`${input.kind} image is not a supported image.`);
+  }
+
+  if (!metadata.format || !SUPPORTED_FORMATS.has(metadata.format)) {
+    throw new IntegrationAssetError(`${input.kind} image type is not supported.`);
+  }
+
+  const width = metadata.width ?? 0;
+  const height = metadata.height ?? 0;
+  if (width < MIN_DIMENSION || height < MIN_DIMENSION || width > MAX_DIMENSION || height > MAX_DIMENSION) {
+    throw new IntegrationAssetError(`${input.kind} image dimensions are outside ${MIN_DIMENSION}-${MAX_DIMENSION}px.`);
+  }
+
+  const extension = EXT_BY_FORMAT[metadata.format] ?? metadata.format;
+  const ownerDir = safePathPart(input.ownerId);
+  const assetBase = safePathPart(input.assetId);
+  const relativePath = path.join(ownerDir, `${assetBase}.${extension}`);
+  const absolutePath = path.join(PUBLIC_ASSET_ROOT, relativePath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, bytes);
+
+  return `${PUBLIC_ASSET_URL_ROOT}/${ownerDir}/${assetBase}.${extension}`;
+}
+
+function parseRemoteAssetUrl(value: string) {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new IntegrationAssetError("asset URL must be a valid URL.");
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new IntegrationAssetError("asset URL must use http or https.");
+  }
+
+  return url;
+}
+
+function safePathPart(value: string) {
+  return value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "asset";
+}

--- a/src/features/integrations/runtime.ts
+++ b/src/features/integrations/runtime.ts
@@ -1,0 +1,147 @@
+import { cards } from "@/features/battle/model/cards";
+import { READABLE_CARD_FRAME_URL } from "@/features/battle/model/cardAssets";
+import { clans, type ClanRecord } from "@/features/battle/model/clans";
+import type { Bonus, Card, EffectSpec } from "@/features/battle/model/types";
+
+export const GROUP_CARD_RARITY = "Legend" as const;
+export const GROUP_CARD_ACCENT = "#f0c431";
+
+export type GroupIntegrationRecord = {
+  chatId: string;
+  clan: string;
+  boosterId: string;
+  displayName: string;
+  glyphUrl: string;
+  bonus: Bonus;
+  cardIds: string[];
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type GroupCardIntegrationRecord = {
+  id: string;
+  chatId: string;
+  creatorTelegramId: string;
+  idempotencyKey: string;
+  dropWeight: number;
+  createdAt: Date;
+};
+
+export type GroupCardInput = {
+  chatId: string;
+  creatorTelegramId: string;
+  idempotencyKey: string;
+  name: string;
+  power: number;
+  damage: number;
+  ability: {
+    id: string;
+    name: string;
+    description: string;
+    effects: EffectSpec[];
+  };
+  imageUrl: string;
+  artUrl: string;
+  dropWeight: number;
+};
+
+export function groupBoosterId(chatId: string) {
+  return `group-${encodeURIComponent(chatId)}`;
+}
+
+export function groupCardId(chatId: string, idempotencyKey: string) {
+  return `group-${slugPart(chatId)}-${slugPart(idempotencyKey)}`;
+}
+
+export function registerGroupRuntime(group: GroupIntegrationRecord) {
+  const record: ClanRecord = {
+    slug: slugPart(group.chatId),
+    name: group.clan,
+    sourceUrl: `nexus://integrations/groups/${group.chatId}`,
+    logoUrl: group.glyphUrl,
+    cardCounts: {
+      Common: 0,
+      Rare: 0,
+      Unique: 0,
+      Legend: group.cardIds.length,
+    },
+    bonus: cloneBonus(group.bonus),
+  };
+
+  clans[group.clan] = record;
+}
+
+export function registerGroupCardRuntime(group: GroupIntegrationRecord, cardInput: GroupCardInput) {
+  registerGroupRuntime(group);
+  const existingIndex = cards.findIndex((card) => card.id === groupCardId(cardInput.chatId, cardInput.idempotencyKey));
+  const card = buildGroupCard(group, cardInput);
+  if (existingIndex >= 0) {
+    cards[existingIndex] = card;
+    return card;
+  }
+
+  cards.push(card);
+  return card;
+}
+
+export function buildGroupCard(group: GroupIntegrationRecord, input: GroupCardInput): Card {
+  const id = groupCardId(input.chatId, input.idempotencyKey);
+  return {
+    id,
+    name: input.name,
+    clan: group.clan,
+    level: 4,
+    power: input.power,
+    damage: input.damage,
+    ability: {
+      ...input.ability,
+      effects: input.ability.effects.map((effect) => ({ ...effect })),
+    },
+    bonus: cloneBonus(group.bonus),
+    artUrl: input.artUrl,
+    frameUrl: READABLE_CARD_FRAME_URL,
+    used: false,
+    rarity: GROUP_CARD_RARITY,
+    portrait: groupCardPortrait(id),
+    accent: GROUP_CARD_ACCENT,
+    source: {
+      sourceId: stableSourceId(id),
+      sourceUrl: `nexus://integrations/group-cards/${id}`,
+      sourceArtUrl: input.imageUrl,
+      collectible: true,
+      abilityText: input.ability.name,
+      abilityDescription: input.ability.description,
+      bonusText: group.bonus.name,
+      bonusDescription: group.bonus.description,
+    },
+  };
+}
+
+function cloneBonus(bonus: Bonus): Bonus {
+  return {
+    ...bonus,
+    effects: bonus.effects.map((effect) => ({ ...effect })),
+  };
+}
+
+function groupCardPortrait(seed: string) {
+  const hue = stableSourceId(seed) % 360;
+  return [
+    "radial-gradient(circle at 50% 20%, rgba(255,246,210,0.95) 0 8%, transparent 9%)",
+    `linear-gradient(145deg, hsl(${hue} 58% 52%), hsl(${(hue + 26) % 360} 46% 32%) 52%, #131319)`,
+  ].join(", ");
+}
+
+function stableSourceId(value: string) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash >>> 0);
+}
+
+function slugPart(value: string) {
+  const slug = value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
+  return slug || stableSourceId(value).toString(36);
+}

--- a/src/features/integrations/runtime.ts
+++ b/src/features/integrations/runtime.ts
@@ -5,6 +5,10 @@ import type { Bonus, Card, EffectSpec } from "@/features/battle/model/types";
 
 export const GROUP_CARD_RARITY = "Legend" as const;
 export const GROUP_CARD_ACCENT = "#f0c431";
+const STATIC_CARD_IDS = new Set(cards.map((card) => card.id));
+const STATIC_CLAN_NAMES = new Set(Object.keys(clans));
+const dynamicCardIds = new Set<string>();
+const dynamicClanNames = new Set<string>();
 
 export type GroupIntegrationRecord = {
   chatId: string;
@@ -69,19 +73,53 @@ export function registerGroupRuntime(group: GroupIntegrationRecord) {
   };
 
   clans[group.clan] = record;
+  if (!STATIC_CLAN_NAMES.has(group.clan)) {
+    dynamicClanNames.add(group.clan);
+  }
 }
 
 export function registerGroupCardRuntime(group: GroupIntegrationRecord, cardInput: GroupCardInput) {
   registerGroupRuntime(group);
-  const existingIndex = cards.findIndex((card) => card.id === groupCardId(cardInput.chatId, cardInput.idempotencyKey));
+  const cardId = groupCardId(cardInput.chatId, cardInput.idempotencyKey);
+  const existingIndex = cards.findIndex((card) => card.id === cardId);
   const card = buildGroupCard(group, cardInput);
   if (existingIndex >= 0) {
     cards[existingIndex] = card;
+    if (!STATIC_CARD_IDS.has(cardId)) {
+      dynamicCardIds.add(cardId);
+    }
     return card;
   }
 
   cards.push(card);
+  dynamicCardIds.add(card.id);
   return card;
+}
+
+export function hydrateGroupRuntime(groups: readonly GroupIntegrationRecord[], groupCards: readonly GroupCardInput[]) {
+  const groupsByChatId = new Map(groups.map((group) => [group.chatId, group] as const));
+  for (const group of groups) {
+    registerGroupRuntime(group);
+  }
+  for (const groupCard of groupCards) {
+    const group = groupsByChatId.get(groupCard.chatId);
+    if (group) {
+      registerGroupCardRuntime(group, groupCard);
+    }
+  }
+}
+
+export function resetDynamicIntegrationRuntimeForTests() {
+  for (let index = cards.length - 1; index >= 0; index -= 1) {
+    if (dynamicCardIds.has(cards[index].id)) {
+      cards.splice(index, 1);
+    }
+  }
+  for (const clanName of dynamicClanNames) {
+    delete clans[clanName];
+  }
+  dynamicCardIds.clear();
+  dynamicClanNames.clear();
 }
 
 export function buildGroupCard(group: GroupIntegrationRecord, input: GroupCardInput): Card {

--- a/src/features/player/profile/mongo.ts
+++ b/src/features/player/profile/mongo.ts
@@ -21,12 +21,24 @@ import { computeLevelUpBonusForRange } from "./progression";
 import { SellError, type ApplyMatchRewardsInput, type ApplyMatchRewardsOutput, type PlayerAvatarStore, type PlayerDeckStore, type PlayerMatchRewardsStore, type PlayerSellStore } from "./api";
 import { getMilestonesCrossed, pickMilestoneRewards, type MilestoneCardReward } from "@/features/economy/milestones";
 import { cards as activeCards } from "@/features/battle/model/cards";
+import {
+  createGroupCardRecord,
+  createNewGroup,
+  validateGroupBonusChange,
+  type CreateGroupCardInput,
+  type CreateGroupCardResult,
+  type IntegrationStore,
+  type UpsertGroupInput,
+} from "@/features/integrations/api";
+import type { GroupCardIntegrationRecord, GroupIntegrationRecord } from "@/features/integrations/runtime";
 
 const DEFAULT_MONGODB_URI = "mongodb://127.0.0.1:27017/nexus-card-battle";
 const DEFAULT_MONGODB_DB = "nexus-card-battle";
 const DEFAULT_MONGODB_SERVER_SELECTION_TIMEOUT_MS = 1_500;
 const PLAYERS_COLLECTION = "players";
 const BOOSTER_OPENINGS_COLLECTION = "boosterOpenings";
+const GROUPS_COLLECTION = "integrationGroups";
+const GROUP_CARDS_COLLECTION = "integrationGroupCards";
 
 // Progression fields are optional so pre-existing documents read cleanly.
 // `level` is intentionally absent — it is derived from totalXp on read,
@@ -73,9 +85,15 @@ export function getMongoPlayerProfileStore() {
   return new MongoPlayerProfileStore(clientPromise, dbName);
 }
 
-export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewardsStore, PlayerAvatarStore, PlayerSellStore {
+type MongoGroupDocument = GroupIntegrationRecord;
+type MongoGroupCardDocument = GroupCardIntegrationRecord & {
+  card: CreateGroupCardInput;
+};
+
+export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewardsStore, PlayerAvatarStore, PlayerSellStore, IntegrationStore {
   private indexesReady?: Promise<void>;
   private boosterOpeningIndexesReady?: Promise<void>;
+  private integrationIndexesReady?: Promise<void>;
 
   constructor(
     private readonly clientPromise: Promise<MongoClient>,
@@ -351,6 +369,78 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
     return applySellCardsToPlayer(players, identity, cardId, count);
   }
 
+  async upsertGroup(input: UpsertGroupInput): Promise<GroupIntegrationRecord> {
+    const groups = await this.getGroupsCollection();
+    const current = await groups.findOne({ chatId: input.chatId });
+    validateGroupBonusChange(current ?? undefined, input.bonus);
+
+    const now = new Date();
+    const base = current ?? createNewGroup(input, now);
+    const next: GroupIntegrationRecord = {
+      ...base,
+      displayName: input.displayName,
+      glyphUrl: input.glyphUrl,
+      bonus: input.bonus,
+      updatedAt: now,
+    };
+
+    await groups.updateOne({ chatId: input.chatId }, { $set: next, $setOnInsert: { createdAt: next.createdAt } }, { upsert: true });
+    const stored = await groups.findOne({ chatId: input.chatId });
+    if (!stored) throw new Error("Integration group upsert did not return a group.");
+    return fromMongoGroup(stored);
+  }
+
+  async createGroupCard(input: CreateGroupCardInput): Promise<CreateGroupCardResult> {
+    const groups = await this.getGroupsCollection();
+    const groupCards = await this.getGroupCardsCollection();
+    const players = await this.getPlayersCollection();
+    const existing = await this.findGroupCardByIdempotencyKey(input.idempotencyKey);
+    if (existing) return existing;
+
+    const group = await groups.findOne({ chatId: input.chatId });
+    if (!group) {
+      throw new Error(`Integration group does not exist for chatId: ${input.chatId}`);
+    }
+
+    const now = new Date();
+    const groupCard = createGroupCardRecord(input, now);
+    const identity: PlayerIdentity = { mode: "telegram", telegramId: input.creatorTelegramId };
+    await this.findOrCreateByIdentity(identity);
+
+    try {
+      try {
+        await groupCards.insertOne({ ...groupCard, card: input });
+      } catch (error) {
+        if (isDuplicateKeyError(error)) {
+          const duplicate = await this.findGroupCardByIdempotencyKey(input.idempotencyKey);
+          if (duplicate) return duplicate;
+        }
+        throw error;
+      }
+      await groups.updateOne({ chatId: input.chatId }, { $addToSet: { cardIds: groupCard.id }, $set: { updatedAt: now } });
+      const updatedPlayer = await grantGroupCardOnce(players, identity, groupCard.id, now);
+      const updatedGroup = await groups.findOne({ chatId: input.chatId });
+      const responseGroup = updatedGroup ?? { ...group, cardIds: [...new Set([...group.cardIds, groupCard.id])], updatedAt: now };
+      return { group: fromMongoGroup(responseGroup), groupCard, cardInput: input, player: updatedPlayer, idempotent: false };
+    } catch (error) {
+      await groupCards.deleteOne({ idempotencyKey: input.idempotencyKey }).catch(() => undefined);
+      await groups.updateOne({ chatId: input.chatId }, { $pull: { cardIds: groupCard.id } }).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async findGroupCardByIdempotencyKey(idempotencyKey: string): Promise<CreateGroupCardResult | undefined> {
+    const groups = await this.getGroupsCollection();
+    const groupCards = await this.getGroupCardsCollection();
+    const existing = await groupCards.findOne({ idempotencyKey });
+    if (!existing) return undefined;
+    const group = await groups.findOne({ chatId: existing.chatId });
+    if (!group) throw new Error("Integration group card history references a missing group.");
+    const players = await this.getPlayersCollection();
+    const player = await grantGroupCardOnce(players, { mode: "telegram", telegramId: existing.creatorTelegramId }, existing.id, new Date());
+    return { group: fromMongoGroup(group), groupCard: fromMongoGroupCard(existing), cardInput: existing.card, player, idempotent: true };
+  }
+
   private async getPlayersCollection() {
     const client = await this.clientPromise;
     const collection = client.db(this.dbName).collection<MongoPlayerDocument>(PLAYERS_COLLECTION);
@@ -362,6 +452,20 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
     const client = await this.clientPromise;
     const collection = client.db(this.dbName).collection<MongoBoosterOpeningDocument>(BOOSTER_OPENINGS_COLLECTION);
     await this.ensureBoosterOpeningIndexes(collection);
+    return collection;
+  }
+
+  private async getGroupsCollection() {
+    const client = await this.clientPromise;
+    const collection = client.db(this.dbName).collection<MongoGroupDocument>(GROUPS_COLLECTION);
+    await this.ensureIntegrationIndexes();
+    return collection;
+  }
+
+  private async getGroupCardsCollection() {
+    const client = await this.clientPromise;
+    const collection = client.db(this.dbName).collection<MongoGroupCardDocument>(GROUP_CARDS_COLLECTION);
+    await this.ensureIntegrationIndexes();
     return collection;
   }
 
@@ -393,6 +497,44 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
 
     return this.boosterOpeningIndexesReady;
   }
+
+  private async ensureIntegrationIndexes() {
+    this.integrationIndexesReady ??= (async () => {
+      const client = await this.clientPromise;
+      const db = client.db(this.dbName);
+      await Promise.all([
+        db.collection<MongoGroupDocument>(GROUPS_COLLECTION).createIndex({ chatId: 1 }, { unique: true, name: "uniq_integration_group_chat" }),
+        db.collection<MongoGroupCardDocument>(GROUP_CARDS_COLLECTION).createIndex({ idempotencyKey: 1 }, { unique: true, name: "uniq_integration_group_card_idempotency" }),
+        db.collection<MongoGroupCardDocument>(GROUP_CARDS_COLLECTION).createIndex({ chatId: 1 }, { name: "idx_integration_group_cards_chat" }),
+      ]);
+    })();
+    return this.integrationIndexesReady;
+  }
+}
+
+function fromMongoGroup(group: WithId<MongoGroupDocument> | MongoGroupDocument): GroupIntegrationRecord {
+  return {
+    chatId: group.chatId,
+    clan: group.clan,
+    boosterId: group.boosterId,
+    displayName: group.displayName,
+    glyphUrl: group.glyphUrl,
+    bonus: group.bonus,
+    cardIds: Array.isArray(group.cardIds) ? group.cardIds : [],
+    createdAt: group.createdAt,
+    updatedAt: group.updatedAt,
+  };
+}
+
+function fromMongoGroupCard(card: WithId<MongoGroupCardDocument> | MongoGroupCardDocument): GroupCardIntegrationRecord {
+  return {
+    id: card.id,
+    chatId: card.chatId,
+    creatorTelegramId: card.creatorTelegramId,
+    idempotencyKey: card.idempotencyKey,
+    dropWeight: card.dropWeight,
+    createdAt: card.createdAt,
+  };
 }
 
 async function ensureBoosterOpeningIndexes(collection: Collection<MongoBoosterOpeningDocument>) {
@@ -504,6 +646,40 @@ async function applyPaidOpeningToPlayer(
   }
 
   throw new BoosterOpeningError("invalid_booster_opening", "Paid booster opening could not be saved for the current player state.", 409);
+}
+
+async function grantGroupCardOnce(
+  players: Collection<MongoPlayerDocument>,
+  identity: PlayerIdentity,
+  cardId: string,
+  now: Date,
+): Promise<StoredPlayerProfile> {
+  const updated = await players.findOneAndUpdate(
+    {
+      ...identityFilter(identity),
+      "ownedCards.cardId": { $ne: cardId },
+    },
+    [
+      {
+        $set: {
+          ownedCards: buildOwnedCardsIncrementPipeline([cardId]),
+          updatedAt: now,
+        },
+      },
+    ],
+    { returnDocument: "after" },
+  );
+
+  if (updated) {
+    return fromMongoDocument(updated);
+  }
+
+  const current = await players.findOne(identityFilter(identity));
+  if (current) {
+    return fromMongoDocument(current);
+  }
+
+  throw new Error("Player profile did not exist for group card grant.");
 }
 
 async function applySellCardsToPlayer(

--- a/src/features/player/profile/mongo.ts
+++ b/src/features/player/profile/mongo.ts
@@ -30,7 +30,7 @@ import {
   type IntegrationStore,
   type UpsertGroupInput,
 } from "@/features/integrations/api";
-import type { GroupCardIntegrationRecord, GroupIntegrationRecord } from "@/features/integrations/runtime";
+import { hydrateGroupRuntime, type GroupCardIntegrationRecord, type GroupIntegrationRecord } from "@/features/integrations/runtime";
 
 const DEFAULT_MONGODB_URI = "mongodb://127.0.0.1:27017/nexus-card-battle";
 const DEFAULT_MONGODB_DB = "nexus-card-battle";
@@ -134,6 +134,7 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
       throw new Error("MongoDB did not return a player profile.");
     }
 
+    await this.hydrateIntegrationRuntime();
     return fromMongoDocument(document);
   }
 
@@ -394,7 +395,7 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
     const groups = await this.getGroupsCollection();
     const groupCards = await this.getGroupCardsCollection();
     const players = await this.getPlayersCollection();
-    const existing = await this.findGroupCardByIdempotencyKey(input.idempotencyKey);
+    const existing = await this.findGroupCardByIdempotencyKey(input.chatId, input.idempotencyKey);
     if (existing) return existing;
 
     const group = await groups.findOne({ chatId: input.chatId });
@@ -412,7 +413,7 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
         await groupCards.insertOne({ ...groupCard, card: input });
       } catch (error) {
         if (isDuplicateKeyError(error)) {
-          const duplicate = await this.findGroupCardByIdempotencyKey(input.idempotencyKey);
+          const duplicate = await this.findGroupCardByIdempotencyKey(input.chatId, input.idempotencyKey);
           if (duplicate) return duplicate;
         }
         throw error;
@@ -423,22 +424,32 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
       const responseGroup = updatedGroup ?? { ...group, cardIds: [...new Set([...group.cardIds, groupCard.id])], updatedAt: now };
       return { group: fromMongoGroup(responseGroup), groupCard, cardInput: input, player: updatedPlayer, idempotent: false };
     } catch (error) {
-      await groupCards.deleteOne({ idempotencyKey: input.idempotencyKey }).catch(() => undefined);
+      await groupCards.deleteOne({ chatId: input.chatId, idempotencyKey: input.idempotencyKey }).catch(() => undefined);
       await groups.updateOne({ chatId: input.chatId }, { $pull: { cardIds: groupCard.id } }).catch(() => undefined);
       throw error;
     }
   }
 
-  async findGroupCardByIdempotencyKey(idempotencyKey: string): Promise<CreateGroupCardResult | undefined> {
+  async findGroupCardByIdempotencyKey(chatId: string, idempotencyKey: string): Promise<CreateGroupCardResult | undefined> {
     const groups = await this.getGroupsCollection();
     const groupCards = await this.getGroupCardsCollection();
-    const existing = await groupCards.findOne({ idempotencyKey });
+    const existing = await groupCards.findOne({ chatId, idempotencyKey });
     if (!existing) return undefined;
     const group = await groups.findOne({ chatId: existing.chatId });
     if (!group) throw new Error("Integration group card history references a missing group.");
     const players = await this.getPlayersCollection();
     const player = await grantGroupCardOnce(players, { mode: "telegram", telegramId: existing.creatorTelegramId }, existing.id, new Date());
     return { group: fromMongoGroup(group), groupCard: fromMongoGroupCard(existing), cardInput: existing.card, player, idempotent: true };
+  }
+
+  async hydrateIntegrationRuntime() {
+    const groups = await this.getGroupsCollection();
+    const groupCards = await this.getGroupCardsCollection();
+    const [storedGroups, storedGroupCards] = await Promise.all([
+      groups.find({}).toArray(),
+      groupCards.find({}).toArray(),
+    ]);
+    hydrateGroupRuntime(storedGroups.map(fromMongoGroup), storedGroupCards.map((card) => card.card));
   }
 
   private async getPlayersCollection() {
@@ -504,7 +515,11 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
       const db = client.db(this.dbName);
       await Promise.all([
         db.collection<MongoGroupDocument>(GROUPS_COLLECTION).createIndex({ chatId: 1 }, { unique: true, name: "uniq_integration_group_chat" }),
-        db.collection<MongoGroupCardDocument>(GROUP_CARDS_COLLECTION).createIndex({ idempotencyKey: 1 }, { unique: true, name: "uniq_integration_group_card_idempotency" }),
+        db.collection<MongoGroupCardDocument>(GROUP_CARDS_COLLECTION).dropIndex("uniq_integration_group_card_idempotency").catch((error) => {
+          if (error instanceof MongoServerError && error.codeName === "IndexNotFound") return undefined;
+          throw error;
+        }),
+        db.collection<MongoGroupCardDocument>(GROUP_CARDS_COLLECTION).createIndex({ chatId: 1, idempotencyKey: 1 }, { unique: true, name: "uniq_integration_group_card_chat_idempotency" }),
         db.collection<MongoGroupCardDocument>(GROUP_CARDS_COLLECTION).createIndex({ chatId: 1 }, { name: "idx_integration_group_cards_chat" }),
       ]);
     })();

--- a/tests/integrations.test.ts
+++ b/tests/integrations.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import sharp from "sharp";
-import { findCard } from "../src/features/battle/model/domain/decks";
+import { cards } from "../src/features/battle/model/cards";
+import { createBattleHand, createCardCollection, createDeck, findCard } from "../src/features/battle/model/domain/decks";
 import type { Bonus } from "../src/features/battle/model/types";
 import { handleGroupCardPost, handleGroupUpsertPut, createGroupCardRecord, createNewGroup, validateGroupBonusChange, type CreateGroupCardInput, type CreateGroupCardResult, type IntegrationStore, type UpsertGroupInput } from "../src/features/integrations/api";
-import { groupCardId } from "../src/features/integrations/runtime";
+import { groupCardId, hydrateGroupRuntime, resetDynamicIntegrationRuntimeForTests } from "../src/features/integrations/runtime";
 import { addToInventory, getOwnedCount } from "../src/features/inventory/inventoryOps";
+import { handlePlayerDeckSavePost } from "../src/features/player/profile/api";
+import { createPlayerSessionCookie } from "../src/features/player/profile/auth";
 import { createNewStoredPlayerProfile, type PlayerIdentity, type StoredPlayerProfile } from "../src/features/player/profile/types";
 
 const TOKEN = "integration-test-token";
@@ -28,9 +31,11 @@ describe("integration API", () => {
   beforeEach(() => {
     previousToken = process.env.INTEGRATION_API_TOKEN;
     process.env.INTEGRATION_API_TOKEN = TOKEN;
+    resetDynamicIntegrationRuntimeForTests();
   });
 
   afterEach(() => {
+    resetDynamicIntegrationRuntimeForTests();
     if (previousToken === undefined) {
       delete process.env.INTEGRATION_API_TOKEN;
     } else {
@@ -59,7 +64,7 @@ describe("integration API", () => {
   test("upserts a group clan and booster with Nexus-owned glyph URL", async () => {
     const store = new MemoryIntegrationStore();
     const response = await putGroup(store, "-100777", { displayName: "The Chat" });
-    const body = (await response.json()) as { group: { chatId: string; clan: string; boosterId: string; displayName: string; glyphUrl: string; bonus: Bonus } };
+    const body = (await response.json()) as { group: { chatId: string; clan: string; boosterId: string; booster: { opening: { available: boolean; reason: string } }; displayName: string; glyphUrl: string; bonus: Bonus } };
 
     expect(response.status).toBe(200);
     expect(body.group).toMatchObject({
@@ -68,6 +73,15 @@ describe("integration API", () => {
       boosterId: "group--100777",
       displayName: "The Chat",
       bonus,
+    });
+    expect(body.group.booster).toMatchObject({
+      id: "group--100777",
+      name: "The Chat",
+      clans: ["The Chat"],
+      opening: {
+        available: false,
+        reason: "group_booster_opening_out_of_scope",
+      },
     });
     expect(body.group.glyphUrl).toMatch(/^\/nexus-assets\/integrations\/100777\/glyph\.png$/);
     expect(store.groups.get("-100777")?.displayName).toBe("The Chat");
@@ -139,6 +153,86 @@ describe("integration API", () => {
     expect(getOwnedCount(secondBody.player.ownedCards, firstBody.card.id)).toBe(1);
   });
 
+  test("scopes card idempotency by group so different chats can reuse a key", async () => {
+    const store = new MemoryIntegrationStore();
+    await putGroup(store, "-100a", { displayName: "Group A" });
+    await putGroup(store, "-100b", { displayName: "Group B" });
+
+    const first = await postCard(store, { chatId: "-100a", creatorTelegramId: "101", idempotencyKey: "shared-key", name: "A Card" });
+    const second = await postCard(store, { chatId: "-100b", creatorTelegramId: "202", idempotencyKey: "shared-key", name: "B Card" });
+    const firstBody = (await first.json()) as { card: { id: string; clan: string }; player: { ownedCards: { cardId: string; count: number }[] }; idempotent: boolean };
+    const secondBody = (await second.json()) as { card: { id: string; clan: string }; player: { ownedCards: { cardId: string; count: number }[] }; idempotent: boolean };
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(firstBody.idempotent).toBe(false);
+    expect(secondBody.idempotent).toBe(false);
+    expect(firstBody.card.id).toBe(groupCardId("-100a", "shared-key"));
+    expect(secondBody.card.id).toBe(groupCardId("-100b", "shared-key"));
+    expect(firstBody.card.id).not.toBe(secondBody.card.id);
+    expect(firstBody.card.clan).toBe("Group A");
+    expect(secondBody.card.clan).toBe("Group B");
+    expect(getOwnedCount(firstBody.player.ownedCards, firstBody.card.id)).toBe(1);
+    expect(getOwnedCount(secondBody.player.ownedCards, secondBody.card.id)).toBe(1);
+  });
+
+  test("hydrates persisted dynamic cards before profile, deck, and battle lookups", async () => {
+    const store = new MemoryIntegrationStore();
+    const group = createNewGroup({
+      chatId: "-100persist",
+      displayName: "Persisted Chat",
+      glyphUrl: "/nexus-assets/integrations/100persist/glyph.png",
+      bonus,
+    });
+    const cardInput = {
+      ...cardBody({
+        chatId: "-100persist",
+        creatorTelegramId: "303",
+        idempotencyKey: "persist-card",
+        imageUrl: "https://assets.test/persist.png",
+      }),
+      artUrl: "/nexus-assets/integrations/100persist/persist-card.png",
+      dropWeight: 1,
+    } as CreateGroupCardInput;
+    const groupCard = createGroupCardRecord(cardInput);
+    group.cardIds.push(groupCard.id);
+    const identity: PlayerIdentity = { mode: "telegram", telegramId: "303" };
+    const staticDeckIds = cards.filter((card) => !card.id.startsWith("group-")).slice(0, 8).map((card) => card.id);
+    const deckIds = [...staticDeckIds, groupCard.id];
+    store.groups.set(group.chatId, group);
+    store.groupCards.set(store.groupCardKey(group.chatId, groupCard.idempotencyKey), groupCard);
+    store.groupCardInputs.set(store.groupCardKey(group.chatId, groupCard.idempotencyKey), cardInput);
+    store.players.set(store.playerKey(identity), {
+      ...createNewStoredPlayerProfile("player-persisted", identity),
+      ownedCards: deckIds.map((cardId) => ({ cardId, count: 1 })),
+      deckIds,
+    });
+
+    resetDynamicIntegrationRuntimeForTests();
+    expect(() => findCard(groupCard.id)).toThrow("Unknown card id");
+
+    await store.findOrCreateByIdentity(identity);
+    expect(findCard(groupCard.id)).toMatchObject({
+      id: groupCard.id,
+      clan: "Persisted Chat",
+      rarity: "Legend",
+    });
+
+    const collection = createCardCollection("player-persisted", deckIds);
+    const deck = createDeck("player-persisted", collection, deckIds);
+    expect(deck.cardIds).toContain(groupCard.id);
+    expect(createBattleHand({ ownerId: "player-persisted", cardIds: [groupCard.id] }).map((card) => card.id)).toEqual([groupCard.id]);
+
+    const deckSave = await handlePlayerDeckSavePost(
+      jsonRequest("http://localhost/api/player/deck", { identity, deckIds }, {
+        "Content-Type": "application/json",
+        Cookie: createPlayerSessionCookie(identity),
+      }),
+      store,
+    );
+    expect(deckSave.status).toBe(200);
+  });
+
   test("rejects invalid assets and invalid dropWeight atomically", async () => {
     const store = new MemoryIntegrationStore();
     await putGroup(store, "-100atomic", { displayName: "Atomic" });
@@ -163,6 +257,14 @@ class MemoryIntegrationStore implements IntegrationStore {
   groupCards = new Map<string, ReturnType<typeof createGroupCardRecord>>();
   players = new Map<string, StoredPlayerProfile>();
 
+  groupCardKey(chatId: string, idempotencyKey: string) {
+    return `${chatId}\u0000${idempotencyKey}`;
+  }
+
+  playerKey(identity: PlayerIdentity) {
+    return `${identity.mode}:${identity.mode === "telegram" ? identity.telegramId : identity.guestId}`;
+  }
+
   async upsertGroup(input: UpsertGroupInput) {
     const current = this.groups.get(input.chatId);
     validateGroupBonusChange(current, input.bonus);
@@ -178,15 +280,15 @@ class MemoryIntegrationStore implements IntegrationStore {
   }
 
   async createGroupCard(input: CreateGroupCardInput): Promise<CreateGroupCardResult> {
-    const existing = await this.findGroupCardByIdempotencyKey(input.idempotencyKey);
+    const existing = await this.findGroupCardByIdempotencyKey(input.chatId, input.idempotencyKey);
     if (existing) return existing;
 
     const group = this.groups.get(input.chatId);
     if (!group) throw new Error("missing group");
     const player = await this.findOrCreateByIdentity({ mode: "telegram", telegramId: input.creatorTelegramId });
     const groupCard = createGroupCardRecord(input);
-    this.groupCards.set(input.idempotencyKey, groupCard);
-    this.groupCardInputs.set(input.idempotencyKey, input);
+    this.groupCards.set(this.groupCardKey(input.chatId, input.idempotencyKey), groupCard);
+    this.groupCardInputs.set(this.groupCardKey(input.chatId, input.idempotencyKey), input);
     group.cardIds.push(groupCard.id);
     player.ownedCards = addToInventory(player.ownedCards, groupCard.id, 1);
 
@@ -195,9 +297,9 @@ class MemoryIntegrationStore implements IntegrationStore {
 
   groupCardInputs = new Map<string, CreateGroupCardInput>();
 
-  async findGroupCardByIdempotencyKey(idempotencyKey: string): Promise<CreateGroupCardResult | undefined> {
-    const existing = this.groupCards.get(idempotencyKey);
-    const cardInput = this.groupCardInputs.get(idempotencyKey);
+  async findGroupCardByIdempotencyKey(chatId: string, idempotencyKey: string): Promise<CreateGroupCardResult | undefined> {
+    const existing = this.groupCards.get(this.groupCardKey(chatId, idempotencyKey));
+    const cardInput = this.groupCardInputs.get(this.groupCardKey(chatId, idempotencyKey));
     if (!existing || !cardInput) return undefined;
     const group = this.groups.get(existing.chatId);
     if (!group) throw new Error("missing group");
@@ -211,12 +313,19 @@ class MemoryIntegrationStore implements IntegrationStore {
   }
 
   async findOrCreateByIdentity(identity: PlayerIdentity) {
-    const key = `${identity.mode}:${identity.mode === "telegram" ? identity.telegramId : identity.guestId}`;
+    hydrateGroupRuntime([...this.groups.values()], [...this.groupCardInputs.values()]);
+    const key = this.playerKey(identity);
     const existing = this.players.get(key);
     if (existing) return existing;
     const created = createNewStoredPlayerProfile(`player-${this.players.size + 1}`, identity);
     this.players.set(key, created);
     return created;
+  }
+
+  async saveDeck(identity: PlayerIdentity, deckIds: string[]) {
+    const profile = await this.findOrCreateByIdentity(identity);
+    profile.deckIds = deckIds;
+    return profile;
   }
 }
 

--- a/tests/integrations.test.ts
+++ b/tests/integrations.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import sharp from "sharp";
+import { findCard } from "../src/features/battle/model/domain/decks";
+import type { Bonus } from "../src/features/battle/model/types";
+import { handleGroupCardPost, handleGroupUpsertPut, createGroupCardRecord, createNewGroup, validateGroupBonusChange, type CreateGroupCardInput, type CreateGroupCardResult, type IntegrationStore, type UpsertGroupInput } from "../src/features/integrations/api";
+import { groupCardId } from "../src/features/integrations/runtime";
+import { addToInventory, getOwnedCount } from "../src/features/inventory/inventoryOps";
+import { createNewStoredPlayerProfile, type PlayerIdentity, type StoredPlayerProfile } from "../src/features/player/profile/types";
+
+const TOKEN = "integration-test-token";
+const bonus: Bonus = {
+  id: "plus2-power",
+  name: "+2 power",
+  description: "Power increases by 2.",
+  effects: [{ key: "add-power", amount: 2 }],
+};
+
+const ability = {
+  id: "plus1-attack",
+  name: "+1 attack",
+  description: "Attack increases by 1.",
+  effects: [{ key: "add-attack", amount: 1 }],
+};
+
+describe("integration API", () => {
+  let previousToken: string | undefined;
+
+  beforeEach(() => {
+    previousToken = process.env.INTEGRATION_API_TOKEN;
+    process.env.INTEGRATION_API_TOKEN = TOKEN;
+  });
+
+  afterEach(() => {
+    if (previousToken === undefined) {
+      delete process.env.INTEGRATION_API_TOKEN;
+    } else {
+      process.env.INTEGRATION_API_TOKEN = previousToken;
+    }
+  });
+
+  test("requires bearer auth for every integration endpoint", async () => {
+    const store = new MemoryIntegrationStore();
+    const groupResponse = await handleGroupUpsertPut(
+      jsonRequest("http://localhost/api/integrations/groups/-100", { displayName: "Group", glyphUrl: "https://assets.test/glyph.png", bonus }),
+      { params: { chatId: "-100" } },
+      store,
+      { fetcher: imageFetcher() },
+    );
+    const cardResponse = await handleGroupCardPost(
+      jsonRequest("http://localhost/api/integrations/group-cards", cardBody({ chatId: "-100" })),
+      store,
+      { fetcher: imageFetcher() },
+    );
+
+    expect(groupResponse.status).toBe(401);
+    expect(cardResponse.status).toBe(401);
+  });
+
+  test("upserts a group clan and booster with Nexus-owned glyph URL", async () => {
+    const store = new MemoryIntegrationStore();
+    const response = await putGroup(store, "-100777", { displayName: "The Chat" });
+    const body = (await response.json()) as { group: { chatId: string; clan: string; boosterId: string; displayName: string; glyphUrl: string; bonus: Bonus } };
+
+    expect(response.status).toBe(200);
+    expect(body.group).toMatchObject({
+      chatId: "-100777",
+      clan: "The Chat",
+      boosterId: "group--100777",
+      displayName: "The Chat",
+      bonus,
+    });
+    expect(body.group.glyphUrl).toMatch(/^\/nexus-assets\/integrations\/100777\/glyph\.png$/);
+    expect(store.groups.get("-100777")?.displayName).toBe("The Chat");
+  });
+
+  test("rejects bonus changes after group pool has cards but still accepts metadata updates with same bonus", async () => {
+    const store = new MemoryIntegrationStore();
+    await putGroup(store, "-100locked", { displayName: "Locked" });
+    await postCard(store, { chatId: "-100locked", idempotencyKey: "first" });
+
+    const changed = await putGroup(store, "-100locked", {
+      displayName: "Locked New",
+      bonus: { ...bonus, effects: [{ key: "add-power", amount: 3 }] },
+    });
+    const unchanged = await putGroup(store, "-100locked", { displayName: "Locked New", bonus });
+
+    expect(changed.status).toBe(409);
+    expect(((await changed.json()) as { error: string }).error).toBe("group_bonus_locked");
+    expect(unchanged.status).toBe(200);
+    expect(store.groups.get("-100locked")?.displayName).toBe("Locked New");
+  });
+
+  test("creates a Legend group card, adds it to the pool, grants one creator copy, and registers domain lookup", async () => {
+    const store = new MemoryIntegrationStore();
+    await putGroup(store, "-100cards", { displayName: "Card Chat" });
+
+    const response = await postCard(store, { chatId: "-100cards", creatorTelegramId: "4242", idempotencyKey: "unique-card" });
+    const body = (await response.json()) as { card: { id: string; rarity: string; clan: string; bonus: Bonus; artUrl: string }; player: { ownedCards: { cardId: string; count: number }[] }; group: { cardIds: string[] } };
+    const cardId = groupCardId("-100cards", "unique-card");
+
+    expect(response.status).toBe(200);
+    expect(body.card).toMatchObject({
+      id: cardId,
+      rarity: "Legend",
+      clan: "Card Chat",
+      bonus,
+    });
+    expect(body.card.artUrl).toMatch(/^\/nexus-assets\/integrations\/100cards\/unique-card\.png$/);
+    expect(body.group.cardIds).toEqual([cardId]);
+    expect(getOwnedCount(body.player.ownedCards, cardId)).toBe(1);
+    expect(findCard(cardId).id).toBe(cardId);
+  });
+
+  test("is idempotent by idempotencyKey and does not double grant", async () => {
+    const store = new MemoryIntegrationStore();
+    await putGroup(store, "-100idem", { displayName: "Idem Chat" });
+
+    const first = await postCard(store, { chatId: "-100idem", creatorTelegramId: "4242", idempotencyKey: "same" });
+    let retryFetched = false;
+    const second = await handleGroupCardPost(
+      jsonRequest("http://localhost/api/integrations/group-cards", cardBody({ chatId: "-100idem", creatorTelegramId: "4242", idempotencyKey: "same", imageUrl: "https://assets.test/missing.png" }), authHeaders()),
+      store,
+      {
+        fetcher: async () => {
+          retryFetched = true;
+          return new Response("missing", { status: 404 });
+        },
+      },
+    );
+    const firstBody = (await first.json()) as { card: { id: string }; idempotent: boolean };
+    const secondBody = (await second.json()) as { card: { id: string }; player: { ownedCards: { cardId: string; count: number }[] }; idempotent: boolean };
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(firstBody.idempotent).toBe(false);
+    expect(secondBody.idempotent).toBe(true);
+    expect(retryFetched).toBe(false);
+    expect(secondBody.card.id).toBe(firstBody.card.id);
+    expect(getOwnedCount(secondBody.player.ownedCards, firstBody.card.id)).toBe(1);
+  });
+
+  test("rejects invalid assets and invalid dropWeight atomically", async () => {
+    const store = new MemoryIntegrationStore();
+    await putGroup(store, "-100atomic", { displayName: "Atomic" });
+
+    const badImage = await handleGroupCardPost(
+      jsonRequest("http://localhost/api/integrations/group-cards", cardBody({ chatId: "-100atomic", idempotencyKey: "bad-image" }), authHeaders()),
+      store,
+      { fetcher: async () => new Response("not image") },
+    );
+    const badWeight = await postCard(store, { chatId: "-100atomic", idempotencyKey: "bad-weight", dropWeight: 0 });
+
+    expect(badImage.status).toBe(400);
+    expect(badWeight.status).toBe(400);
+    expect(store.groupCards.size).toBe(0);
+    expect(store.groups.get("-100atomic")?.cardIds).toEqual([]);
+    expect(store.players.size).toBe(0);
+  });
+});
+
+class MemoryIntegrationStore implements IntegrationStore {
+  groups = new Map<string, ReturnType<typeof createNewGroup>>();
+  groupCards = new Map<string, ReturnType<typeof createGroupCardRecord>>();
+  players = new Map<string, StoredPlayerProfile>();
+
+  async upsertGroup(input: UpsertGroupInput) {
+    const current = this.groups.get(input.chatId);
+    validateGroupBonusChange(current, input.bonus);
+    const next = {
+      ...(current ?? createNewGroup(input)),
+      displayName: input.displayName,
+      glyphUrl: input.glyphUrl,
+      bonus: input.bonus,
+      updatedAt: new Date(),
+    };
+    this.groups.set(input.chatId, next);
+    return next;
+  }
+
+  async createGroupCard(input: CreateGroupCardInput): Promise<CreateGroupCardResult> {
+    const existing = await this.findGroupCardByIdempotencyKey(input.idempotencyKey);
+    if (existing) return existing;
+
+    const group = this.groups.get(input.chatId);
+    if (!group) throw new Error("missing group");
+    const player = await this.findOrCreateByIdentity({ mode: "telegram", telegramId: input.creatorTelegramId });
+    const groupCard = createGroupCardRecord(input);
+    this.groupCards.set(input.idempotencyKey, groupCard);
+    this.groupCardInputs.set(input.idempotencyKey, input);
+    group.cardIds.push(groupCard.id);
+    player.ownedCards = addToInventory(player.ownedCards, groupCard.id, 1);
+
+    return { group, groupCard, cardInput: input, player, idempotent: false };
+  }
+
+  groupCardInputs = new Map<string, CreateGroupCardInput>();
+
+  async findGroupCardByIdempotencyKey(idempotencyKey: string): Promise<CreateGroupCardResult | undefined> {
+    const existing = this.groupCards.get(idempotencyKey);
+    const cardInput = this.groupCardInputs.get(idempotencyKey);
+    if (!existing || !cardInput) return undefined;
+    const group = this.groups.get(existing.chatId);
+    if (!group) throw new Error("missing group");
+    return {
+      group,
+      groupCard: existing,
+      cardInput,
+      player: await this.findOrCreateByIdentity({ mode: "telegram", telegramId: existing.creatorTelegramId }),
+      idempotent: true,
+    };
+  }
+
+  async findOrCreateByIdentity(identity: PlayerIdentity) {
+    const key = `${identity.mode}:${identity.mode === "telegram" ? identity.telegramId : identity.guestId}`;
+    const existing = this.players.get(key);
+    if (existing) return existing;
+    const created = createNewStoredPlayerProfile(`player-${this.players.size + 1}`, identity);
+    this.players.set(key, created);
+    return created;
+  }
+}
+
+function putGroup(store: IntegrationStore, chatId: string, overrides: Partial<{ displayName: string; bonus: Bonus }> = {}) {
+  return handleGroupUpsertPut(
+    jsonRequest(
+      `http://localhost/api/integrations/groups/${encodeURIComponent(chatId)}`,
+      {
+        displayName: overrides.displayName ?? "Test Chat",
+        glyphUrl: "https://assets.test/glyph.png",
+        bonus: overrides.bonus ?? bonus,
+      },
+      authHeaders(),
+    ),
+    { params: { chatId } },
+    store,
+    { fetcher: imageFetcher() },
+  );
+}
+
+function postCard(store: IntegrationStore, overrides: Partial<Record<string, unknown>> = {}) {
+  return handleGroupCardPost(
+    jsonRequest("http://localhost/api/integrations/group-cards", cardBody(overrides), authHeaders()),
+    store,
+    { fetcher: imageFetcher() },
+  );
+}
+
+function cardBody(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    chatId: "-100",
+    creatorTelegramId: "111",
+    idempotencyKey: "idem-1",
+    name: "Creator Card",
+    power: 7,
+    damage: 5,
+    ability,
+    imageUrl: "https://assets.test/card.png",
+    ...overrides,
+  };
+}
+
+function jsonRequest(url: string, body: unknown, headers: HeadersInit = { "Content-Type": "application/json" }) {
+  return new Request(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function authHeaders() {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${TOKEN}`,
+  };
+}
+
+function imageFetcher() {
+  return async () => {
+    const bytes = await sharp({
+      create: {
+        width: 64,
+        height: 64,
+        channels: 4,
+        background: "#ff00aa",
+      },
+    }).png().toBuffer();
+    return new Response(new Uint8Array(bytes), {
+      status: 200,
+      headers: { "Content-Type": "image/png" },
+    });
+  };
+}


### PR DESCRIPTION
## Summary
- add bearer-token protected group/clan upsert and group card ingestion endpoints
- validate/copy remote assets, persist dynamic group cards, and grant creator copies idempotently
- hydrate dynamic cards for profile/deck/battle lookup paths and include integration coverage in default tests

## Verification
- rtk bun test tests/integrations.test.ts
- rtk bun run test
- rtk env BUN_TMPDIR=/tmp bunx eslint src/features/integrations src/app/api/integrations tests/integrations.test.ts src/features/player/profile/mongo.ts
- rtk bun run build

Closes #54
Refs #53