### PR TITLE
feat(boosters): signed group booster openings

### DIFF
--- a/src/app/api/boosters/route.ts
+++ b/src/app/api/boosters/route.ts
@@ -3,8 +3,8 @@ import { getMongoPlayerProfileStore } from "@/features/player/profile/mongo";
 
 export const runtime = "nodejs";
 
-export async function GET() {
-  return handleBoosterCatalogGet();
+export async function GET(request: Request) {
+  return handleBoosterCatalogGet(request, getMongoPlayerProfileStore());
 }
 
 export async function POST(request: Request) {

--- a/src/app/api/integrations/groups/[chatId]/launch-url/route.ts
+++ b/src/app/api/integrations/groups/[chatId]/launch-url/route.ts
@@ -1,0 +1,7 @@
+import { handleGroupLaunchUrlPost } from "@/features/integrations/api";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request, context: { params: Promise<{ chatId: string }> }) {
+  return handleGroupLaunchUrlPost(request, context);
+}

--- a/src/features/boosters/api.ts
+++ b/src/features/boosters/api.ts
@@ -1,15 +1,17 @@
 import { cards as activeCards } from "@/features/battle/model/cards";
 import type { Card } from "@/features/battle/model/types";
+import { GroupContextError, verifyGroupLaunchContext } from "@/features/integrations/groupContext";
 import { PlayerAuthError, resolveAuthenticatedPlayerIdentity, type PlayerAuthResult } from "@/features/player/profile/auth";
 import { PlayerIdentityValidationError, toPlayerProfile } from "@/features/player/profile/types";
-import { getBoosterCatalogForPlayer, getBoosterCatalogResponse, validateBoosterCatalog } from "./catalog";
-import { BoosterOpeningError, preparePaidBoosterOpening, prepareStarterBoosterOpening, type RandomSource } from "./opening";
-import type { BoosterOpeningRecord, BoosterOpeningStore, StoredBoosterOpeningRecord } from "./types";
+import { boosterCatalog, getBoosterCatalogForPlayerWithBoosters, getBoosterCatalogResponse, serializeBooster, validateBoosterCatalog } from "./catalog";
+import { BoosterOpeningError, createGroupBooster, preparePaidBoosterOpening, prepareStarterBoosterOpening, type RandomSource } from "./opening";
+import type { Booster, BoosterOpeningRecord, BoosterOpeningStore, StoredBoosterOpeningRecord } from "./types";
 
-export async function handleBoosterCatalogGet() {
+export async function handleBoosterCatalogGet(request?: Request, store?: BoosterOpeningStore) {
   try {
     validateBoosterCatalog();
-    return noStoreJson({ boosters: getBoosterCatalogResponse() });
+    const groupBooster = request && store ? await resolveGroupBoosterFromRequest(request, store, { required: false }) : undefined;
+    return noStoreJson({ boosters: groupBooster ? [...getBoosterCatalogResponse(), serializeBooster(groupBooster)] : getBoosterCatalogResponse() });
   } catch (error) {
     return boosterApiErrorResponse(error);
   }
@@ -22,9 +24,11 @@ export async function handleBoosterCatalogPost(request: Request, store: BoosterO
     const auth = resolveAuthenticatedPlayerIdentity(request, body, { allowGuestCreation: true });
     const identity = auth.identity;
     const profile = toPlayerProfile(await store.findOrCreateByIdentity(identity));
+    const groupBooster = await resolveGroupBoosterFromBody(body, store, { required: false });
+    const boosters: readonly Booster[] = groupBooster ? [...boosterCatalog, groupBooster] : boosterCatalog;
 
     return noStoreJson({
-      boosters: getBoosterCatalogForPlayer(profile),
+      boosters: getBoosterCatalogForPlayerWithBoosters(profile, boosters),
       player: profile,
     }, auth);
   } catch (error) {
@@ -83,6 +87,9 @@ async function openStarterBooster(
 ) {
   const { identity } = resolveAuthenticatedPlayerIdentity(request, body);
   const boosterId = parseBoosterId(body.boosterId);
+  if (boosterId.startsWith("group-")) {
+    throw new BoosterOpeningError("group_context_required", "Group boosters cannot be opened as starter boosters.", 403);
+  }
   const profile = toPlayerProfile(await store.findOrCreateByIdentity(identity));
   const prepared = prepareStarterBoosterOpening({
     boosterId,
@@ -117,11 +124,14 @@ async function openPaidBooster(
 ) {
   const { identity } = resolveAuthenticatedPlayerIdentity(request, body);
   const boosterId = parseBoosterId(body.boosterId);
+  const groupOpening = boosterId.startsWith("group-") ? await resolveGroupOpening(body, store, boosterId) : undefined;
   const profile = toPlayerProfile(await store.findOrCreateByIdentity(identity));
   const prepared = preparePaidBoosterOpening({
     boosterId,
     player: profile,
     rng: options.rng,
+    booster: groupOpening?.booster,
+    groupCards: groupOpening?.groupCards,
   });
   const openedAt = options.now?.() ?? new Date();
   const persisted = await store.savePaidBoosterOpening({
@@ -139,6 +149,46 @@ async function openPaidBooster(
     opening: serializeOpeningRecord(persisted.opening),
     player: toPlayerProfile(persisted.player),
     crystalCost: prepared.crystalCost,
+  });
+}
+
+async function resolveGroupOpening(body: Record<string, unknown>, store: BoosterOpeningStore, boosterId: string) {
+  const groupBooster = await resolveGroupBoosterFromBody(body, store, { required: true });
+  if (!groupBooster || groupBooster.id !== boosterId || !groupBooster.group) {
+    throw new BoosterOpeningError("group_context_required", "Valid signed group context is required for this booster.", 403);
+  }
+  const groupCards = await store.findIntegrationGroupCardsByChatId?.(groupBooster.group.chatId);
+  if (!groupCards) {
+    throw new BoosterOpeningError("group_booster_unavailable", "Group booster is unavailable.", 404);
+  }
+  return { booster: groupBooster, groupCards };
+}
+
+async function resolveGroupBoosterFromRequest(request: Request, store: BoosterOpeningStore, options: { required: boolean }) {
+  const context = new URL(request.url).searchParams.get("groupContext");
+  return resolveGroupBooster(context, store, options);
+}
+
+async function resolveGroupBoosterFromBody(body: Record<string, unknown>, store: BoosterOpeningStore, options: { required: boolean }) {
+  return resolveGroupBooster(body.groupContext, store, options);
+}
+
+async function resolveGroupBooster(value: unknown, store: BoosterOpeningStore, options: { required: boolean }) {
+  if (value === undefined || value === null || value === "") {
+    if (!options.required) return undefined;
+    throw new BoosterOpeningError("group_context_required", "Valid signed group context is required for group boosters.", 403);
+  }
+  const context = verifyGroupLaunchContext(value);
+  const group = await store.findIntegrationGroupByChatId?.(context.chatId);
+  if (!group) {
+    throw new BoosterOpeningError("group_booster_unavailable", "Group booster is unavailable.", 404);
+  }
+  return createGroupBooster({
+    chatId: group.chatId,
+    boosterId: group.boosterId,
+    name: group.displayName,
+    clan: group.clan,
+    cardCount: group.cardIds.length,
   });
 }
 
@@ -218,6 +268,16 @@ function boosterApiErrorResponse(error: unknown) {
         message: error.message,
       },
       { status: 400 },
+    );
+  }
+
+  if (error instanceof GroupContextError) {
+    return noStoreJson(
+      {
+        error: error.code,
+        message: error.message,
+      },
+      { status: error.status },
     );
   }
 

--- a/src/features/boosters/catalog.ts
+++ b/src/features/boosters/catalog.ts
@@ -2,6 +2,8 @@ import { clans } from "@/features/battle/model/clans";
 import { PAID_BOOSTER_CRYSTAL_COST, type Booster, type BoosterCatalogItem, type BoosterResponse, type PlayerBoosterCatalogProfile } from "./types";
 
 export const boosterCatalog = [
+  // Solo-clan VibeCoders pack: 4 random Legends from the fan clan.
+  { id: "vibe-drop", name: "Vibe Drop", clans: ["VibeCoders"], cardCount: 4, requiredRarities: ["Legend"], presentation: "special" },
   { id: "neon-breach", name: "Neon Breach", clans: ["[Da:Hack]", "Aliens"] },
   { id: "factory-shift", name: "Factory Shift", clans: ["Workers", "Micron"] },
   { id: "street-kings", name: "Street Kings", clans: ["Street", "Kingpin"] },
@@ -14,8 +16,6 @@ export const boosterCatalog = [
   { id: "metro-chase", name: "Metro Chase", clans: ["Metropolis", "Chasers"] },
   { id: "desert-signal", name: "Desert Signal", clans: ["Халифат", "Nemos"] },
   { id: "street-plague", name: "Street Plague", clans: ["Street", "Damned"] },
-  // Solo-clan VibeCoders pack: 4 random Legends from the new fan clan.
-  { id: "vibe-drop", name: "Vibe Drop", clans: ["VibeCoders"], cardCount: 4, requiredRarities: ["Legend"] },
 ] as const satisfies readonly Booster[];
 
 export function getBoosterById(boosterId: string): Booster | undefined {
@@ -28,6 +28,8 @@ export function serializeBooster(booster: Booster): BoosterResponse {
     name: booster.name,
     clans: [...booster.clans],
     cardCount: booster.cardCount,
+    presentation: booster.presentation,
+    groupChatId: booster.group?.chatId,
   };
 }
 
@@ -36,11 +38,16 @@ export function getBoosterCatalogResponse() {
 }
 
 export function getBoosterCatalogForPlayer(profile: PlayerBoosterCatalogProfile): BoosterCatalogItem[] {
+  return getBoosterCatalogForPlayerWithBoosters(profile, boosterCatalog);
+}
+
+export function getBoosterCatalogForPlayerWithBoosters(profile: PlayerBoosterCatalogProfile, boosters: readonly Booster[]): BoosterCatalogItem[] {
   const openedBoosterIds = new Set(profile.openedBoosterIds);
 
-  return boosterCatalog.map((booster) => {
+  return boosters.map((booster) => {
     const opened = openedBoosterIds.has(booster.id);
-    const canOpen = profile.starterFreeBoostersRemaining > 0 && !opened;
+    const starterEligible = !booster.group && (booster.cardCount ?? 5) >= 4;
+    const canOpen = starterEligible && profile.starterFreeBoostersRemaining > 0 && !opened;
     const canOpenPaid = profile.crystals >= PAID_BOOSTER_CRYSTAL_COST;
 
     return {

--- a/src/features/boosters/client.ts
+++ b/src/features/boosters/client.ts
@@ -19,8 +19,9 @@ export type OpenStarterBoosterResponse = {
   crystalCost?: number;
 };
 
-export async function fetchBoosterCatalog(): Promise<BoosterCatalogResponse> {
-  const response = await fetch("/api/boosters", {
+export async function fetchBoosterCatalog(groupContext?: string | null): Promise<BoosterCatalogResponse> {
+  const query = groupContext ? `?groupContext=${encodeURIComponent(groupContext)}` : "";
+  const response = await fetch(`/api/boosters${query}`, {
     method: "GET",
   });
   const body = (await response.json().catch(() => undefined)) as Partial<BoosterCatalogResponse> & {
@@ -40,13 +41,13 @@ export async function fetchBoosterCatalog(): Promise<BoosterCatalogResponse> {
   };
 }
 
-export async function fetchStarterBoosterCatalog(identity: PlayerIdentity): Promise<StarterBoosterCatalogResponse> {
+export async function fetchStarterBoosterCatalog(identity: PlayerIdentity, groupContext?: string | null): Promise<StarterBoosterCatalogResponse> {
   const response = await fetch("/api/boosters", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ identity }),
+    body: JSON.stringify({ identity, ...(groupContext ? { groupContext } : {}) }),
   });
   const body = (await response.json().catch(() => undefined)) as Partial<StarterBoosterCatalogResponse> & {
     message?: string;
@@ -94,13 +95,13 @@ export async function openStarterBooster(identity: PlayerIdentity, boosterId: st
   };
 }
 
-export async function openPaidBooster(identity: PlayerIdentity, boosterId: string): Promise<OpenStarterBoosterResponse> {
+export async function openPaidBooster(identity: PlayerIdentity, boosterId: string, groupContext?: string | null): Promise<OpenStarterBoosterResponse> {
   const response = await fetch("/api/player/open-booster", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ identity, boosterId, source: "paid_crystals" }),
+    body: JSON.stringify({ identity, boosterId, source: "paid_crystals", ...(groupContext ? { groupContext } : {}) }),
   });
   const body = (await response.json().catch(() => undefined)) as Partial<OpenStarterBoosterResponse> & {
     message?: string;

--- a/src/features/boosters/opening.ts
+++ b/src/features/boosters/opening.ts
@@ -1,5 +1,6 @@
 import { cards as activeCards } from "@/features/battle/model/cards";
 import type { Card, Rarity } from "@/features/battle/model/types";
+import type { GroupCardIntegrationRecord } from "@/features/integrations/runtime";
 import type { PlayerProfile } from "@/features/player/profile/types";
 import { getBoosterById, serializeBooster } from "./catalog";
 import { PAID_BOOSTER_CRYSTAL_COST, STARTER_BOOSTER_CARD_COUNT, type Booster, type PreparedPaidBoosterOpening, type PreparedStarterBoosterOpening } from "./types";
@@ -25,6 +26,8 @@ export class BoosterOpeningError extends Error {
       | "insufficient_crystals"
       | "booster_required_rarity_unavailable"
       | "booster_pool_exhausted"
+      | "group_context_required"
+      | "group_booster_unavailable"
       | "invalid_booster_opening",
     message: string,
     readonly status = 400,
@@ -75,8 +78,10 @@ export function preparePaidBoosterOpening(input: {
   player: Pick<PlayerProfile, "crystals">;
   rng?: RandomSource;
   cardPool?: readonly Card[];
+  booster?: Booster;
+  groupCards?: readonly Pick<GroupCardIntegrationRecord, "id" | "dropWeight">[];
 }): PreparedPaidBoosterOpening {
-  const booster = getBoosterById(input.boosterId);
+  const booster = input.booster ?? getBoosterById(input.boosterId);
 
   if (!booster) {
     throw new BoosterOpeningError("invalid_booster_id", "Booster does not exist.", 404);
@@ -86,13 +91,14 @@ export function preparePaidBoosterOpening(input: {
     throw new BoosterOpeningError("insufficient_crystals", "Not enough crystals to open this booster.", 409);
   }
 
-  const requiredRarities = booster.requiredRarities ?? REQUIRED_PAID_RARITIES;
-  const openedCards = prepareBoosterOpeningCards({
-    booster,
-    requiredRarities,
-    rng: input.rng,
-    cardPool: input.cardPool,
-  });
+  const openedCards = booster.group
+    ? prepareGroupBoosterOpeningCards({ booster, rng: input.rng, cardPool: input.cardPool, groupCards: input.groupCards ?? [] })
+    : prepareBoosterOpeningCards({
+        booster,
+        requiredRarities: booster.requiredRarities ?? REQUIRED_PAID_RARITIES,
+        rng: input.rng,
+        cardPool: input.cardPool,
+      });
 
   return {
     booster: serializeBooster(booster),
@@ -100,6 +106,19 @@ export function preparePaidBoosterOpening(input: {
     cardIds: openedCards.map((card) => card.id),
     source: "paid_crystals",
     crystalCost: PAID_BOOSTER_CRYSTAL_COST,
+  };
+}
+
+export function createGroupBooster(input: { chatId: string; boosterId: string; name: string; clan: string; cardCount: number }): Booster {
+  return {
+    id: input.boosterId,
+    name: input.name,
+    clans: [input.clan],
+    cardCount: Math.min(4, input.cardCount),
+    presentation: "group",
+    group: {
+      chatId: input.chatId,
+    },
   };
 }
 
@@ -193,6 +212,50 @@ function pickRandomCard(cards: readonly Card[], rng: RandomSource) {
   return cards[index];
 }
 
+function prepareGroupBoosterOpeningCards(input: {
+  booster: Booster;
+  rng?: RandomSource;
+  cardPool?: readonly Card[];
+  groupCards: readonly Pick<GroupCardIntegrationRecord, "id" | "dropWeight">[];
+}) {
+  const rng = input.rng ?? Math.random;
+  const cardPool = input.cardPool ?? activeCards;
+  const cardsById = new Map(cardPool.map((card) => [card.id, card]));
+  const weightedPool = input.groupCards
+    .filter((entry) => entry.dropWeight > 0)
+    .map((entry) => ({ card: cardsById.get(entry.id), weight: entry.dropWeight }))
+    .filter((entry): entry is { card: Card; weight: number } => Boolean(entry.card) && Number.isFinite(entry.weight) && entry.weight > 0);
+
+  if (weightedPool.length === 0) {
+    throw new BoosterOpeningError("group_booster_unavailable", "Group booster has no cards.", 409);
+  }
+
+  if (weightedPool.length <= 3) {
+    return weightedPool.map((entry) => entry.card);
+  }
+
+  const remaining = [...weightedPool];
+  const openedCards: Card[] = [];
+  while (openedCards.length < 4 && remaining.length > 0) {
+    const index = pickWeightedIndex(remaining, rng);
+    openedCards.push(remaining[index].card);
+    remaining.splice(index, 1);
+  }
+  validateOpeningCards(openedCards, input.booster, cardPool, { expectedCount: openedCards.length, requiredRarities: [] });
+  return openedCards;
+}
+
+function pickWeightedIndex(items: readonly { weight: number }[], rng: RandomSource) {
+  const total = items.reduce((sum, item) => sum + item.weight, 0);
+  const roll = normalizeRandom(rng()) * total;
+  let cumulative = 0;
+  for (let index = 0; index < items.length; index += 1) {
+    cumulative += items[index].weight;
+    if (roll < cumulative) return index;
+  }
+  return items.length - 1;
+}
+
 function normalizeRandom(value: number) {
   if (!Number.isFinite(value)) return 0;
   if (value <= 0) return 0;
@@ -204,9 +267,9 @@ function validateOpeningCards(
   openedCards: readonly Card[],
   booster: Booster,
   cardPool: readonly Card[],
-  options: { requiredRarities: readonly Rarity[] },
+  options: { requiredRarities: readonly Rarity[]; expectedCount?: number },
 ) {
-  const expectedCount = booster.cardCount ?? STARTER_BOOSTER_CARD_COUNT;
+  const expectedCount = options.expectedCount ?? booster.cardCount ?? STARTER_BOOSTER_CARD_COUNT;
   if (openedCards.length !== expectedCount) {
     throw new BoosterOpeningError("invalid_booster_opening", `Booster opening must contain ${expectedCount} cards.`, 500);
   }

--- a/src/features/boosters/types.ts
+++ b/src/features/boosters/types.ts
@@ -11,17 +11,25 @@ export type Booster = {
   id: string;
   name: string;
   clans: readonly string[];
+  presentation?: BoosterPresentation;
+  group?: {
+    chatId: string;
+  };
   // Optional per-booster overrides — fall back to the global defaults when
   // omitted. Allows weird shapes like a 4-Legend solo-clan starter pack.
   cardCount?: number;
   requiredRarities?: readonly Rarity[];
 };
 
+export type BoosterPresentation = "special" | "group";
+
 export type BoosterResponse = {
   id: string;
   name: string;
   clans: string[];
   cardCount?: number;
+  presentation?: BoosterPresentation;
+  groupChatId?: string;
 };
 
 export type BoosterCatalogItem = BoosterResponse & {
@@ -98,6 +106,18 @@ export type BoosterOpeningStore = {
   findOrCreateByIdentity(identity: StoredPlayerProfile["identity"]): Promise<StoredPlayerProfile>;
   saveStarterBoosterOpening(input: PersistStarterBoosterOpeningInput): Promise<PersistedStarterBoosterOpening>;
   savePaidBoosterOpening(input: PersistPaidBoosterOpeningInput): Promise<PersistedPaidBoosterOpening>;
+  findIntegrationGroupByChatId?(chatId: string): Promise<{
+    chatId: string;
+    clan: string;
+    boosterId: string;
+    displayName: string;
+    cardIds: string[];
+  } | undefined>;
+  findIntegrationGroupCardsByChatId?(chatId: string): Promise<readonly {
+    id: string;
+    chatId: string;
+    dropWeight: number;
+  }[]>;
 };
 
 export type PlayerBoosterCatalogProfile = Pick<PlayerProfile, "openedBoosterIds" | "starterFreeBoostersRemaining" | "crystals">;

--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -16,7 +16,7 @@ import { TopBar } from "@/shared/ui/v2/TopBar";
 import type { TelegramPlayer } from "@/shared/lib/telegram";
 import { PLAYER_DECK_SIZE } from "../model/deckConfig";
 import { clearBattleSession, hasBattleSession } from "@/features/battle/persistence";
-import { useUrlEnum } from "./useUrlState";
+import { useUrlEnum, useUrlState } from "./useUrlState";
 
 type BattleMode = "ai" | "human";
 type ProfileStatus = "loading" | "ready" | "unavailable";
@@ -74,6 +74,7 @@ type TelegramWebApp = NonNullable<NonNullable<TelegramWindow["Telegram"]>["WebAp
 export function GameRoot() {
   const allCardIds = useMemo(() => Array.from(cardIds), []);
   const [screen, setScreen] = useUrlEnum<"collection" | "battle">("screen", ["collection", "battle"], "collection", "push");
+  const [groupContext] = useUrlState<string | null>("groupContext", null);
   const [battleMode, setBattleMode] = useState<BattleMode>("human");
   const [deckIds, setDeckIds] = useState<string[]>([]);
   const [playerProfile, setPlayerProfile] = useState<PlayerProfile | null>(null);
@@ -357,6 +358,7 @@ export function GameRoot() {
         canPlay={hudCanPlay}
         onPlay={handlePlayFromHud}
         onPlayerUpdated={handleStarterProfileChange}
+        groupContext={groupContext}
       >
         <StarterBoosterOnboarding
           identity={playerIdentity}
@@ -381,6 +383,7 @@ export function GameRoot() {
       canPlay={hudCanPlay}
       onPlay={handlePlayFromHud}
       onPlayerUpdated={setPlayerProfile}
+      groupContext={groupContext}
     >
       <CollectionDeckScreen
         collectionIds={ownedCardIds}
@@ -411,6 +414,7 @@ function HudShell({
   canPlay,
   onPlay,
   onPlayerUpdated,
+  groupContext,
   children,
 }: {
   profile: PlayerProfile | null;
@@ -420,6 +424,7 @@ function HudShell({
   canPlay: boolean;
   onPlay: () => void;
   onPlayerUpdated?: (profile: PlayerProfile) => void;
+  groupContext?: string | null;
   children: React.ReactNode;
 }) {
   const router = useRouter();
@@ -464,6 +469,7 @@ function HudShell({
           profileCrystals={profile.crystals}
           onProfileChange={onPlayerUpdated}
           onCrystalsUpdated={(next) => onPlayerUpdated?.({ ...profile, crystals: next })}
+          groupContext={groupContext}
         />
       )}
       {profileOpen && (

--- a/src/features/game/ui/v2/collection/BoosterShopModal.tsx
+++ b/src/features/game/ui/v2/collection/BoosterShopModal.tsx
@@ -25,6 +25,7 @@ export type BoosterShopModalProps = {
    * callbacks because it carries fresh ownedCards / openedBoosterIds too.
    */
   onProfileChange?: (profile: PlayerProfile) => void;
+  groupContext?: string | null;
 };
 
 type ShopStatus =
@@ -46,21 +47,23 @@ export function BoosterShopModal({
   onCrystalsUpdated,
   onCardsObtained,
   onProfileChange,
+  groupContext,
 }: BoosterShopModalProps) {
   const isMobile = useIsMobile();
   const [boosters, setBoosters] = useState<BoosterResponse[] | null>(null);
   const [status, setStatus] = useState<ShopStatus>({ kind: "idle" });
   const [reveal, setReveal] = useState<RevealState | null>(null);
-  const fetchedRef = useRef(false);
+  const fetchedKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
-    if (fetchedRef.current) return;
-    fetchedRef.current = true;
+    const fetchKey = groupContext ?? "";
+    if (fetchedKeyRef.current === fetchKey) return;
+    fetchedKeyRef.current = fetchKey;
 
     let cancelled = false;
     setStatus({ kind: "loading" });
-    void fetchBoosterCatalog()
+    void fetchBoosterCatalog(groupContext)
       .then((response) => {
         if (cancelled) return;
         setBoosters(response.boosters);
@@ -75,14 +78,7 @@ export function BoosterShopModal({
     return () => {
       cancelled = true;
     };
-  }, [open]);
-
-  useEffect(() => {
-    if (open) return;
-    // Reset on close so reopening starts fresh (loading shows briefly again).
-    setReveal(null);
-    setStatus({ kind: "idle" });
-  }, [open]);
+  }, [groupContext, open]);
 
   const handleOpenBooster = useCallback(
     (boosterId: string) => {
@@ -91,7 +87,7 @@ export function BoosterShopModal({
       if (profileCrystals < PAID_BOOSTER_CRYSTAL_COST) return;
 
       setStatus({ kind: "opening", boosterId });
-      void openPaidBooster(playerIdentity, boosterId)
+      void openPaidBooster(playerIdentity, boosterId, groupContext)
         .then((response) => {
           setReveal({ booster: response.booster, cards: response.cards });
           setStatus({ kind: "idle" });
@@ -115,6 +111,7 @@ export function BoosterShopModal({
       onCardsObtained,
       onCrystalsUpdated,
       onProfileChange,
+      groupContext,
       playerIdentity,
       profileCrystals,
       status.kind,
@@ -241,16 +238,23 @@ function BoosterRow({
   insufficient: boolean;
   onOpen: () => void;
 }) {
+  const special = booster.presentation === "special" || booster.presentation === "group";
   return (
     <article
       data-testid={`booster-shop-item-${booster.id}`}
-      className="flex items-center gap-3 rounded-md border border-accent-quiet bg-surface px-3 py-3"
+      data-presentation={booster.presentation}
+      className={cn(
+        "flex items-center gap-3 rounded-md border px-3 py-3",
+        special
+          ? "border-accent/80 bg-[linear-gradient(135deg,rgba(240,196,49,0.18),rgba(70,210,255,0.12)),var(--color-surface)] shadow-[0_0_24px_rgba(240,196,49,0.16)]"
+          : "border-accent-quiet bg-surface",
+      )}
     >
       <div className="min-w-0 flex-1">
-        <strong className="block truncate text-[14px] text-ink uppercase tracking-[0.06em]">
+        <strong className={cn("block truncate text-[14px] uppercase tracking-[0.06em]", special ? "text-accent" : "text-ink")}>
           {booster.name}
         </strong>
-        <span className="mt-0.5 block truncate text-[11px] text-cool uppercase tracking-[0.16em]">
+        <span className={cn("mt-0.5 block truncate text-[11px] uppercase tracking-[0.16em]", special ? "text-cool" : "text-cool")}>
           {booster.clans.join(" · ")}
         </span>
       </div>

--- a/src/features/game/ui/v2/collection/BoosterShopModal.tsx
+++ b/src/features/game/ui/v2/collection/BoosterShopModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Card } from "@/features/battle/model/types";
 import { BattleCard } from "@/features/battle/ui/components/BattleCard";
 import { fetchBoosterCatalog, openPaidBooster } from "@/features/boosters/client";
@@ -53,15 +53,13 @@ export function BoosterShopModal({
   const [boosters, setBoosters] = useState<BoosterResponse[] | null>(null);
   const [status, setStatus] = useState<ShopStatus>({ kind: "idle" });
   const [reveal, setReveal] = useState<RevealState | null>(null);
-  const fetchedKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
-    const fetchKey = groupContext ?? "";
-    if (fetchedKeyRef.current === fetchKey) return;
-    fetchedKeyRef.current = fetchKey;
 
     let cancelled = false;
+    setBoosters(null);
+    setReveal(null);
     setStatus({ kind: "loading" });
     void fetchBoosterCatalog(groupContext)
       .then((response) => {
@@ -72,6 +70,8 @@ export function BoosterShopModal({
       .catch((error: unknown) => {
         if (cancelled) return;
         const message = error instanceof Error ? error.message : "Не вдалося завантажити бустери";
+        setBoosters(null);
+        setReveal(null);
         setStatus({ kind: "error", message });
       });
 
@@ -161,7 +161,7 @@ export function BoosterShopModal({
         </div>
 
         <div className="flex-1 overflow-y-auto px-5 sm:px-6 py-4 flex flex-col gap-4">
-          {reveal && (
+          {status.kind !== "error" && reveal && (
             <RevealPanel reveal={reveal} onDismiss={() => setReveal(null)} />
           )}
 
@@ -185,13 +185,13 @@ export function BoosterShopModal({
             </div>
           )}
 
-          {!loading && boosters && boosters.length === 0 && (
+          {status.kind !== "error" && !loading && boosters && boosters.length === 0 && (
             <p className="text-[12px] text-ink-mute uppercase tracking-[0.16em]">
               Бустери недоступні
             </p>
           )}
 
-          {!loading && boosters && boosters.length > 0 && (
+          {status.kind !== "error" && !loading && boosters && boosters.length > 0 && (
             <ul
               data-testid="booster-shop-list"
               className="grid grid-cols-1 sm:grid-cols-2 gap-3"

--- a/src/features/integrations/api.ts
+++ b/src/features/integrations/api.ts
@@ -11,6 +11,7 @@ import {
   type GroupCardIntegrationRecord,
   type GroupIntegrationRecord,
 } from "./runtime";
+import { GroupContextError, signGroupLaunchContext } from "./groupContext";
 
 export type IntegrationStore = {
   upsertGroup(input: UpsertGroupInput): Promise<GroupIntegrationRecord>;
@@ -135,6 +136,26 @@ export async function handleGroupCardPost(request: Request, store: IntegrationSt
   }
 }
 
+export async function handleGroupLaunchUrlPost(
+  request: Request,
+  context: { params: Promise<{ chatId: string }> | { chatId: string } },
+  options: { now?: Date; ttlSeconds?: number } = {},
+) {
+  try {
+    requireIntegrationAuth(request);
+    const { chatId: rawChatId } = await context.params;
+    const chatId = parseId(rawChatId, "chatId");
+    const body = await readOptionalJsonObject(request);
+    const baseUrl = parseOptionalUrlString(body?.baseUrl, "baseUrl") ?? getDefaultWebAppUrl(request);
+    const url = new URL(baseUrl);
+    url.searchParams.set("groupContext", signGroupLaunchContext({ chatId, now: options.now, ttlSeconds: options.ttlSeconds }));
+
+    return json({ url: url.toString(), expiresInSeconds: options.ttlSeconds ?? 10 * 60 });
+  } catch (error) {
+    return integrationErrorResponse(error);
+  }
+}
+
 export async function serializeCreatorProfile(store: Pick<IntegrationStore, "findOrCreateByIdentity">, telegramId: string): Promise<PlayerProfile> {
   return toPlayerProfile(await store.findOrCreateByIdentity({ mode: "telegram", telegramId }));
 }
@@ -171,7 +192,7 @@ export function createGroupCardRecord(input: CreateGroupCardInput, now = new Dat
   };
 }
 
-function requireIntegrationAuth(request: Request) {
+export function requireIntegrationAuth(request: Request) {
   const expected = process.env.INTEGRATION_API_TOKEN;
   if (!expected) {
     throw new IntegrationValidationError("integration_auth_unconfigured", "Integration API token is not configured.", 500);
@@ -182,6 +203,21 @@ function requireIntegrationAuth(request: Request) {
   if (!header.startsWith(prefix) || header.slice(prefix.length) !== expected) {
     throw new IntegrationValidationError("unauthorized", "Missing or invalid integration bearer token.", 401);
   }
+}
+
+async function readOptionalJsonObject(request: Request) {
+  const text = await request.text();
+  if (!text.trim()) return undefined;
+  let body: unknown;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new IntegrationValidationError("invalid_request", "request body must be valid JSON.", 400);
+  }
+  if (!isRecord(body)) {
+    throw new IntegrationValidationError("invalid_request", "request body must be an object.", 400);
+  }
+  return body;
 }
 
 function parseBonus(value: unknown): Bonus {
@@ -290,6 +326,18 @@ function parseUrlString(value: unknown, field: string) {
   return url;
 }
 
+function parseOptionalUrlString(value: unknown, field: string) {
+  if (value === undefined) return undefined;
+  return parseUrlString(value, field);
+}
+
+function getDefaultWebAppUrl(request: Request) {
+  const configured = process.env.NEXT_PUBLIC_WEBAPP_URL || process.env.WEBAPP_URL || process.env.APP_URL;
+  if (configured) return configured;
+  const url = new URL(request.url);
+  return `${url.origin}/`;
+}
+
 function serializeGroup(group: GroupIntegrationRecord) {
   return {
     chatId: group.chatId,
@@ -318,6 +366,9 @@ function integrationErrorResponse(error: unknown) {
   }
   if (error instanceof IntegrationAssetError) {
     return json({ error: "invalid_asset", message: error.message }, 400);
+  }
+  if (error instanceof GroupContextError) {
+    return json({ error: error.code, message: error.message }, error.status);
   }
   if (error instanceof SyntaxError) {
     return json({ error: "invalid_request", message: error.message }, 400);

--- a/src/features/integrations/groupContext.ts
+++ b/src/features/integrations/groupContext.ts
@@ -1,0 +1,89 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+export type GroupLaunchContext = {
+  chatId: string;
+  expiresAt: number;
+};
+
+export class GroupContextError extends Error {
+  constructor(
+    readonly code: "group_context_missing" | "group_context_invalid" | "group_context_expired" | "group_context_unconfigured",
+    message: string,
+    readonly status = 403,
+  ) {
+    super(message);
+    this.name = "GroupContextError";
+  }
+}
+
+export function signGroupLaunchContext(input: { chatId: string; now?: Date; ttlSeconds?: number }) {
+  const now = input.now ?? new Date();
+  const ttlSeconds = input.ttlSeconds ?? 10 * 60;
+  const payload: GroupLaunchContext = {
+    chatId: input.chatId,
+    expiresAt: Math.floor(now.getTime() / 1000) + ttlSeconds,
+  };
+  const encodedPayload = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  const signature = signPayload(encodedPayload);
+  return `${encodedPayload}.${signature}`;
+}
+
+export function verifyGroupLaunchContext(value: unknown, options: { now?: Date } = {}): GroupLaunchContext {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new GroupContextError("group_context_missing", "Signed group context is required.");
+  }
+
+  const [encodedPayload, signature, extra] = value.split(".");
+  if (!encodedPayload || !signature || extra !== undefined) {
+    throw new GroupContextError("group_context_invalid", "Signed group context is invalid.");
+  }
+
+  const expectedSignature = signPayload(encodedPayload);
+  if (!safeEqual(signature, expectedSignature)) {
+    throw new GroupContextError("group_context_invalid", "Signed group context is invalid.");
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8"));
+  } catch {
+    throw new GroupContextError("group_context_invalid", "Signed group context is invalid.");
+  }
+
+  if (!isRecord(payload) || typeof payload.chatId !== "string" || typeof payload.expiresAt !== "number") {
+    throw new GroupContextError("group_context_invalid", "Signed group context is invalid.");
+  }
+
+  const nowSeconds = Math.floor((options.now ?? new Date()).getTime() / 1000);
+  if (!Number.isFinite(payload.expiresAt) || payload.expiresAt <= nowSeconds) {
+    throw new GroupContextError("group_context_expired", "Signed group context has expired.");
+  }
+
+  return {
+    chatId: payload.chatId,
+    expiresAt: payload.expiresAt,
+  };
+}
+
+function signPayload(encodedPayload: string) {
+  return createHmac("sha256", getGroupContextSecret()).update(encodedPayload).digest("base64url");
+}
+
+function getGroupContextSecret() {
+  const secret = process.env.GROUP_CONTEXT_SIGNING_SECRET || process.env.INTEGRATION_API_TOKEN;
+  if (!secret) {
+    throw new GroupContextError("group_context_unconfigured", "Group context signing secret is not configured.", 500);
+  }
+  return secret;
+}
+
+function safeEqual(a: string, b: string) {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/features/player/profile/mongo.ts
+++ b/src/features/player/profile/mongo.ts
@@ -442,6 +442,18 @@ export class MongoPlayerProfileStore implements PlayerDeckStore, PlayerMatchRewa
     return { group: fromMongoGroup(group), groupCard: fromMongoGroupCard(existing), cardInput: existing.card, player, idempotent: true };
   }
 
+  async findIntegrationGroupByChatId(chatId: string): Promise<GroupIntegrationRecord | undefined> {
+    const groups = await this.getGroupsCollection();
+    const group = await groups.findOne({ chatId });
+    return group ? fromMongoGroup(group) : undefined;
+  }
+
+  async findIntegrationGroupCardsByChatId(chatId: string): Promise<GroupCardIntegrationRecord[]> {
+    const groupCards = await this.getGroupCardsCollection();
+    const cards = await groupCards.find({ chatId }).toArray();
+    return cards.map(fromMongoGroupCard);
+  }
+
   async hydrateIntegrationRuntime() {
     const groups = await this.getGroupsCollection();
     const groupCards = await this.getGroupCardsCollection();

--- a/tests/boosterOpening.test.ts
+++ b/tests/boosterOpening.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { cards } from "../src/features/battle/model/cards";
 import type { Card, Rarity } from "../src/features/battle/model/types";
 import { handleBoosterCatalogGet, handleBoosterCatalogPost, handleBoosterOpenPost, handleStarterBoosterOpenPost } from "../src/features/boosters/api";
@@ -6,6 +6,8 @@ import { getBoosterById } from "../src/features/boosters/catalog";
 import { BoosterOpeningError, chooseStarterWeightedRarity, prepareStarterBoosterOpening, type RandomSource } from "../src/features/boosters/opening";
 import type { BoosterCatalogItem, BoosterOpeningRecord, BoosterOpeningStore, StoredBoosterOpeningRecord } from "../src/features/boosters/types";
 import { addToInventory, getOwnedCount } from "../src/features/inventory/inventoryOps";
+import { signGroupLaunchContext } from "../src/features/integrations/groupContext";
+import { groupBoosterId, groupCardId, hydrateGroupRuntime, resetDynamicIntegrationRuntimeForTests, type GroupCardIntegrationRecord, type GroupIntegrationRecord } from "../src/features/integrations/runtime";
 import { createPlayerSessionCookie } from "../src/features/player/profile/auth";
 import { createNewStoredPlayerProfile, isSamePlayerIdentity, type PlayerIdentity, type PlayerProfile, type StoredPlayerProfile } from "../src/features/player/profile/types";
 
@@ -13,6 +15,19 @@ const guestIdentity: PlayerIdentity = {
   mode: "guest",
   guestId: "booster-guest",
 };
+const GROUP_CONTEXT_SECRET = "group-context-test-secret";
+
+let previousGroupContextSecret: string | undefined;
+beforeEach(() => {
+  previousGroupContextSecret = process.env.GROUP_CONTEXT_SIGNING_SECRET;
+  process.env.GROUP_CONTEXT_SIGNING_SECRET = GROUP_CONTEXT_SECRET;
+});
+
+afterEach(() => {
+  resetDynamicIntegrationRuntimeForTests();
+  if (previousGroupContextSecret === undefined) delete process.env.GROUP_CONTEXT_SIGNING_SECRET;
+  else process.env.GROUP_CONTEXT_SIGNING_SECRET = previousGroupContextSecret;
+});
 
 describe("booster catalog", () => {
   test("returns thirteen curated boosters without C.O.R.R.", async () => {
@@ -22,6 +37,7 @@ describe("booster catalog", () => {
     expect(response.status).toBe(200);
     expect(body.boosters).toHaveLength(13);
     expect(body.boosters.map((booster) => booster.name)).toEqual([
+      "Vibe Drop",
       "Neon Breach",
       "Factory Shift",
       "Street Kings",
@@ -34,8 +50,8 @@ describe("booster catalog", () => {
       "Metro Chase",
       "Desert Signal",
       "Street Plague",
-      "Vibe Drop",
     ]);
+    expect(body.boosters[0]).toMatchObject({ id: "vibe-drop", presentation: "special" });
 
     for (const booster of body.boosters) {
       expect(booster.clans.length).toBeGreaterThanOrEqual(1);
@@ -86,6 +102,63 @@ describe("booster catalog", () => {
     expect(body.player.crystals).toBe(100);
     expect(body.boosters.every((booster) => booster.paid.canOpen)).toBe(true);
     expect(body.boosters.every((booster) => booster.paid.crystalCost === 100)).toBe(true);
+  });
+
+  test("shows a group booster only for a valid signed context for that group", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    store.seedProfile(guestIdentity, { crystals: 100 });
+    store.seedGroup("-100visible", ["visible-a", "visible-b", "visible-c", "visible-d"]);
+    store.seedGroup("-100other", ["other-a", "other-b", "other-c", "other-d"]);
+    const visibleContext = signGroupLaunchContext({ chatId: "-100visible", now: new Date("2099-05-06T10:00:00.000Z") });
+    const otherContext = signGroupLaunchContext({ chatId: "-100other", now: new Date("2099-05-06T10:00:00.000Z") });
+
+    const noContextBody = (await (await postCatalog(store, guestIdentity)).json()) as { boosters: BoosterCatalogItem[] };
+    const visibleBody = (await (await postCatalog(store, guestIdentity, visibleContext)).json()) as { boosters: BoosterCatalogItem[] };
+    const otherBody = (await (await postCatalog(store, guestIdentity, otherContext)).json()) as { boosters: BoosterCatalogItem[] };
+
+    expect(noContextBody.boosters.some((booster) => booster.id.startsWith("group-"))).toBe(false);
+    expect(visibleBody.boosters.find((booster) => booster.id === groupBoosterId("-100visible"))).toMatchObject({
+      id: groupBoosterId("-100visible"),
+      groupChatId: "-100visible",
+      presentation: "group",
+      paid: {
+        canOpen: true,
+      },
+    });
+    expect(visibleBody.boosters.some((booster) => booster.id === groupBoosterId("-100other"))).toBe(false);
+    expect(otherBody.boosters.some((booster) => booster.id === groupBoosterId("-100visible"))).toBe(false);
+  });
+
+  test("includes signed group booster metadata on the public paid-shop catalog GET", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    const group = store.seedGroup("-100shop", ["shop-a", "shop-b", "shop-c", "shop-d"]);
+    const context = signGroupLaunchContext({ chatId: "-100shop", now: new Date("2099-05-06T10:00:00.000Z") });
+
+    const response = await handleBoosterCatalogGet(new Request(`http://localhost/api/boosters?groupContext=${encodeURIComponent(context)}`), store);
+    const body = (await response.json()) as { boosters: { id: string; presentation?: string; groupChatId?: string }[] };
+
+    expect(response.status).toBe(200);
+    expect(body.boosters.at(0)).toMatchObject({ id: "vibe-drop", presentation: "special" });
+    expect(body.boosters.at(-1)).toMatchObject({
+      id: group.boosterId,
+      presentation: "group",
+      groupChatId: "-100shop",
+    });
+  });
+
+  test("rejects expired, tampered, or unsigned group contexts for group catalog", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    store.seedGroup("-100secure", ["secure-a"]);
+    const expired = signGroupLaunchContext({ chatId: "-100secure", now: new Date("2000-05-06T10:00:00.000Z"), ttlSeconds: -1 });
+    const tampered = `${expired.slice(0, -1)}x`;
+
+    const expiredResponse = await postCatalog(store, guestIdentity, expired);
+    const tamperedResponse = await postCatalog(store, guestIdentity, tampered);
+
+    expect(expiredResponse.status).toBe(403);
+    expect(((await expiredResponse.json()) as { error: string }).error).toBe("group_context_expired");
+    expect(tamperedResponse.status).toBe(403);
+    expect(((await tamperedResponse.json()) as { error: string }).error).toBe("group_context_invalid");
   });
 });
 
@@ -374,10 +447,64 @@ describe("paid booster opening", () => {
     expect(profile.ownedCards).toEqual([]);
     expect(store.openings).toHaveLength(0);
   });
+
+  test("opens all available group cards when the paid group pool has one to three cards", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    const group = store.seedGroup("-100small", ["one", "two", "three"]);
+    store.seedProfile(guestIdentity, { crystals: 100, starterFreeBoostersRemaining: 0 });
+    const context = signGroupLaunchContext({ chatId: "-100small", now: new Date("2099-05-06T10:00:00.000Z") });
+
+    const response = await openPaidBooster(store, group.boosterId, context);
+    const body = (await response.json()) as OpenBoosterResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.cards.map((card) => card.id)).toEqual(group.cardIds);
+    expect(body.player.crystals).toBe(0);
+    expect(body.player.ownedCards.map((entry) => [entry.cardId, entry.count])).toEqual(group.cardIds.map((cardId) => [cardId, 1]));
+  });
+
+  test("opens four weighted group cards from a larger paid group pool and increments duplicate ownership", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    const group = store.seedGroup("-100large", ["low", "medium", "high", "top", "tail"], [1, 2, 3, 4, 5]);
+    store.seedProfile(guestIdentity, {
+      crystals: 200,
+      starterFreeBoostersRemaining: 0,
+      ownedCards: [{ cardId: group.cardIds[4], count: 1 }],
+    });
+    const context = signGroupLaunchContext({ chatId: "-100large", now: new Date("2099-05-06T10:00:00.000Z") });
+
+    const response = await openPaidBooster(store, group.boosterId, context, [0.99, 0.99, 0.99, 0.99]);
+    const body = (await response.json()) as OpenBoosterResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.cards.map((card) => card.id)).toEqual([group.cardIds[4], group.cardIds[3], group.cardIds[2], group.cardIds[1]]);
+    expect(body.cards).toHaveLength(4);
+    expect(getOwnedCount(body.player.ownedCards, group.cardIds[4])).toBe(2);
+    expect(body.player.crystals).toBe(100);
+  });
+
+  test("requires a matching signed group context to open a group booster", async () => {
+    const store = new MemoryBoosterOpeningStore();
+    const group = store.seedGroup("-100locked", ["locked-a"]);
+    store.seedGroup("-100unrelated", ["unrelated-a"]);
+    store.seedProfile(guestIdentity, { crystals: 300, starterFreeBoostersRemaining: 0 });
+    const unrelatedContext = signGroupLaunchContext({ chatId: "-100unrelated", now: new Date("2099-05-06T10:00:00.000Z") });
+
+    const missing = await openPaidBooster(store, group.boosterId);
+    const unrelated = await openPaidBooster(store, group.boosterId, unrelatedContext);
+
+    expect(missing.status).toBe(403);
+    expect(((await missing.json()) as { error: string }).error).toBe("group_context_required");
+    expect(unrelated.status).toBe(403);
+    expect(((await unrelated.json()) as { error: string }).error).toBe("group_context_required");
+    expect(store.openings).toHaveLength(0);
+  });
 });
 
 class MemoryBoosterOpeningStore implements BoosterOpeningStore {
   private readonly profiles: StoredPlayerProfile[] = [];
+  private readonly groups = new Map<string, GroupIntegrationRecord>();
+  private readonly groupCards = new Map<string, GroupCardIntegrationRecord>();
   readonly openings: StoredBoosterOpeningRecord[] = [];
   private nextProfileId = 1;
   private nextOpeningId = 1;
@@ -529,6 +656,63 @@ class MemoryBoosterOpeningStore implements BoosterOpeningStore {
     return opening;
   }
 
+  seedGroup(chatId: string, idempotencyKeys: string[], dropWeights: number[] = []) {
+    const group: GroupIntegrationRecord = {
+      chatId,
+      clan: `Clan ${chatId}`,
+      boosterId: groupBoosterId(chatId),
+      displayName: `Clan ${chatId}`,
+      glyphUrl: `/nexus-assets/integrations/${encodeURIComponent(chatId)}/glyph.png`,
+      bonus: {
+        id: "test-bonus",
+        name: "Test Bonus",
+        description: "Test bonus.",
+        effects: [{ key: "add-power", amount: 1 }],
+      },
+      cardIds: idempotencyKeys.map((key) => groupCardId(chatId, key)),
+      createdAt: new Date("2099-05-06T10:00:00.000Z"),
+      updatedAt: new Date("2099-05-06T10:00:00.000Z"),
+    };
+    this.groups.set(chatId, group);
+    const cardInputs = idempotencyKeys.map((key, index) => ({
+      chatId,
+      creatorTelegramId: `creator-${index}`,
+      idempotencyKey: key,
+      name: `Group Card ${key}`,
+      power: 10 + index,
+      damage: 3 + index,
+      ability: {
+        id: "group-ability",
+        name: "Group Ability",
+        description: "Group ability.",
+        effects: [{ key: "add-attack", amount: 1 }],
+      },
+      imageUrl: `https://assets.test/${key}.png`,
+      artUrl: `/nexus-assets/integrations/${encodeURIComponent(chatId)}/${key}.webp`,
+      dropWeight: dropWeights[index] ?? 1,
+    }));
+    for (const input of cardInputs) {
+      this.groupCards.set(groupCardId(chatId, input.idempotencyKey), {
+        id: groupCardId(chatId, input.idempotencyKey),
+        chatId,
+        creatorTelegramId: input.creatorTelegramId,
+        idempotencyKey: input.idempotencyKey,
+        dropWeight: input.dropWeight,
+        createdAt: new Date("2099-05-06T10:00:00.000Z"),
+      });
+    }
+    hydrateGroupRuntime([group], cardInputs);
+    return group;
+  }
+
+  async findIntegrationGroupByChatId(chatId: string) {
+    return this.groups.get(chatId);
+  }
+
+  async findIntegrationGroupCardsByChatId(chatId: string) {
+    return [...this.groupCards.values()].filter((card) => card.chatId === chatId);
+  }
+
   private removeOpening(openingId: string) {
     const openingIndex = this.openings.findIndex((opening) => opening.id === openingId);
     if (openingIndex >= 0) {
@@ -551,25 +735,27 @@ function openBooster(store: BoosterOpeningStore, boosterId: string) {
   );
 }
 
-function openPaidBooster(store: BoosterOpeningStore, boosterId: string) {
+function openPaidBooster(store: BoosterOpeningStore, boosterId: string, groupContext?: string, rngValues = Array.from({ length: 16 }, () => 0)) {
   return handleBoosterOpenPost(
     postRequest("http://localhost/api/player/open-booster", {
       identity: guestIdentity,
       boosterId,
       source: "paid_crystals",
+      ...(groupContext ? { groupContext } : {}),
     }),
     store,
     {
-      rng: sequenceRng(Array.from({ length: 16 }, () => 0)),
+      rng: sequenceRng(rngValues),
       now: () => new Date("2026-05-02T12:00:00.000Z"),
     },
   );
 }
 
-function postCatalog(store: BoosterOpeningStore, identity: PlayerIdentity) {
+function postCatalog(store: BoosterOpeningStore, identity: PlayerIdentity, groupContext?: string) {
   return handleBoosterCatalogPost(
     postRequest("http://localhost/api/boosters", {
       identity,
+      ...(groupContext ? { groupContext } : {}),
     }),
     store,
   );
@@ -625,7 +811,7 @@ type OpenBoosterResponse = {
   booster: {
     id: string;
     name: string;
-    clans: [string, string];
+    clans: string[];
   };
   cards: (Card & { rarity: Rarity })[];
   opening: BoosterOpeningRecord;

--- a/tests/collection-deck.spec.ts
+++ b/tests/collection-deck.spec.ts
@@ -204,6 +204,74 @@ test("opens an already known booster again for 100 crystals from the collection 
   await expect(page.getByTestId("paid-booster-open-neon-breach")).toBeDisabled();
 });
 
+test("does not keep a stale group booster visible after group context becomes invalid", async ({ page }) => {
+  const identity: PlayerIdentity = { mode: "guest", guestId: "guest-group-booster-stale-e2e" };
+  let boosterCatalogRequests = 0;
+
+  await mockDeckReadyProfile(page, {
+    identity,
+    crystals: 100,
+    openedBoosterIds: ["neon-breach", "factory-shift"],
+    starterFreeBoostersRemaining: 0,
+  });
+
+  await page.route("**/api/boosters**", async (route) => {
+    boosterCatalogRequests += 1;
+    const url = new URL(route.request().url());
+    const groupContext = url.searchParams.get("groupContext");
+
+    if (groupContext === "valid-group-context") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          boosters: [
+            {
+              id: "vibe-drop",
+              name: "Vibe Drop",
+              clans: ["VibeCoders"],
+              cardCount: 4,
+              presentation: "special",
+            },
+            {
+              id: "group--100valid",
+              name: "Valid Group",
+              clans: ["Valid Group"],
+              cardCount: 4,
+              presentation: "group",
+              groupChatId: "-100valid",
+            },
+          ],
+        }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 403,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error: "group_context_invalid",
+        message: "Signed group context is invalid.",
+      }),
+    });
+  });
+
+  await page.goto("/?groupContext=valid-group-context");
+  await page.getByTestId("topbar-open-boosters").click();
+  await expect(page.getByTestId("booster-shop-item-group--100valid")).toBeVisible();
+
+  await page.evaluate(() => {
+    window.history.pushState(null, "", "/?groupContext=tampered-group-context");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  });
+
+  await expect(page.getByTestId("booster-shop-error")).toBeVisible();
+  await expect(page.getByTestId("booster-shop-list")).toHaveCount(0);
+  await expect(page.getByTestId("booster-shop-item-group--100valid")).toHaveCount(0);
+  expect(boosterCatalogRequests).toBeGreaterThanOrEqual(2);
+});
+
 test("blocks overlapping deck edits and rolls a failed save back to the confirmed profile deck", async ({ page }) => {
   if (!extraOwnedCardId || !secondExtraOwnedCardId) throw new Error("Fixture must include two owned cards outside the deck.");
 

--- a/tests/integrations.test.ts
+++ b/tests/integrations.test.ts
@@ -3,7 +3,8 @@ import sharp from "sharp";
 import { cards } from "../src/features/battle/model/cards";
 import { createBattleHand, createCardCollection, createDeck, findCard } from "../src/features/battle/model/domain/decks";
 import type { Bonus } from "../src/features/battle/model/types";
-import { handleGroupCardPost, handleGroupUpsertPut, createGroupCardRecord, createNewGroup, validateGroupBonusChange, type CreateGroupCardInput, type CreateGroupCardResult, type IntegrationStore, type UpsertGroupInput } from "../src/features/integrations/api";
+import { handleGroupCardPost, handleGroupLaunchUrlPost, handleGroupUpsertPut, createGroupCardRecord, createNewGroup, validateGroupBonusChange, type CreateGroupCardInput, type CreateGroupCardResult, type IntegrationStore, type UpsertGroupInput } from "../src/features/integrations/api";
+import { verifyGroupLaunchContext } from "../src/features/integrations/groupContext";
 import { groupCardId, hydrateGroupRuntime, resetDynamicIntegrationRuntimeForTests } from "../src/features/integrations/runtime";
 import { addToInventory, getOwnedCount } from "../src/features/inventory/inventoryOps";
 import { handlePlayerDeckSavePost } from "../src/features/player/profile/api";
@@ -59,6 +60,36 @@ describe("integration API", () => {
 
     expect(groupResponse.status).toBe(401);
     expect(cardResponse.status).toBe(401);
+    const launchResponse = await handleGroupLaunchUrlPost(
+      jsonRequest("http://localhost/api/integrations/groups/-100/launch-url", {}),
+      { params: { chatId: "-100" } },
+    );
+    expect(launchResponse.status).toBe(401);
+  });
+
+  test("generates a signed expiring group launch URL", async () => {
+    const response = await handleGroupLaunchUrlPost(
+      jsonRequest(
+        "http://localhost/api/integrations/groups/-100launch/launch-url",
+        { baseUrl: "https://nexus.test/play?screen=collection" },
+        authHeaders(),
+      ),
+      { params: { chatId: "-100launch" } },
+      { now: new Date("2026-05-06T10:00:00.000Z"), ttlSeconds: 60 },
+    );
+    const body = (await response.json()) as { url: string; expiresInSeconds: number };
+    const url = new URL(body.url);
+    const groupContext = url.searchParams.get("groupContext");
+
+    expect(response.status).toBe(200);
+    expect(body.expiresInSeconds).toBe(60);
+    expect(url.origin).toBe("https://nexus.test");
+    expect(url.searchParams.get("screen")).toBe("collection");
+    expect(groupContext).toBeString();
+    expect(verifyGroupLaunchContext(groupContext, { now: new Date("2026-05-06T10:00:30.000Z") })).toMatchObject({
+      chatId: "-100launch",
+      expiresAt: 1778061660,
+    });
   });
 
   test("upserts a group clan and booster with Nexus-owned glyph URL", async () => {


### PR DESCRIPTION
## Summary
- add signed group launch URLs and backend group-context validation for catalog/open operations
- expose scoped group paid boosters, opening behavior for small/weighted pools, and global ownership behavior
- mark VibeCoders/group boosters as special, move vibe-drop first, and thread group context through the WebApp paid shop
- add unit/integration and targeted Playwright regression coverage

## Verification
- rtk bun test tests/boosterOpening.test.ts tests/integrations.test.ts
- rtk bun run test
- rtk bun run test:e2e -- tests/collection-deck.spec.ts -g "stale group booster"
- rtk bun run build
- rtk git diff --check

Closes #55
Refs #53