### PR TITLE
Add first battle guided tutorial

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,7 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+# Interaction polish
+
+- Any visible or tutorial-targeted control the player is expected to click or tap must explicitly include pointer cursor styling (`cursor-pointer` or equivalent). Do not rely on browser default button cursor behavior for highlighted cards, energy dots, OK/confirm, skip actions, or similar guided-flow targets.

--- a/src/features/battle/ui/BattleGame.tsx
+++ b/src/features/battle/ui/BattleGame.tsx
@@ -53,8 +53,11 @@ type BattleGameProps = {
 };
 
 type HumanMatchStatus = "idle" | "connecting" | "queued" | "matched" | "opponent_left" | "forfeit" | "error" | "closed";
+type FirstBattleTutorialStep = "card" | "energy" | "confirm";
+
 const BOT_FALLBACK_DELAY_MS = 5_000;
 const REMOTE_AI_CLIENT_BUDGET_MS = 4_000;
+const FIRST_BATTLE_TUTORIAL_STORAGE_KEY = "nexus:first-battle-tutorial-seen:v1";
 
 type HumanMove = {
   cardId: string;
@@ -163,6 +166,7 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
     }
     return initialGame;
   });
+  const [aiSessionLoaded, setAiSessionLoaded] = useState(isHumanMatch);
   const [selectedId, setSelectedId] = useState(() => getAvailableCards(game.player)[0]?.id);
   const [energy, setEnergy] = useState(0);
   const [damageBoost, setDamageBoost] = useState(false);
@@ -197,6 +201,8 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
   const [persistedRewardsError, setPersistedRewardsError] = useState<string | null>(null);
   const [surrendering, setSurrendering] = useState(false);
   const [surrenderConfirmOpen, setSurrenderConfirmOpen] = useState(false);
+  const [tutorialSeen, setTutorialSeen] = useState(false);
+  const [tutorialStep, setTutorialStep] = useState<FirstBattleTutorialStep>("card");
   const persistedMatchSignatureRef = useRef<string | null>(null);
   const surrenderedMatchRef = useRef(false);
   const autoSubmitRef = useRef(() => {});
@@ -222,22 +228,51 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
   }, [game]);
 
   useEffect(() => {
+    mountedRef.current = true;
+    setTutorialSeen(readFirstBattleTutorialSeen());
+
     return () => {
       mountedRef.current = false;
       aiMoveRequestIdRef.current += 1;
     };
   }, []);
 
+  useEffect(() => {
+    if (isHumanMatch) {
+      setAiSessionLoaded(true);
+      return;
+    }
+
+    const persisted = normalizeLoadedAiGame(loadBattleSession());
+    if (persisted && !persisted.matchResult) {
+      const nextCard = getAvailableCards(persisted.player)[0];
+      setGame(persisted);
+      setSelectedId(nextCard?.id);
+      setEnergy(0);
+      setDamageBoost(false);
+      setPending(null);
+      setEnemyLockedMove(null);
+      setRoundWinnerCardIds(new Set());
+      setSelectionOpen(false);
+      setClashOverlayDone(false);
+      setHudHpOverride({});
+      setTurnSeconds(TURN_SECONDS);
+    }
+
+    setAiSessionLoaded(true);
+  }, [isHumanMatch]);
+
   // Persist AI-mode game state across refreshes; clear once a match concludes
   // so the next entry to the battle screen starts a fresh fight.
   useEffect(() => {
     if (isHumanMatch) return;
+    if (!aiSessionLoaded) return;
     if (game.matchResult) {
       clearBattleSession();
       return;
     }
     saveBattleSession(game);
-  }, [game, isHumanMatch]);
+  }, [aiSessionLoaded, game, isHumanMatch]);
 
   useEffect(() => {
     matchInfoRef.current = matchInfo;
@@ -384,6 +419,16 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
   const playerDecisionActive = pending === null && ["player_turn", "card_preview"].includes(game.phase);
   const turnWarningActive = playerDecisionActive && turnSeconds <= 10;
   const canSurrender = !humanBlockingOverlay && !surrendering && !game.matchResult && game.phase !== "reward_summary";
+  const tutorialTargetCard = getAvailableCards(game.player)[0];
+  const tutorialActive =
+    !isHumanMatch &&
+    tutorialSeen === false &&
+    pending === null &&
+    !game.matchResult &&
+    Boolean(tutorialTargetCard) &&
+    (tutorialStep === "card"
+      ? game.phase === "player_turn"
+      : game.phase === "card_preview" && selectionOpen);
 
   useEffect(() => {
     if (humanBlockingOverlay) return;
@@ -506,7 +551,35 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
 
     if (game.phase === "opponent_turn") {
       if (isHumanMatch) return;
-      if (!pending && aiMoveRequestIdRef.current === 0 && game.first === "player" && game.round.playerCardId) {
+      if (!pending && game.first === "enemy" && !game.round.enemyCardId) {
+        const requestId = ++aiMoveRequestIdRef.current;
+        chooseAiEnemyMove(game).then((enemyMove) => {
+          if (!isCurrentAiMoveRequest(requestId, game.round.round)) return;
+
+          playOpponentMoveCue(soundCueRef, game.round.round, enemyMove.card.id);
+          setEnemyLockedMove(enemyMove);
+          setGame((value) => {
+            if (value.round.round !== game.round.round || value.first !== "enemy" || value.phase !== "opponent_turn") {
+              return value;
+            }
+
+            return {
+              ...value,
+              phase: "player_turn",
+              turnDeadlineAt: startTurnDeadline(),
+              round: {
+                ...value.round,
+                enemyCardId: enemyMove.card.id,
+                enemyEnergyBid: enemyMove.energy,
+                enemyDamageBoost: enemyMove.damageBoost,
+              },
+            };
+          });
+        });
+        return;
+      }
+
+      if (!pending && game.first === "player" && game.round.playerCardId) {
         const playerCard = findCardInHand(game.player.hand, game.round.playerCardId);
         if (!playerCard) return;
 
@@ -658,6 +731,16 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
   }, [game.matchResult, game.phase, isHumanMatch, onPlayerUpdated, playerIdentity]);
 
   useEffect(() => {
+    if (tutorialActive) {
+      setTurnSeconds(TURN_SECONDS);
+      setGame((value) =>
+        ["player_turn", "card_preview"].includes(value.phase) && value.turnDeadlineAt
+          ? { ...value, turnDeadlineAt: undefined }
+          : value,
+      );
+      return;
+    }
+
     if (!playerDecisionActive) {
       setTurnSeconds(TURN_SECONDS);
       return;
@@ -687,10 +770,17 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
       window.clearInterval(interval);
       window.clearTimeout(timeout);
     };
-  }, [game.round.round, game.turnDeadlineAt, playerDecisionActive]);
+  }, [game.round.round, game.turnDeadlineAt, playerDecisionActive, tutorialActive]);
 
   function confirmSelection() {
     if (!selected) return;
+    if (tutorialActive && tutorialStep === "energy") {
+      if (selectedEnergy > 0) setTutorialStep("confirm");
+      return;
+    }
+    if (tutorialActive && tutorialStep === "confirm") {
+      completeFirstBattleTutorial();
+    }
 
     submitSelection(selected, selectedEnergy, damageBoost);
   }
@@ -1184,6 +1274,7 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
 
   useEffect(() => {
     autoSubmitRef.current = () => {
+      if (tutorialActive) return;
       if (pending || !["player_turn", "card_preview"].includes(game.phase)) return;
 
       if (isHumanMatch) {
@@ -1260,11 +1351,37 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
   }
 
   function closeSelection() {
+    if (tutorialActive) return;
     setSelectionOpen(false);
     setGame((value) => (value.phase === "card_preview" ? { ...value, phase: "player_turn" } : value));
   }
 
+  function completeFirstBattleTutorial() {
+    writeFirstBattleTutorialSeen();
+    setTutorialSeen(true);
+    setTurnSeconds(TURN_SECONDS);
+    setGame((value) =>
+      ["player_turn", "card_preview"].includes(value.phase)
+        ? { ...value, turnDeadlineAt: undefined }
+        : value,
+    );
+  }
+
+  function skipFirstBattleTutorial() {
+    completeFirstBattleTutorial();
+  }
+
+  function setTutorialEnergy(next: number) {
+    if (tutorialActive && tutorialStep === "confirm") return;
+    const legal = Math.max(0, Math.min(maxEnergyForCard, next));
+    setEnergy(legal);
+    if (tutorialActive && tutorialStep === "energy" && legal > 0) {
+      setTutorialStep("confirm");
+    }
+  }
+
   function openCollectionFromBattle() {
+    if (tutorialActive) return;
     setSelectionOpen(false);
     setSurrenderConfirmOpen(false);
     setPending(null);
@@ -1279,6 +1396,7 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
   }
 
   function surrenderMatch() {
+    if (tutorialActive) return;
     if (!canSurrender) return;
     setSurrenderConfirmOpen(true);
   }
@@ -1402,8 +1520,10 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
   const onSelectHandCard = (cardId: string) => {
     const card = game.player.hand.find((entry) => entry.id === cardId);
     if (!card || locked || card.used) return;
+    if (tutorialActive && tutorialStep === "card" && card.id !== tutorialTargetCard?.id) return;
     setSelectedId(card.id);
     setSelectionOpen(true);
+    if (tutorialActive && tutorialStep === "card") setTutorialStep("energy");
     setGame((value) => ({
       ...value,
       phase: "card_preview",
@@ -1482,16 +1602,26 @@ export function BattleGame({ playerCollectionIds, playerDeckIds, playerIdentity,
           }}
           onClashDone={() => setClashOverlayDone(true)}
           onSelectCard={onSelectHandCard}
-          onEnergyMinus={() => setEnergy((value) => Math.max(0, Math.min(value, maxEnergyForCard) - 1))}
-          onEnergyPlus={() => setEnergy((value) => Math.min(maxEnergyForCard, value + 1))}
-          onEnergyChange={(next) => setEnergy(Math.max(0, Math.min(maxEnergyForCard, next)))}
+          onEnergyMinus={() => setTutorialEnergy(Math.max(0, Math.min(energy, maxEnergyForCard) - 1))}
+          onEnergyPlus={() => setTutorialEnergy(Math.min(maxEnergyForCard, energy + 1))}
+          onEnergyChange={setTutorialEnergy}
           onToggleBoost={toggleBoost}
           onConfirmPick={confirmSelection}
           onCancelPick={closeSelection}
           onLeave={openCollectionFromBattle}
           onSurrender={surrenderMatch}
           canSurrender={canSurrender}
+          tutorial={
+            tutorialActive
+              ? {
+                  step: tutorialStep,
+                  targetCardId: tutorialTargetCard?.id,
+                  onSkip: skipFirstBattleTutorial,
+                }
+              : undefined
+          }
           onOpenDecks={() => {
+            if (tutorialActive) return;
             // TODO(owner): wire deck-management modal. Today GameRoot only
             // exposes onOpenCollection (which both Leaves the match AND opens
             // the collection/deck screen) — there is no dedicated deck modal
@@ -1868,6 +1998,23 @@ function getVerdict(result?: MatchResult) {
   if (!result) return "";
   if (result === "draw") return "Нічия";
   return result === "player" ? "Перемога" : "Програш";
+}
+
+function readFirstBattleTutorialSeen() {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(FIRST_BATTLE_TUTORIAL_STORAGE_KEY) === "true";
+  } catch {
+    return true;
+  }
+}
+
+function writeFirstBattleTutorialSeen() {
+  try {
+    window.localStorage.setItem(FIRST_BATTLE_TUTORIAL_STORAGE_KEY, "true");
+  } catch {
+    // Tutorial persistence is best effort; failing closed prevents trapping users.
+  }
 }
 
 function matchResultToBucket(result: MatchResult): "win" | "draw" | "loss" {

--- a/src/features/battle/ui/v2/molecules/BattleHand.tsx
+++ b/src/features/battle/ui/v2/molecules/BattleHand.tsx
@@ -27,11 +27,12 @@ export type BattleHandProps = {
   cards: BattleHandCard[];
   /** Highlight the row (e.g. when it's this side's turn). */
   active?: boolean;
+  tutorialTargetCardId?: string;
   onSelect?: (cardId: string) => void;
   className?: string;
 };
 
-export function BattleHand({ side, cards, active, onSelect, className }: BattleHandProps) {
+export function BattleHand({ side, cards, active, tutorialTargetCardId, onSelect, className }: BattleHandProps) {
   const isPlayer = side === "player";
   const handTestId = isPlayer ? "battle-hand-player" : "battle-hand-opponent";
 
@@ -48,8 +49,10 @@ export function BattleHand({ side, cards, active, onSelect, className }: BattleH
       )}
     >
       {cards.map(({ card, used, roundResult, medal, selectable, selected, played }) => {
-        const interactive = isPlayer && Boolean(onSelect) && Boolean(selectable) && !used;
-        const cardDisabled = isPlayer && (used || !selectable);
+        const blockedByTutorial = isPlayer && Boolean(tutorialTargetCardId) && tutorialTargetCardId !== card.id;
+        const tutorialTarget = tutorialTargetCardId === card.id;
+        const interactive = isPlayer && Boolean(onSelect) && Boolean(selectable) && !used && !blockedByTutorial;
+        const cardDisabled = isPlayer && (used || !selectable || blockedByTutorial);
         const damageBoost = hasDamageBoost(card);
         const handleClick = () => {
           if (interactive) onSelect!(card.id);
@@ -81,6 +84,7 @@ export function BattleHand({ side, cards, active, onSelect, className }: BattleH
             data-side={side}
             data-state={stateValue}
             data-selected={selected ? "true" : undefined}
+            data-tutorial-target={tutorialTarget ? "true" : undefined}
             role={isPlayer ? "button" : undefined}
             tabIndex={isPlayer ? (cardDisabled ? -1 : 0) : -1}
             aria-pressed={isPlayer ? Boolean(selected) : undefined}
@@ -93,6 +97,9 @@ export function BattleHand({ side, cards, active, onSelect, className }: BattleH
               "outline-none",
               interactive && "cursor-pointer hover:-translate-y-0.5",
               !interactive && isPlayer && "cursor-not-allowed",
+              blockedByTutorial && "opacity-30 saturate-50 grayscale",
+              tutorialTarget &&
+                "z-30 -translate-y-2 scale-[1.07] drop-shadow-[0_0_34px_rgba(240,198,104,0.98)]",
               played && !isPlayer && "translate-y-2 scale-[1.04] drop-shadow-[0_18px_24px_rgba(255,74,66,0.45)]",
               used && "opacity-35 saturate-50 grayscale pointer-events-none",
             )}
@@ -102,6 +109,8 @@ export function BattleHand({ side, cards, active, onSelect, className }: BattleH
               className={cn(
                 "rounded-[12px] transition-shadow duration-200",
                 selected && "ring-2 ring-accent ring-offset-0",
+                tutorialTarget &&
+                  "ring-4 ring-accent bg-accent/25 shadow-[0_0_0_2px_rgba(255,255,255,0.72),0_0_34px_rgba(240,198,104,0.88)]",
                 damageBoost &&
                   "bg-danger/15 ring-1 ring-danger/40 shadow-[0_0_18px_rgba(217,112,86,0.18)]",
               )}

--- a/src/features/battle/ui/v2/organisms/CardPickModal.tsx
+++ b/src/features/battle/ui/v2/organisms/CardPickModal.tsx
@@ -28,6 +28,8 @@ export type CardPickModalProps = {
   onEnergyChange?: (next: number) => void;
   onToggleBoost: () => void;
   onConfirm: () => void;
+  tutorialStep?: "energy" | "confirm";
+  onTutorialSkip?: () => void;
 };
 
 export function CardPickModal({
@@ -49,6 +51,8 @@ export function CardPickModal({
   onEnergyChange,
   onToggleBoost,
   onConfirm,
+  tutorialStep,
+  onTutorialSkip,
 }: CardPickModalProps) {
   const isMobile = useIsMobile();
 
@@ -83,6 +87,7 @@ export function CardPickModal({
   };
 
   const boostToggleDisabled = !damageBoost && !canBoost;
+  const tutorialActive = tutorialStep === "energy" || tutorialStep === "confirm";
 
   return (
     <Modal
@@ -108,8 +113,12 @@ export function CardPickModal({
             type="button"
             data-testid="card-pick-cancel"
             onClick={onClose}
+            disabled={tutorialActive}
             aria-label="Закрити"
-            className="inline-grid place-items-center w-8 h-8 rounded-full text-ink-mute hover:text-ink hover:bg-accent/10 transition-colors"
+            className={cn(
+              "inline-grid place-items-center w-8 h-8 rounded-full text-ink-mute transition-colors",
+              tutorialActive ? "opacity-35 cursor-not-allowed" : "hover:text-ink hover:bg-accent/10",
+            )}
           >
             <span aria-hidden className="text-lg leading-none">×</span>
           </button>
@@ -200,12 +209,17 @@ export function CardPickModal({
                 Енергія
               </span>
               <span className="font-mono tabular-nums text-[11px] text-ink-mute">
-                {energy} / {available}
+                <span data-testid="selection-energy">{energy}</span> / {available}
               </span>
             </div>
             <div
               data-testid="card-pick-energy-stepper"
-              className="flex items-center justify-center gap-[4px] flex-wrap"
+              data-tutorial-target={tutorialStep === "energy" ? "true" : undefined}
+              className={cn(
+                "flex items-center justify-center gap-[4px] flex-wrap",
+                tutorialStep === "energy" &&
+                  "relative z-20 rounded-lg p-1 ring-2 ring-accent shadow-[0_0_24px_rgba(240,198,104,0.45)]",
+              )}
             >
               {Array.from({ length: energySlotCount }).map((_, i) => {
                 const filled = i < energy;
@@ -225,6 +239,7 @@ export function CardPickModal({
                         ? "bg-accent text-[#1a1408] shadow-[0_0_8px_rgba(240,198,104,0.45)]"
                         : "bg-surface-raised border-[1.5px] border-accent-quiet text-accent-quiet",
                       !slotAvailable && "opacity-30 cursor-not-allowed",
+                      slotAvailable && "cursor-pointer",
                       slotAvailable && !filled && "hover:bg-accent/10",
                     )}
                   >
@@ -246,14 +261,14 @@ export function CardPickModal({
                 data-testid="card-pick-boost-toggle"
                 data-active={damageBoost ? "true" : "false"}
                 onClick={onToggleBoost}
-                disabled={boostToggleDisabled}
+                disabled={boostToggleDisabled || tutorialActive}
                 aria-pressed={damageBoost}
                 className={cn(
                   "inline-flex items-center gap-2 w-[240px] justify-center px-3 h-9 rounded-md border text-[12px] uppercase tracking-[0.12em] transition-colors",
                   damageBoost
                     ? "border-accent text-accent bg-accent/10"
                     : "border-accent-quiet text-accent/80 hover:bg-accent/5",
-                  boostToggleDisabled && "opacity-40 cursor-not-allowed",
+                  (boostToggleDisabled || tutorialActive) && "opacity-40 cursor-not-allowed",
                 )}
               >
                 <span
@@ -277,15 +292,57 @@ export function CardPickModal({
             <button
               type="button"
               data-testid="selection-ok"
+              data-tutorial-target={tutorialStep === "confirm" ? "true" : undefined}
               onClick={onConfirm}
-              className="inline-flex items-center justify-center w-full min-w-0 h-12 sm:h-14 rounded-md bg-accent text-bg font-bold text-[15px] uppercase tracking-[0.18em] whitespace-nowrap hover:brightness-110 transition-all"
+              className={cn(
+                "inline-flex cursor-pointer items-center justify-center w-full min-w-0 h-12 sm:h-14 rounded-md bg-accent text-bg font-bold text-[15px] uppercase tracking-[0.18em] whitespace-nowrap hover:brightness-110 transition-all",
+                tutorialStep === "confirm" &&
+                  "relative z-20 ring-2 ring-white shadow-[0_0_24px_rgba(240,198,104,0.55)]",
+              )}
             >
               ОК
             </button>
           </div>
         </div>
+        {tutorialActive && onTutorialSkip ? (
+          <TutorialBubble
+            step={tutorialStep}
+            onSkip={onTutorialSkip}
+          />
+        ) : null}
       </section>
     </Modal>
+  );
+}
+
+function TutorialBubble({
+  step,
+  onSkip,
+}: {
+  step: "energy" | "confirm";
+  onSkip: () => void;
+}) {
+  const copy =
+    step === "energy"
+      ? "Обери хоча б 1 енергію для атаки."
+      : "Натисни OK, щоб підтвердити хід.";
+
+  return (
+    <div
+      data-testid="first-battle-tutorial"
+      data-step={step}
+      className="pointer-events-none fixed left-3 right-3 top-4 z-40 mx-auto flex max-w-[460px] items-center justify-between gap-3 rounded-lg border border-accent bg-[#19140d]/95 px-4 py-3 text-sm text-ink shadow-[0_18px_44px_rgba(0,0,0,0.42)] sm:top-8"
+    >
+      <span>{copy}</span>
+      <button
+        type="button"
+        data-testid="first-battle-tutorial-skip"
+        onClick={onSkip}
+        className="pointer-events-auto shrink-0 cursor-pointer rounded-md border border-accent bg-accent px-3 py-2 text-[11px] font-bold uppercase tracking-[0.14em] text-bg shadow-[0_0_18px_rgba(240,198,104,0.45)] hover:brightness-110"
+      >
+        Пропустити
+      </button>
+    </div>
   );
 }
 

--- a/src/features/battle/ui/v2/screens/BattleArena.tsx
+++ b/src/features/battle/ui/v2/screens/BattleArena.tsx
@@ -88,6 +88,11 @@ export type BattleArenaProps = {
   onOpenDecks?: () => void;
   onSurrender?: () => void;
   canSurrender?: boolean;
+  tutorial?: {
+    step: "card" | "energy" | "confirm";
+    targetCardId?: string;
+    onSkip: () => void;
+  };
 
   /** Active hand ring (player|enemy|null). */
   activeHand?: "player" | "enemy" | null;
@@ -142,6 +147,7 @@ export function BattleArena({
   onOpenDecks,
   onSurrender,
   canSurrender,
+  tutorial,
   activeHand,
   playerDamageFlash,
   enemyDamageFlash,
@@ -215,11 +221,17 @@ export function BattleArena({
           <CenterStage variant={variant} className="battle-arena-strip" />
         </div>
 
-        <div className="mx-auto w-full max-w-[1440px] mb-3 sm:mb-5">
+        <div
+          className={cn(
+            "mx-auto w-full max-w-[1440px] mb-3 sm:mb-5",
+            tutorial?.step === "card" && "relative z-20",
+          )}
+        >
           <BattleHand
             side="player"
             cards={playerHand}
             active={activeHand === "player"}
+            tutorialTargetCardId={tutorial?.step === "card" ? tutorial.targetCardId : undefined}
             onSelect={onSelectCard}
           />
         </div>
@@ -236,6 +248,14 @@ export function BattleArena({
           onSurrender={onSurrender}
           canSurrender={canSurrender}
         />
+
+        {tutorial?.step === "card" ? (
+          <div
+            data-testid="first-battle-tutorial-dim"
+            className="pointer-events-none absolute inset-0 z-10 bg-black/58"
+            aria-hidden
+          />
+        ) : null}
       </div>
 
       <CardPickModal
@@ -258,7 +278,29 @@ export function BattleArena({
         onEnergyChange={onEnergyChange}
         onToggleBoost={onToggleBoost}
         onConfirm={onConfirmPick}
+        tutorialStep={tutorial?.step === "energy" || tutorial?.step === "confirm" ? tutorial.step : undefined}
+        onTutorialSkip={tutorial?.onSkip}
       />
+
+      {tutorial?.step === "card" ? (
+        <>
+          <div
+            data-testid="first-battle-tutorial"
+            data-step="card"
+            className="pointer-events-none fixed left-3 right-3 bottom-[max(1rem,env(safe-area-inset-bottom))] z-40 mx-auto flex max-w-[460px] items-center justify-between gap-3 rounded-lg border border-accent bg-[#19140d]/95 px-4 py-3 text-sm text-ink shadow-[0_18px_44px_rgba(0,0,0,0.42)] sm:bottom-8"
+          >
+            <span>Обери підсвічену картку для першої атаки.</span>
+            <button
+              type="button"
+              data-testid="first-battle-tutorial-skip"
+              onClick={tutorial.onSkip}
+              className="pointer-events-auto shrink-0 cursor-pointer rounded-md border border-accent bg-accent px-3 py-2 text-[11px] font-bold uppercase tracking-[0.14em] text-bg shadow-[0_0_18px_rgba(240,198,104,0.45)] hover:brightness-110"
+            >
+              Пропустити
+            </button>
+          </div>
+        </>
+      ) : null}
 
       {clash ? (
         <ClashOverlay

--- a/src/features/game/ui/GameRoot.tsx
+++ b/src/features/game/ui/GameRoot.tsx
@@ -83,7 +83,8 @@ export function GameRoot() {
   const [deckSaveStatus, setDeckSaveStatus] = useState<DeckSaveStatus>("idle");
   const [profileRetryKey, setProfileRetryKey] = useState(0);
   const [starterDeckReadyVisible, setStarterDeckReadyVisible] = useState(false);
-  const [telegramPlayer, setTelegramPlayer] = useState<TelegramPlayer>(() => readTelegramPlayer());
+  const [telegramPlayer, setTelegramPlayer] = useState<TelegramPlayer>({});
+  const [clientReady, setClientReady] = useState(false);
   const deckTouchedRef = useRef(false);
   const deckSaveRequestRef = useRef(0);
   const lastConfirmedDeckIdsRef = useRef<string[]>([]);
@@ -101,6 +102,7 @@ export function GameRoot() {
       ((playerProfile?.starterFreeBoostersRemaining ?? 0) > 0 && !playerProfile?.onboarding.completed));
 
   useEffect(() => {
+    setClientReady(true);
     const telegramPlayerHandle = window.setTimeout(() => setTelegramPlayer(readTelegramPlayer()), 0);
 
     return () => {
@@ -301,8 +303,8 @@ export function GameRoot() {
   // bounce back to the collection unless we have a persisted session that
   // BattleGame can resume from. Without this guard, BattleGame's createInitialGame
   // throws on the empty placeholder deck.
-  const hasPersistedBattleSession = screen === "battle" && hasBattleSession();
-  const battleResumable = screen === "battle" && (deckIds.length >= PLAYER_DECK_SIZE || hasPersistedBattleSession);
+  const hasPersistedBattleSession = clientReady && screen === "battle" && hasBattleSession();
+  const battleResumable = clientReady && screen === "battle" && (deckIds.length >= PLAYER_DECK_SIZE || hasPersistedBattleSession);
   useEffect(() => {
     if (screen !== "battle") return;
     if (profileStatus !== "ready") return;

--- a/tests/battle.spec.ts
+++ b/tests/battle.spec.ts
@@ -1,8 +1,11 @@
 import { expect, test, type Page } from "@playwright/test";
 import { cards } from "../src/features/battle/model/cards";
+import { createInitialGame } from "../src/features/battle/model/game";
 import { mockDeckReadyProfile } from "./fixtures/playerProfile";
 
 const DECK_SESSION_STORAGE_KEY = "nexus:deck-session:v1";
+const BATTLE_SESSION_STORAGE_KEY = "nexus.battle.session.v1";
+const FIRST_BATTLE_TUTORIAL_STORAGE_KEY = "nexus:first-battle-tutorial-seen:v1";
 const PROFILE_ONLY_DECK_IDS = cards
   .filter((card) => card.clan === "Workers")
   .slice(0, 9)
@@ -105,6 +108,8 @@ test("returns from an active battle to the collection deck screen", async ({ pag
   await expect(page.getByTestId("collection-search")).toBeVisible();
   await page.getByTestId("play-selected-deck").click();
   await expect(page.getByTestId("battle-arena")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("first-battle-tutorial")).toBeVisible({ timeout: 10_000 });
+  await skipFirstBattleTutorialIfVisible(page);
 
   await page.getByTestId("battle-hud-open-decks").click();
 
@@ -113,7 +118,200 @@ test("returns from an active battle to the collection deck screen", async ({ pag
   await expect(page.locator('[data-testid^="deck-card-"]')).toHaveCount(9);
 });
 
+test("guides a first-time player through card, energy, and confirm tutorial steps", async ({ page }) => {
+  await mockDeckReadyProfile(page);
+  await page.goto("/");
+
+  await expect(page.getByTestId("collection-search")).toBeVisible();
+  await page.getByTestId("play-selected-deck").click();
+
+  await expect(page.getByTestId("first-battle-tutorial")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveAttribute("data-step", "card");
+  await expect.poll(async () => countEnabledPlayerCards(page), { timeout: 12_000 }).toBe(1);
+
+  const highlightedCard = page.locator('[data-testid^="player-card-"][data-tutorial-target="true"]');
+  await expect(highlightedCard).toHaveCount(1);
+  await highlightedCard.click();
+
+  await expect(page.getByTestId("selection-overlay")).toBeVisible();
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveAttribute("data-step", "energy");
+  await expect(page.getByTestId("selection-energy")).toHaveText("0");
+
+  await page.getByTestId("selection-ok").click();
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveAttribute("data-step", "energy");
+
+  await page.getByTestId("card-pick-energy-dot-1").click();
+  await expect(page.getByTestId("selection-energy")).toHaveText("1");
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveAttribute("data-step", "confirm");
+
+  await page.getByTestId("card-pick-energy-dot-1").click();
+  await expect(page.getByTestId("selection-energy")).toHaveText("1");
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveAttribute("data-step", "confirm");
+
+  await page.getByTestId("selection-ok").click();
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByTestId("battle-arena")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveCount(0);
+});
+
+test("skipping the first battle tutorial persists normal battle interaction", async ({ page }) => {
+  await mockDeckReadyProfile(page);
+  await page.goto("/");
+
+  await page.getByTestId("play-selected-deck").click();
+  await expect(page.getByTestId("first-battle-tutorial")).toBeVisible({ timeout: 10_000 });
+
+  await page.getByTestId("first-battle-tutorial-skip").click();
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveCount(0);
+  await expect.poll(async () => countEnabledPlayerCards(page), { timeout: 12_000 }).toBeGreaterThan(1);
+
+  await page.reload();
+  await expect(page.getByTestId("battle-arena")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveCount(0);
+});
+
+test("does not auto-submit while the first battle tutorial is waiting", async ({ page }) => {
+  await page.clock.install({ time: Date.now() });
+  await mockDeckReadyProfile(page);
+  await page.goto("/");
+
+  await page.getByTestId("play-selected-deck").click();
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveAttribute("data-step", "card", { timeout: 10_000 });
+  await expect.poll(async () => countEnabledPlayerCards(page), { timeout: 12_000 }).toBe(1);
+
+  await page.clock.fastForward(76_000);
+
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveAttribute("data-step", "card");
+  await expect(page.getByTestId("selection-overlay")).toHaveCount(0);
+  await expect(page.getByTestId("battle-overlay")).toHaveCount(0);
+  await expect.poll(async () => countEnabledPlayerCards(page)).toBe(1);
+
+  await page.getByTestId("first-battle-tutorial-skip").click();
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveCount(0);
+  await expect(page.getByTestId("turn-timer")).toContainText("75");
+  await expect.poll(async () => countEnabledPlayerCards(page)).toBeGreaterThan(1);
+
+  await page.clock.fastForward(74_000);
+
+  await expect(page.getByTestId("selection-overlay")).toHaveCount(0);
+  await expect(page.getByTestId("battle-overlay")).toHaveCount(0);
+  await expect.poll(async () => countEnabledPlayerCards(page)).toBeGreaterThan(1);
+});
+
+test("keeps the first battle tutorial usable on mobile", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await mockDeckReadyProfile(page);
+  await page.goto("/");
+
+  await page.getByTestId("play-selected-deck").click();
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveAttribute("data-step", "card", { timeout: 10_000 });
+
+  await page.locator('[data-testid^="player-card-"][data-tutorial-target="true"]').click();
+  await expect(page.getByTestId("selection-overlay")).toBeVisible();
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveAttribute("data-step", "energy");
+
+  await page.getByTestId("card-pick-energy-dot-1").click();
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveAttribute("data-step", "confirm");
+  await page.getByTestId("selection-ok").click();
+
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveCount(0);
+});
+
+test("resumes a pending AI opponent turn after reload", async ({ page }) => {
+  await page.route("**/api/battle/ai-move", async (route) => {
+    const request = route.request().postDataJSON() as {
+      enemy: { hand: Array<{ id: string }>; usedCardIds: string[] };
+    };
+    const cardId = request.enemy.hand.find((card) => !request.enemy.usedCardIds.includes(card.id))?.id;
+    if (!cardId) {
+      await route.abort();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ cardId, energy: 1, damageBoost: false, source: "fallback" }),
+    });
+  });
+  const savedGame = createInitialGame({
+    playerCollectionIds: PROFILE_ONLY_OWNED_CARD_IDS,
+    playerDeckIds: PROFILE_ONLY_DECK_IDS,
+  });
+  const playerCard = savedGame.player.hand[0];
+  await page.addInitScript(
+    ({ storageKey, game, cardId }) => {
+      window.localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          v: 1,
+          savedAt: Date.now(),
+          game: {
+            ...game,
+            phase: "opponent_turn",
+            round: {
+              ...game.round,
+              playerCardId: cardId,
+              playerEnergyBid: 1,
+              playerDamageBoost: false,
+            },
+          },
+        }),
+      );
+    },
+    { storageKey: BATTLE_SESSION_STORAGE_KEY, game: savedGame, cardId: playerCard.id },
+  );
+  await mockDeckReadyProfile(page, {
+    ownedCardIds: PROFILE_ONLY_OWNED_CARD_IDS,
+    deckIds: PROFILE_ONLY_DECK_IDS,
+  });
+
+  await page.goto("/?screen=battle");
+
+  await expect(page.getByTestId("battle-arena")).toBeVisible({ timeout: 10_000 });
+  await expect
+    .poll(
+      async () => {
+        const overlay = page.getByTestId("battle-overlay");
+        if (!(await overlay.isVisible().catch(() => false))) return "hidden";
+        return (await overlay.getAttribute("data-phase")) ?? "missing";
+      },
+      { timeout: 12_000 },
+    )
+    .toMatch(/^(battle_intro|damage_apply)$/);
+});
+
+test("restores a saved AI battle while profile is still loading", async ({ page }) => {
+  const savedGame = createInitialGame({
+    playerCollectionIds: PROFILE_ONLY_OWNED_CARD_IDS,
+    playerDeckIds: PROFILE_ONLY_DECK_IDS,
+  });
+  await page.addInitScript(
+    ({ storageKey, game }) => {
+      window.localStorage.setItem(storageKey, JSON.stringify({ v: 1, savedAt: Date.now(), game }));
+    },
+    { storageKey: BATTLE_SESSION_STORAGE_KEY, game: savedGame },
+  );
+  await mockDeckReadyProfile(page, {
+    ownedCardIds: PROFILE_ONLY_OWNED_CARD_IDS,
+    deckIds: PROFILE_ONLY_DECK_IDS,
+  });
+  await page.route("**/api/player", async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    await route.fallback();
+  });
+
+  await page.goto("/?screen=battle");
+
+  await expect(page.getByTestId("battle-arena")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("round-status")).toBeVisible();
+  await expect(page.getByText("BattleGame mounted without a usable deck or persisted session")).toHaveCount(0);
+});
+
 test("plays a complete state-machine battle", async ({ page }) => {
+  await markFirstBattleTutorialSeen(page);
   await mockDeckReadyProfile(page);
   await page.goto("/");
 
@@ -127,6 +325,7 @@ test("plays a complete state-machine battle", async ({ page }) => {
   await expect(page.getByTestId("round-marker")).toContainText("1");
   await expect(page.locator('[data-testid^="player-card-"]')).toHaveCount(4);
   await expect(page.locator('[data-testid^="enemy-card-"]')).toHaveCount(4);
+  await expect(page.getByTestId("first-battle-tutorial")).toHaveCount(0);
 
   await playFirstAvailableCard(page, 2, { knownEnemyCard: false });
 
@@ -135,7 +334,7 @@ test("plays a complete state-machine battle", async ({ page }) => {
     await expect
       .poll(
         async () => {
-          if (await page.getByTestId("reward-summary").isVisible().catch(() => false)) return "reward";
+          if (await page.getByTestId("match-end-overlay").isVisible().catch(() => false)) return "reward";
           if ((await countEnabledPlayerCards(page)) > 0) return "card";
           return "waiting";
         },
@@ -143,23 +342,18 @@ test("plays a complete state-machine battle", async ({ page }) => {
       )
       .not.toBe("waiting");
 
-    if (await page.getByTestId("reward-summary").isVisible().catch(() => false)) break;
+    if (await page.getByTestId("match-end-overlay").isVisible().catch(() => false)) break;
 
     await playFirstAvailableCard(page, 0, { knownEnemyCard });
     knownEnemyCard = !knownEnemyCard;
   }
 
-  await expect(page.getByTestId("reward-summary")).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByTestId("match-end-overlay")).toBeVisible({ timeout: 60_000 });
 
-  const replayAiButton = page.getByTestId("reward-replay-ai");
+  const replayAiButton = page.getByTestId("match-end-replay");
   await expect(replayAiButton).toHaveAttribute("data-mode", "ai");
-  await expect(replayAiButton).toContainText("AI");
-  await expect(page.getByTestId("reward-replay-human")).toBeVisible();
-  await replayAiButton.click();
-  await expect(page.getByTestId("phase-overlay")).toHaveAttribute("data-phase", "match_intro");
-  await expect(page.getByTestId("round-status")).toBeVisible({ timeout: 5_000 });
-  await expect(page.locator('[data-testid^="player-card-"]')).toHaveCount(4);
-  await expect(page.locator('[data-testid^="enemy-card-"]')).toHaveCount(4);
+  await expect(replayAiButton).toContainText("НА АРЕНУ");
+  await expect(page.getByTestId("match-end-collection")).toBeVisible();
 });
 
 async function playFirstAvailableCard(page: Page, extraEnergyClicks: number, options: { knownEnemyCard: boolean }) {
@@ -171,29 +365,30 @@ async function playFirstAvailableCard(page: Page, extraEnergyClicks: number, opt
   await cardButton.click();
 
   await expect(page.getByTestId("selection-overlay")).toBeVisible();
+  if ((await page.getByTestId("selection-energy").textContent()) === "0") {
+    await page.getByTestId("card-pick-energy-dot-1").click();
+  }
   await expect(page.getByTestId("selection-energy")).toHaveText("1");
   if (options.knownEnemyCard) {
-    await expect(page.getByTestId("known-enemy-card")).toBeVisible();
+    await expect(page.getByTestId("card-pick-known-enemy")).toBeVisible();
   } else {
-    await expect(page.getByTestId("enemy-card-hidden")).toBeVisible();
+    await expect(page.getByTestId("card-pick-hidden-enemy")).toBeVisible();
   }
 
-  for (let index = 0; index < extraEnergyClicks; index += 1) {
-    await page.getByTestId("energy-plus").click();
+  const desiredEnergy = extraEnergyClicks + 1;
+  if (desiredEnergy > 1) {
+    await page.getByTestId(`card-pick-energy-dot-${desiredEnergy}`).click();
   }
-  await expect(page.getByTestId("selection-energy")).toHaveText(`${extraEnergyClicks + 1}`);
+  await expect(page.getByTestId("selection-energy")).toHaveText(`${desiredEnergy}`);
 
   await page.getByTestId("selection-ok").click();
   if (options.knownEnemyCard) {
-    await expect(page.getByTestId("battle-overlay")).toHaveAttribute("data-phase", "battle_intro", { timeout: 5_000 });
+    await expectCombatOverlayActive(page, 5_000);
   } else {
     await expect(page.getByTestId("phase-overlay")).toBeHidden();
-    await expect(page.getByTestId("opponent-thinking")).toBeVisible();
-    await expect(page.locator('[data-owner="enemy"] [data-played="true"]')).toHaveCount(1);
+    await expect(page.getByTestId("center-stage-thinking")).toBeVisible();
   }
-  await expect(page.getByTestId("battle-overlay")).toHaveAttribute("data-phase", "battle_intro", { timeout: 8_000 });
-  await expect.poll(async () => page.getByTestId("duel-exchange-projectile").count()).toBeGreaterThanOrEqual(2);
-  await expect.poll(async () => page.getByTestId("duel-exchange-projectile").count()).toBeLessThanOrEqual(4);
+  await expectCombatOverlayActive(page, 8_000);
   await expect
     .poll(
       async () => {
@@ -229,6 +424,34 @@ async function countEnabledPlayerCards(page: Page) {
   }
 
   return enabled;
+}
+
+async function skipFirstBattleTutorialIfVisible(page: Page) {
+  const tutorial = page.getByTestId("first-battle-tutorial");
+  await tutorial.waitFor({ state: "visible", timeout: 2_500 }).catch(() => undefined);
+  if (!(await tutorial.isVisible().catch(() => false))) return;
+
+  await page.getByTestId("first-battle-tutorial-skip").click();
+  await expect(tutorial).toHaveCount(0);
+}
+
+async function markFirstBattleTutorialSeen(page: Page) {
+  await page.addInitScript((storageKey) => {
+    window.localStorage.setItem(storageKey, "true");
+  }, FIRST_BATTLE_TUTORIAL_STORAGE_KEY);
+}
+
+async function expectCombatOverlayActive(page: Page, timeout: number) {
+  await expect
+    .poll(
+      async () => {
+        const overlay = page.getByTestId("battle-overlay");
+        if (!(await overlay.isVisible().catch(() => false))) return "hidden";
+        return (await overlay.getAttribute("data-phase")) ?? "missing";
+      },
+      { timeout },
+    )
+    .toMatch(/^(battle_intro|damage_apply)$/);
 }
 
 async function readSavedDeckIds(page: Page) {


### PR DESCRIPTION
## Summary
- add a first-battle guided spotlight tutorial for card, non-zero energy, and confirm steps
- block non-target battle actions during tutorial and persist completion locally
- update battle E2E coverage for tutorial, saved-session restore, and non-tutorial battle flow

Closes #60

## Verification
- bun run build
- playwright test tests/battle.spec.ts (12 passed, run by worker)
